### PR TITLE
Bl reviving wake phase

### DIFF
--- a/bliss/models/decoder.py
+++ b/bliss/models/decoder.py
@@ -64,8 +64,7 @@ class ImageDecoder(nn.Module):
         psf_params_file="psf_params.npy",
         background_values=(686.0, 1123.0),
         loc_min=0.0,
-        loc_max=1.0,
-        add_noise=True,
+        loc_max=1.0
     ):
         super(ImageDecoder, self).__init__()
 
@@ -113,8 +112,6 @@ class ImageDecoder(nn.Module):
         # per-tile constraints on the location of sources
         self.loc_min = loc_min
         self.loc_max = loc_max
-
-        self.add_noise = add_noise
 
         # prior parameters on fluxes
         self.f_min = f_min
@@ -604,7 +601,7 @@ class ImageDecoder(nn.Module):
             self.ptile_slen,
         )
 
-    def render_images(self, n_sources, locs, galaxy_bool, galaxy_params, fluxes):
+    def render_images(self, n_sources, locs, galaxy_bool, galaxy_params, fluxes, add_noise=True):
         # constructs the full slen x slen image
 
         # n_sources: is (batch_size x n_tiles_per_image)
@@ -631,7 +628,7 @@ class ImageDecoder(nn.Module):
 
         # add background and noise
         images += self.background.unsqueeze(0)
-        if self.add_noise:
+        if add_noise:
             images = self._apply_noise(images)
 
         return images

--- a/bliss/models/decoder.py
+++ b/bliss/models/decoder.py
@@ -64,7 +64,7 @@ class ImageDecoder(nn.Module):
         psf_params_file="psf_params.npy",
         background_values=(686.0, 1123.0),
         loc_min=0.0,
-        loc_max=1.0
+        loc_max=1.0,
     ):
         super(ImageDecoder, self).__init__()
 
@@ -601,7 +601,9 @@ class ImageDecoder(nn.Module):
             self.ptile_slen,
         )
 
-    def render_images(self, n_sources, locs, galaxy_bool, galaxy_params, fluxes, add_noise=True):
+    def render_images(
+        self, n_sources, locs, galaxy_bool, galaxy_params, fluxes, add_noise=True
+    ):
         # constructs the full slen x slen image
 
         # n_sources: is (batch_size x n_tiles_per_image)

--- a/bliss/wake.py
+++ b/bliss/wake.py
@@ -55,7 +55,7 @@ class WakeNet(pl.LightningModule):
         with torch.no_grad():
             self.star_encoder.eval()
             sample = self.star_encoder.sample_encoder(obs_img, self.n_samples)
-
+        
         recon_mean = self.image_decoder.render_images(
             sample["n_sources"].contiguous(),
             sample["locs"].contiguous(),

--- a/bliss/wake.py
+++ b/bliss/wake.py
@@ -11,35 +11,6 @@ from .models.decoder import get_mgrid
 from . import device
 
 
-class PlanarBackground(nn.Module):
-    def __init__(self, init_background_params, image_slen=101):
-        super(PlanarBackground, self).__init__()
-
-        assert len(init_background_params.shape) == 2
-        self.n_bands = init_background_params.shape[0]
-
-        self.init_background_params = init_background_params.clone()
-
-        self.image_slen = image_slen
-
-        # get grid
-        # can we use cached grid to replace?
-        _mgrid = get_mgrid(image_slen).to(device)
-        self.mgrid = torch.stack([_mgrid for _ in range(self.n_bands)], dim=0)
-
-        # initial weights
-        # why do we clone the parameter here?
-        self.params = nn.Parameter(init_background_params.clone())
-
-    def forward(self):
-        return (
-            self.params[:, 0][:, None, None]
-            + self.params[:, 1][:, None, None] * self.mgrid[:, :, :, 0]
-            + self.params[:, 2][:, None, None] * self.mgrid[:, :, :, 1]
-        )
-
-
-# TODO: Does not work with background padding.
 class WakeNet(pl.LightningModule):
 
     # ---------------
@@ -79,22 +50,13 @@ class WakeNet(pl.LightningModule):
         # get n_bands
         self.n_bands = self.image_decoder.n_bands
 
-        # set up initial background parameters
-        assert len(init_background_values) == self.n_bands
-        init_background_params = torch.zeros(self.n_bands, 3)
-        for i in range(self.n_bands):
-            init_background_params[i, 0] = init_background_values[i]
-            
-        self.planar_background = PlanarBackground(init_background_params, self.slen_plus_padding)
-
     def forward(self, obs_img):
 
         with torch.no_grad():
             self.star_encoder.eval()
             sample = self.star_encoder.sample_encoder(obs_img, self.n_samples)
 
-        background = self.planar_background.forward().unsqueeze(0).detach()
-        sources = self.image_decoder.render_images(
+        recon_mean = self.image_decoder.render_images(
             sample["n_sources"].contiguous(),
             sample["locs"].contiguous(),
             sample["galaxy_bool"].contiguous(),
@@ -102,9 +64,7 @@ class WakeNet(pl.LightningModule):
             sample["fluxes"].contiguous(),
             add_noise = False
         )
-
-        recon_mean = sources + background
-
+        
         return recon_mean
 
     # ---------------
@@ -145,62 +105,3 @@ class WakeNet(pl.LightningModule):
     def validation_step(self, batch, batch_idx):
         loss = self.get_loss(batch)
         self.log("validation_loss", loss)
-
-    def _get_init_background(self, sample_every=25):
-        sampled_background = self._sample_image(sample_every)
-        self.init_background_params = torch.tensor(
-            self._fit_plane_to_background(sampled_background)
-        ).to(device)
-        self.planar_background = PlanarBackground(
-            self.init_background_params, self.slen
-        )
-
-    def _sample_image(self, sample_every=10):
-        batch_size = self.observed_image.shape[0]
-        n_bands = self.observed_image.shape[1]
-        slen = self.observed_image.shape[-1]
-
-        samples = torch.zeros(
-            n_bands,
-            int(np.floor(slen / sample_every)),
-            int(np.floor(slen / sample_every)),
-        )
-
-        for i in range(samples.shape[1]):
-            for j in range(samples.shape[2]):
-                x0 = i * sample_every
-                x1 = j * sample_every
-                samples[:, i, j] = (
-                    self.observed_image[
-                        :, :, x0 : (x0 + sample_every), x1 : (x1 + sample_every)
-                    ]
-                    .view(batch_size, n_bands, -1)
-                    .min(2)[0]
-                    .mean(0)
-                )
-
-        return samples
-
-    @staticmethod
-    def _fit_plane_to_background(background):
-        assert len(background.shape) == 3
-        n_bands = background.shape[0]
-        slen = background.shape[-1]
-
-        planar_params = np.zeros((n_bands, 3))
-        for i in range(n_bands):
-            # can we make numpy to torch?
-            y = background[i].flatten().detach().numpy()
-            grid = get_mgrid(slen).detach().numpy()
-
-            x = np.ones((slen ** 2, 3))
-            x[:, 1:] = np.array(
-                [grid[:, :, 0].flatten(), grid[:, :, 1].flatten()]
-            ).transpose()
-
-            xtx = np.einsum("ki, kj -> ij", x, x)
-            xty = np.einsum("ki, k -> i", x, y)
-
-            planar_params[i, :] = np.linalg.solve(xtx, xty)
-
-        return planar_params

--- a/tests/test_wake.py
+++ b/tests/test_wake.py
@@ -11,7 +11,7 @@ import pytorch_lightning as pl
 
 from copy import deepcopy
 
-class TestSleepStarTiles:
+class TestWake:
     @pytest.fixture(scope="class")
     def overrides(self, devices):
         overrides = dict(
@@ -32,6 +32,7 @@ class TestSleepStarTiles:
         image_decoder = trained_sleep.image_decoder.to(device)
         
         # draw some catalogs from the prior
+        torch.manual_seed(23421)
         batch = trained_sleep.image_decoder.sample_prior(batch_size=100)
         
         # pick the catalog with the most stars. 

--- a/tests/test_wake.py
+++ b/tests/test_wake.py
@@ -101,12 +101,13 @@ class TestWake:
         trained_loss = eval_decoder_loss(wake_net.image_decoder)
 
         # check loss went down
-        print(target_loss)
-        print(init_loss)
-        print(trained_loss)
+        print("target loss: ", target_loss)
+        print("initial loss: ", init_loss)
+        print("trained loss: ", trained_loss)
         diff0 = init_loss - target_loss
         diff1 = trained_loss - target_loss
-        assert diff1 < (diff0 * 0.5)
+        if torch.cuda.is_available():
+            assert diff1 < (diff0 * 0.5)
 
         # now compare PSFs
         psf_true = image_decoder.forward().detach()
@@ -116,9 +117,10 @@ class TestWake:
         trained_psf_mse = ((psf_fitted - psf_true) ** 2).mean()
 
         # check if mse of psf improved
-        print(init_psf_mse)
-        print(trained_psf_mse)
-        assert trained_psf_mse < (init_psf_mse * 0.5)
+        print("initial psf mse: ", init_psf_mse)
+        print("trained psf mse: ", trained_psf_mse)
+        if torch.cuda.is_available():
+            assert trained_psf_mse < (init_psf_mse * 0.5)
 
 
 # def test_star_wake(sleep_setup, paths, devices):

--- a/tests/test_wake.py
+++ b/tests/test_wake.py
@@ -71,18 +71,14 @@ class TestSleepStarTiles:
 
         # loss of perurbed decoder
         init_loss = eval_decoder_loss(image_decoder_perturbed)
-        
-        print('LOOOOOOOOOOOO')
-        print(target_loss)
-        print(init_loss)
-        
+                
         # define wake-phase and train starting from the perturbed decoder
         wake_net = wake.WakeNet(trained_sleep.image_encoder,
                                 image_decoder_perturbed,
                                 obs_image,
                                 torch.Tensor([686.]),
                                 hparams = dict({'lr':1e-5, 
-                                           'n_samples':3000}));
+                                           'n_samples':2000}));
         wake_net.to(device);
         
         n_epochs = 3000 if torch.cuda.is_available() else 2

--- a/tests/test_wake.py
+++ b/tests/test_wake.py
@@ -11,6 +11,7 @@ import pytorch_lightning as pl
 
 from copy import deepcopy
 
+
 class TestWake:
     @pytest.fixture(scope="class")
     def overrides(self, devices):
@@ -27,94 +28,99 @@ class TestWake:
 
     def test_simulated(self, overrides, trained_sleep, sleep_setup, devices):
         overrides.update({"testing": "default"})
-        
+
         # the original decoder
         image_decoder = trained_sleep.image_decoder.to(device)
-        
+
         # draw some catalogs from the prior
         torch.manual_seed(23421)
         batch = trained_sleep.image_decoder.sample_prior(batch_size=100)
-        
-        # pick the catalog with the most stars. 
+
+        # pick the catalog with the most stars.
         # we will use this to construct an image
-        which_batch = batch['n_sources'].sum(1).argmax()
+        which_batch = batch["n_sources"].sum(1).argmax()
         batch_i = dict()
-        for key in batch.keys(): 
-            if key != 'slen': 
-                batch_i[key] = batch[key][which_batch:(which_batch+1)]
-        
+        for key in batch.keys():
+            if key != "slen":
+                batch_i[key] = batch[key][which_batch : (which_batch + 1)]
+
         # the "observed" image
-        obs_image = image_decoder.render_images(batch_i['n_sources'], 
-                                           batch_i['locs'], 
-                                           batch_i['galaxy_bool'] * 0., 
-                                           batch_i['galaxy_params'], 
-                                           batch_i['fluxes'])
-        
+        obs_image = image_decoder.render_images(
+            batch_i["n_sources"],
+            batch_i["locs"],
+            batch_i["galaxy_bool"] * 0.0,
+            batch_i["galaxy_params"],
+            batch_i["fluxes"],
+        )
+
         # now perturb psf parameters and get new decoder
         image_decoder_perturbed = deepcopy(image_decoder)
         true_psf_params = image_decoder.params
         psf_params_perturbed = true_psf_params * (1.1)
         image_decoder_perturbed.params = nn.Parameter(psf_params_perturbed)
         psf_init = image_decoder_perturbed.forward().detach()
-        
-        def eval_decoder_loss(image_decoder): 
+
+        def eval_decoder_loss(image_decoder):
             # evaluate loss of a decoder at the **true** catalog
-            recon = image_decoder.render_images(batch_i['n_sources'], 
-                                               batch_i['locs'], 
-                                               batch_i['galaxy_bool'] * 0., 
-                                               batch_i['galaxy_params'], 
-                                               batch_i['fluxes'], 
-                                               add_noise = False)
+            recon = image_decoder.render_images(
+                batch_i["n_sources"],
+                batch_i["locs"],
+                batch_i["galaxy_bool"] * 0.0,
+                batch_i["galaxy_params"],
+                batch_i["fluxes"],
+                add_noise=False,
+            )
             loss = -Normal(recon, recon.sqrt()).log_prob(obs_image).mean()
             return loss
-        
+
         # loss of true decoder
         target_loss = eval_decoder_loss(image_decoder)
 
         # loss of perurbed decoder
         init_loss = eval_decoder_loss(image_decoder_perturbed)
         assert (init_loss - target_loss) > 0
-        
+
         # define wake-phase and train starting from the perturbed decoder
-        wake_net = wake.WakeNet(trained_sleep.image_encoder,
-                                image_decoder_perturbed,
-                                obs_image,
-                                torch.Tensor([686.]),
-                                hparams = dict({'lr':1e-5, 
-                                           'n_samples':2000}));
-        wake_net.to(device);
-        
+        wake_net = wake.WakeNet(
+            trained_sleep.image_encoder,
+            image_decoder_perturbed,
+            obs_image,
+            torch.Tensor([686.0]),
+            hparams=dict({"lr": 1e-5, "n_samples": 2000}),
+        )
+        wake_net.to(device)
+
         n_epochs = 3000 if torch.cuda.is_available() else 2
-        wake_trainer = pl.Trainer(check_val_every_n_epoch = 10000, 
-                                     max_epochs = n_epochs, 
-                                     min_epochs = n_epochs)
-        
+        wake_trainer = pl.Trainer(
+            check_val_every_n_epoch=10000, max_epochs=n_epochs, min_epochs=n_epochs
+        )
+
         wake_trainer.fit(wake_net)
-        
+
         # loss after training
         trained_loss = eval_decoder_loss(wake_net.image_decoder)
-        
+
         # check loss went down
         print(target_loss)
         print(init_loss)
         print(trained_loss)
         diff0 = init_loss - target_loss
         diff1 = trained_loss - target_loss
-        assert diff1 < (diff0 * 0.75)
-        
-        
+        assert diff1 < (diff0 * 0.5)
+
         # now compare PSFs
         psf_true = image_decoder.forward().detach()
         psf_fitted = wake_net.image_decoder.forward().detach()
-        
-        init_psf_mse = ((psf_init - psf_true)**2).mean()
-        trained_psf_mse = ((psf_fitted - psf_true)**2).mean()
-        
+
+        init_psf_mse = ((psf_init - psf_true) ** 2).mean()
+        trained_psf_mse = ((psf_fitted - psf_true) ** 2).mean()
+
         # check if mse of psf improved
         print(init_psf_mse)
         print(trained_psf_mse)
-        assert trained_psf_mse < (init_psf_mse * 0.75)
-        
+        assert trained_psf_mse < (init_psf_mse * 0.5)
+
+
 # def test_star_wake(sleep_setup, paths, devices):
 #     device = devices.device
 #     overrides = dict(model="sleep_star_one_tile", training="cpu", dataset="cpu")

--- a/tests/test_wake.py
+++ b/tests/test_wake.py
@@ -1,47 +1,148 @@
 import torch
+from torch import nn
+from torch.distributions.normal import Normal
+
+device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+import pytest
+
 from bliss import wake
 import pytorch_lightning as pl
 
+from copy import deepcopy
 
-def test_star_wake(sleep_setup, paths, devices):
-    device = devices.device
-    overrides = dict(model="sleep_star_one_tile", training="cpu", dataset="cpu")
-    sleep_net = sleep_setup.get_trained_sleep(overrides)
+class TestSleepStarTiles:
+    @pytest.fixture(scope="class")
+    def overrides(self, devices):
+        overrides = dict(
+            model="sleep_star_basic",
+            dataset="default" if devices.use_cuda else "cpu",
+            training="unittest" if devices.use_cuda else "cpu",
+        )
+        return overrides
 
-    # load the test image
-    test_path = paths["data"].joinpath("star_wake_test1.pt")
-    test_star = torch.load(test_path, map_location="cpu")
-    test_image = test_star["images"][0].unsqueeze(0).to(device)
-    test_slen = test_star["slen"].item()
-    image_decoder = sleep_net.image_decoder.to(device)
-    background_value = image_decoder.background.mean().item()
+    @pytest.fixture(scope="class")
+    def trained_sleep(self, overrides, sleep_setup):
+        return sleep_setup.get_trained_sleep(overrides)
 
-    # initialize background params, which will create the true background
-    init_background_params = torch.zeros(1, 3, device=device)
-    init_background_params[0, 0] = background_value
+    def test_simulated(self, overrides, trained_sleep, sleep_setup, devices):
+        overrides.update({"testing": "default"})
+        
+        # the original decoder
+        image_decoder = trained_sleep.image_decoder.to(device)
+        
+        # draw a bunch of catalogs from the prior
+        batch = trained_sleep.image_decoder.sample_prior(batch_size=100)
+        
+        # pick the catalog with the most stars. 
+        # we will use this image
+        which_batch = batch['n_sources'].sum(1).argmax()
+        batch_i = dict()
+        for key in batch.keys(): 
+            if key != 'slen': 
+                batch_i[key] = batch[key][which_batch:(which_batch+1)]
+        
+        # the "observed" image
+        obs_image = image_decoder.render_images(batch_i['n_sources'], 
+                                           batch_i['locs'], 
+                                           batch_i['galaxy_bool'] * 0., 
+                                           batch_i['galaxy_params'], 
+                                           batch_i['fluxes'])
+        
+        # now perturb psf parameters and get new decoder
+        image_decoder_perturbed = deepcopy(image_decoder)
+        true_psf_params = image_decoder.params
+        psf_params_perturbed = true_psf_params * (1.1)
+        image_decoder_perturbed.params = nn.Parameter(psf_params_perturbed)
+        
+        def eval_decoder_loss(image_decoder): 
+            recon = image_decoder.render_images(batch_i['n_sources'], 
+                                               batch_i['locs'], 
+                                               batch_i['galaxy_bool'] * 0., 
+                                               batch_i['galaxy_params'], 
+                                               batch_i['fluxes'], 
+                                               add_noise = False)
+            loss = -Normal(recon, recon.sqrt()).log_prob(obs_image).mean()
+            return loss
+        
+        # loss of true decoder
+        target_loss = eval_decoder_loss(image_decoder)
+        
+        # loss of perurbed decoder
+        init_loss = eval_decoder_loss(image_decoder_perturbed)
+        
+        # define wake-phase
+        wake_net = wake.WakeNet(trained_sleep.image_encoder,
+                           deepcopy(image_decoder_perturbed),
+                           obs_image,
+                           torch.Tensor([686.]),
+                           hparams = dict({'lr':1e-5, 
+                                           'n_samples':2000}));
+        wake_net.to(device);
+        
+        # train: 
+        n_epochs = 3000 if torch.cuda.is_available() else 2
+        wake_trainer = pl.Trainer(check_val_every_n_epoch = 10000, 
+                                     max_epochs = n_epochs, 
+                                     min_epochs = n_epochs)
+        
+        wake_trainer.fit(wake_net)
+        trained_loss = eval_decoder_loss(wake_net.image_decoder)
+        
+        print(target_loss)
+        print(init_loss)
+        print(trained_loss)
+        
+        # now compare PSFs
+        psf_true = image_decoder.forward().detach()
+        psf_pert = image_decoder_perturbed.forward().detach()
+        psf_fitted = wake_net.image_decoder.forward().detach()
+        
+        init_psf_mse = ((psf_fitted - psf_true)**2).mean()
+        trained_psf_mse = ((psf_fitted - psf_true)**2).mean()
+        
+        print(init_psf_mse)
+        print(trained_psf_mse)
+            
+# def test_star_wake(sleep_setup, paths, devices):
+#     device = devices.device
+#     overrides = dict(model="sleep_star_one_tile", training="cpu", dataset="cpu")
+#     sleep_net = sleep_setup.get_trained_sleep(overrides)
 
-    n_samples = 1
-    hparams = {"n_samples": n_samples, "lr": 0.001}
-    assert image_decoder.slen == test_slen
-    wake_phase_model = wake.WakeNet(
-        sleep_net.image_encoder,
-        image_decoder,
-        test_image,
-        init_background_params,
-        hparams,
-    )
+#     # load the test image
+#     test_path = paths["data"].joinpath("star_wake_test1.pt")
+#     test_star = torch.load(test_path, map_location="cpu")
+#     test_image = test_star["images"][0].unsqueeze(0).to(device)
+#     test_slen = test_star["slen"].item()
+#     image_decoder = sleep_net.image_decoder.to(device)
+#     background_value = image_decoder.background.mean().item()
 
-    # run the wake-phase training
-    n_epochs = 1
+#     # initialize background params, which will create the true background
+#     init_background_params = torch.zeros(1, 3, device=device)
+#     init_background_params[0, 0] = background_value
 
-    wake_trainer = pl.Trainer(
-        gpus=devices.gpus,
-        profiler=None,
-        logger=False,
-        checkpoint_callback=False,
-        min_epochs=n_epochs,
-        max_epochs=n_epochs,
-        reload_dataloaders_every_epoch=True,
-    )
+#     n_samples = 1
+#     hparams = {"n_samples": n_samples, "lr": 0.001}
+#     assert image_decoder.slen == test_slen
+#     wake_phase_model = wake.WakeNet(
+#         sleep_net.image_encoder,
+#         image_decoder,
+#         test_image,
+#         init_background_params,
+#         hparams,
+#     )
 
-    wake_trainer.fit(wake_phase_model)
+#     # run the wake-phase training
+#     n_epochs = 1
+
+#     wake_trainer = pl.Trainer(
+#         gpus=devices.gpus,
+#         profiler=None,
+#         logger=False,
+#         checkpoint_callback=False,
+#         min_epochs=n_epochs,
+#         max_epochs=n_epochs,
+#         reload_dataloaders_every_epoch=True,
+#     )
+
+#     wake_trainer.fit(wake_phase_model)

--- a/tests/test_wake.py
+++ b/tests/test_wake.py
@@ -2,8 +2,6 @@ import torch
 from torch import nn
 from torch.distributions.normal import Normal
 
-device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
 import pytest
 
 from bliss import wake
@@ -27,10 +25,9 @@ class TestWake:
         return sleep_setup.get_trained_sleep(overrides)
 
     def test_simulated(self, overrides, trained_sleep, sleep_setup, devices):
-        overrides.update({"testing": "default"})
 
         # the original decoder
-        image_decoder = trained_sleep.image_decoder.to(device)
+        image_decoder = trained_sleep.image_decoder.to(devices.device)
 
         # draw some catalogs from the prior
         torch.manual_seed(23421)
@@ -48,7 +45,7 @@ class TestWake:
         obs_image = image_decoder.render_images(
             batch_i["n_sources"],
             batch_i["locs"],
-            batch_i["galaxy_bool"] * 0.0,
+            batch_i["galaxy_bool"],
             batch_i["galaxy_params"],
             batch_i["fluxes"],
         )
@@ -85,10 +82,9 @@ class TestWake:
             trained_sleep.image_encoder,
             image_decoder_perturbed,
             obs_image,
-            torch.Tensor([686.0]),
+            image_decoder.background.mean((1, 2)),
             hparams=dict({"lr": 1e-5, "n_samples": 2000}),
-        )
-        wake_net.to(device)
+        ).to(devices.device)
 
         n_epochs = 3000 if torch.cuda.is_available() else 2
         wake_trainer = pl.Trainer(
@@ -121,47 +117,3 @@ class TestWake:
         print("trained psf mse: ", trained_psf_mse)
         if torch.cuda.is_available():
             assert trained_psf_mse < (init_psf_mse * 0.5)
-
-
-# def test_star_wake(sleep_setup, paths, devices):
-#     device = devices.device
-#     overrides = dict(model="sleep_star_one_tile", training="cpu", dataset="cpu")
-#     sleep_net = sleep_setup.get_trained_sleep(overrides)
-
-#     # load the test image
-#     test_path = paths["data"].joinpath("star_wake_test1.pt")
-#     test_star = torch.load(test_path, map_location="cpu")
-#     test_image = test_star["images"][0].unsqueeze(0).to(device)
-#     test_slen = test_star["slen"].item()
-#     image_decoder = sleep_net.image_decoder.to(device)
-#     background_value = image_decoder.background.mean().item()
-
-#     # initialize background params, which will create the true background
-#     init_background_params = torch.zeros(1, 3, device=device)
-#     init_background_params[0, 0] = background_value
-
-#     n_samples = 1
-#     hparams = {"n_samples": n_samples, "lr": 0.001}
-#     assert image_decoder.slen == test_slen
-#     wake_phase_model = wake.WakeNet(
-#         sleep_net.image_encoder,
-#         image_decoder,
-#         test_image,
-#         init_background_params,
-#         hparams,
-#     )
-
-#     # run the wake-phase training
-#     n_epochs = 1
-
-#     wake_trainer = pl.Trainer(
-#         gpus=devices.gpus,
-#         profiler=None,
-#         logger=False,
-#         checkpoint_callback=False,
-#         min_epochs=n_epochs,
-#         max_epochs=n_epochs,
-#         reload_dataloaders_every_epoch=True,
-#     )
-
-#     wake_trainer.fit(wake_phase_model)


### PR DESCRIPTION
The WakePhase class should now be compatible with our most recent changes. I've also added a test for the wake-phase, which I can go over when we meet. We can discuss if what I have currently is the best way to test the wake-phase. 

In brief, the test
- runs the sleep phase to train the encoder
- picks an image, `obs_image`, from the original dataset (it picks one with the most stars)
- defines a new dataset with a perturbed PSF
- runs the wake-phase on `obs_image` and the trained encoder, with the perturbed PSF as an initialization. 
- checks if the wake-phase recovers the PSF in the original dataset (i.e. the PSF that constructed `obs_image`). 

I took out functions for background estimation for now. I'll make another pull request to add it back in. I think we need the background estimation stuff in the decoder (just like the PSF) -- before, this was included in the WakePhase class. 