### PR TITLE
get rid of all warnings in pytest

### DIFF
--- a/bin/train.py
+++ b/bin/train.py
@@ -96,7 +96,7 @@ def main(cfg: DictConfig):
     setup_seed(cfg)
 
     # setup dataset.
-    dataset = datasets[cfg.dataset.module_name](cfg)
+    dataset = datasets[cfg.dataset.name](cfg)
 
     # setup model
     model = models[cfg.model.name](cfg)

--- a/bliss/datasets/simulated.py
+++ b/bliss/datasets/simulated.py
@@ -1,11 +1,17 @@
 from omegaconf import DictConfig
 import pytorch_lightning as pl
+import warnings
 
 import torch
 from torch.utils.data import IterableDataset, Dataset
 from torch.utils.data import DataLoader
 
 from bliss.models.decoder import ImageDecoder
+
+# prevent pytorch_lightning warning for num_workers = 0 in dataloaders with IterableDataset
+warnings.filterwarnings(
+    "ignore", ".*does not have many workers which may be a bottleneck.*", UserWarning
+)
 
 
 class SimulatedDataset(pl.LightningDataModule, IterableDataset):

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -341,14 +341,12 @@ class SleepPhase(pl.LightningModule):
         estimates = self.image_encoder.map_estimate(images)
 
         # accuracy of counts
-        counts_acc = (
-            torch.eq(true_params["n_sources"], estimates["n_sources"]).float().mean()
-        )
+        counts_acc = true_params["n_sources"].eq(estimates["n_sources"]).float().mean()
 
-        # acuraccy of galaxy counts
+        # accuracy of galaxy counts
         est_n_gal = estimates["galaxy_bool"].view(batch_size, -1).sum(-1)
         true_n_gal = estimates["galaxy_bool"].view(batch_size, -1).sum(-1)
-        galaxy_counts_acc = torch.eq(est_n_gal, true_n_gal).float().mean()
+        galaxy_counts_acc = est_n_gal.eq(true_n_gal).float().mean()
 
         # accuracy of locations
         est_locs = estimates["locs"]

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -341,12 +341,14 @@ class SleepPhase(pl.LightningModule):
         estimates = self.image_encoder.map_estimate(images)
 
         # accuracy of counts
-        counts_acc = (true_params["n_sources"] == estimates["n_sources"]).float().mean()
+        counts_acc = (
+            torch.eq(true_params["n_sources"], estimates["n_sources"]).float().mean()
+        )
 
         # acuraccy of galaxy counts
         est_n_gal = estimates["galaxy_bool"].view(batch_size, -1).sum(-1)
         true_n_gal = estimates["galaxy_bool"].view(batch_size, -1).sum(-1)
-        galaxy_counts_acc = (est_n_gal == true_n_gal).float().mean()
+        galaxy_counts_acc = torch.eq(est_n_gal, true_n_gal).float().mean()
 
         # accuracy of locations
         est_locs = estimates["locs"]

--- a/bliss/wake.py
+++ b/bliss/wake.py
@@ -80,8 +80,6 @@ class WakeNet(pl.LightningModule):
         self.init_background_params = init_background_params
         self.planar_background = PlanarBackground(init_background_params, self.slen)
 
-        # self.init_background = self.planar_background.forward()
-
     def forward(self, obs_img):
 
         with torch.no_grad():
@@ -133,15 +131,12 @@ class WakeNet(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         loss = self.get_loss(batch)
-        logs = {"train_loss": loss}
-        return {"loss": loss, "log": logs}
+        self.log("train_loss", loss)
+        return loss
 
     def validation_step(self, batch, batch_idx):
         loss = self.get_loss(batch)
-        return {"val_loss": loss}
-
-    def validation_epoch_end(self, outputs):
-        return {"val_loss": outputs[-1]["val_loss"]}
+        self.log("validation_loss", loss)
 
     def _get_init_background(self, sample_every=25):
         sampled_background = self._sample_image(sample_every)


### PR DESCRIPTION
Closes #145 

Does anybody know how to edit the fits file and get rid of this warning quickly? This is the only warning left when running tests - maybe @Runjing-Liu120 or @jeff-regier ?

```
tests/test_sdss.py::TestSDSS::test_sdss[0]
  /Users/Ismael/miniconda3/envs/galsim/lib/python3.7/site-packages/astropy/wcs/wcs.py:466: FITSFixedWarning: RADECSYS= 'ICRS ' / International Celestial Ref. System 
  the RADECSYS keyword is deprecated, use RADESYSa.
    colsel=colsel)
```