### PR TITLE
Implement kl_qp for encoder in sleep phase

### DIFF
--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -546,7 +546,9 @@ class SleepPhase(pl.LightningModule):
         return param_log_probs_all
 
     @staticmethod
-    def _get_kl_qp_galaxy_params(image_ptiles, galaxy_param_mean, galaxy_param_logvar):
+    def _get_kl_qp_galaxy_params(
+        image_ptiles, locs, galaxy_param_mean, galaxy_param_logvar
+    ):
         pass
 
     @staticmethod


### PR DESCRIPTION
Use this PR to incorporate functionality into the encoder that allows to calculate `kl_qp` for galaxy parameters. This will necessarily have to be for each individual ptile, so it is good that our decoder can now generate these ptiles. 

## Steps 

- [ ] Need to access true images on ptiles. 

- [ ] Need to do a similar step with permutations on log_probs as in `_get_log_probs_all_perms` but with predicted `locs`. The idea is that, for each ptile, we need to try all possible permutations of galaxy_parameters on each `ptile` and corresponding locations to draw ( # possibilities = `max_detections!`) 

- [ ] For each possible permutation in the previous step we can use the decoder to draw the tiles using `galaxy_param_mean`, `galaxy_param_logvar` and `locs`. How do we feed this into the decoder? Would the former correspond to `z_mean` and `z_var` in the code below? 

```
q_z = Normal(z_mean, z_var.sqrt())
z = q_z.rsample()

log_q_z = q_z.log_prob(z).sum(1)
p_z = Normal(self.zero, self.one)  # prior on z.
log_p_z = p_z.log_prob(z).sum(1)
kl_z = log_q_z - log_p_z  # log q(z | x) - log p(z)

# reconstructed mean/variances images (per pixel quantities)
recon_mean, recon_var = self.dec.forward(z)

recon_mean = recon_mean + background
recon_var = recon_var + background
```

- [ ] From the code above  I obtain a `recon_mean` and `recon_var` corresponding to the mean and variance of the reconstructed galaxy image. **Question:** If the tile has more than one galaxy how do I combine the variances of their images? I can just add them right? 

- [ ] Now that I'm thinking about this, should our decoder return the variance images too? To evaluate this loss we need to draw `recon_mean` and `recon_var` in the correct places in `locs`. But not sure if it is worth doing more generally. 

- [ ] Finally we need to evaluate (assuming all `recon_mean` and `recon_var` are in correct places.)

```
recon_losses = recon_losses.view(image.size(0), -1).sum(1)
recon_losses = -Normal(recon_mean, recon_var.sqrt()).log_prob(image)
loss = (recon_losses + kl_z).sum()
```

## Questions

- When evaluating this loss can we ignore that tiles might contain stars in addition to the galaxies? 
