### PR TITLE
gets tox testing working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ htmlcov/
 build/
 celeste.egg-info/
 .DS_Store
+.eggs
+.tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include data

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+# content of: tox.ini , put in same dir as setup.py
+[tox]
+envlist = py37
+[testenv]
+# install testing framework
+# ... or install anything else you might need here
+deps = -rrequirements.txt
+# run the tests
+# ... or run any other command line tool you need to run here
+commands = pytest


### PR DESCRIPTION
tox runs the unit tests locally in an isolated environment, so it's more like the circleci enviroment, but run locally. It's helpful for checking the dependencies aren't missing. It also makes it straightfoward to test against many different versions of Python, but here I'm just trying Python 3.7.
