### PR TITLE
Move common config value to sleep_base.yaml

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,6 @@
 defaults:
   - optimizer: adam
+  - model/sleep_base # force-load common config 
   - model: sleep_star_basic
   - training: default
   - dataset: default

--- a/config/model/m2.yaml
+++ b/config/model/m2.yaml
@@ -1,37 +1,20 @@
 # @package _group_
-name: SleepPhase
 image:
   slen: 100
   n_bands: 2
   background:
     - 686.0
     - 1123.0
-galaxy:
-  slen: 51
-  latent_dim: 8
 decoder:
   params:
-    n_bands: ${model.image.n_bands}
-    slen: ${model.image.slen}
-    tile_slen: 2
     ptile_slen: 26
     border_padding: 3
-    prob_galaxy: 0.0
-    n_galaxy_params: ${model.galaxy.latent_dim}
     max_sources: 5
     mean_sources: 0.48
-    min_sources: 0
     f_min: 1e3
-    f_max: 1e6
     alpha: 0.5
-    gal_slen: ${model.galaxy.slen}
-    decoder_file: null
     psf_params_file: ${paths.root}/data/psField-002583-2-0136.fits
-    background_values: ${model.image.background}
 encoder:
   params:
-    n_bands: ${model.image.n_bands}
-    tile_slen: ${model.decoder.params.tile_slen}
     ptile_slen: 8
     max_detections: 2
-    n_galaxy_params: ${model.galaxy.latent_dim}

--- a/config/model/sleep_1galaxy_1star.yaml
+++ b/config/model/sleep_1galaxy_1star.yaml
@@ -1,33 +1,13 @@
 # @package _group_
-name: SleepPhase
 image:
   slen: 40
-  n_bands: 1
-  background:
-    - 686.0
-galaxy:
-  slen: 51
-  latent_dim: 8
 decoder:
   params:
-    n_bands: ${model.image.n_bands}
-    slen: ${model.image.slen}
     tile_slen: 4
     ptile_slen: 36
     border_padding: 4
     prob_galaxy: 0.5
-    n_galaxy_params: ${model.galaxy.latent_dim}
-    max_sources: 1
-    mean_sources: 0.015
-    min_sources: 0
-    gal_slen: ${model.galaxy.slen}
     decoder_file: ${paths.root}/data/galaxy_decoder_1_band.dat
-    psf_params_file: ${paths.root}/data/fitted_powerlaw_psf_params.npy
-    background_values: ${model.image.background}
 encoder:
   params:
-    n_bands: ${model.image.n_bands}
-    tile_slen: ${model.decoder.params.tile_slen}
     ptile_slen: 12
-    max_detections: ${model.decoder.params.max_sources}
-    n_galaxy_params: ${model.galaxy.latent_dim}

--- a/config/model/sleep_base.yaml
+++ b/config/model/sleep_base.yaml
@@ -1,0 +1,34 @@
+# @package _group_
+name: SleepPhase
+image:
+  slen: 30
+  n_bands: 1
+  background:
+    - 686.0
+galaxy:
+  slen: 51
+  latent_dim: 8
+decoder:
+  params:
+    n_bands: ${model.image.n_bands}
+    slen: ${model.image.slen}
+    tile_slen: 2
+    ptile_slen: 6
+    prob_galaxy: 0.0
+    n_galaxy_params: ${model.galaxy.latent_dim}
+    max_sources: 1
+    mean_sources: 0.015
+    min_sources: 0
+    f_min: 1e5
+    f_max: 1e6
+    gal_slen: ${model.galaxy.slen}
+    decoder_file: null
+    psf_params_file: ${paths.root}/data/fitted_powerlaw_psf_params.npy
+    background_values: ${model.image.background}
+encoder:
+  params:
+    n_bands: ${model.image.n_bands}
+    tile_slen: ${model.decoder.params.tile_slen}
+    ptile_slen: ${model.decoder.params.ptile_slen}
+    max_detections: ${model.decoder.params.max_sources}
+    n_galaxy_params: ${model.galaxy.latent_dim}

--- a/config/model/sleep_galaxy_3_centered.yaml
+++ b/config/model/sleep_galaxy_3_centered.yaml
@@ -1,32 +1,14 @@
 # @package _group_
-name: SleepPhase
 image:
   slen: 20
-  n_bands: 1
-  background:
-    - 686.0
-galaxy:
-  slen: 51
-  latent_dim: 8
 decoder:
   params:
-    n_bands: ${model.image.n_bands}
-    slen: ${model.image.slen}
     tile_slen: 4
     ptile_slen: 24
     prob_galaxy: 1.0
-    n_galaxy_params: ${model.galaxy.latent_dim}
     max_sources: 2
     mean_sources: 0.12
-    min_sources: 0
-    gal_slen: ${model.galaxy.slen}
     decoder_file: ${paths.root}/data/galaxy_decoder_1_band.dat
-    psf_params_file: ${paths.root}/data/fitted_powerlaw_psf_params.npy
-    background_values: ${model.image.background}
 encoder:
   params:
-    n_bands: ${model.image.n_bands}
-    tile_slen: ${model.decoder.params.tile_slen}
     ptile_slen: 24
-    max_detections: ${model.decoder.params.max_sources}
-    n_galaxy_params: ${model.galaxy.latent_dim}

--- a/config/model/sleep_galaxy_basic.yaml
+++ b/config/model/sleep_galaxy_basic.yaml
@@ -1,33 +1,12 @@
 # @package _group_
-name: SleepPhase
 image:
   slen: 40
-  n_bands: 1
-  background:
-    - 686.0
-galaxy:
-  slen: 51
-  latent_dim: 8
 decoder:
   params:
-    n_bands: ${model.image.n_bands}
-    slen: ${model.image.slen}
     tile_slen: 4
     ptile_slen: 36
     border_padding: 4
     prob_galaxy: 1.0
-    n_galaxy_params: ${model.galaxy.latent_dim}
-    max_sources: 1
-    mean_sources: 0.015
-    min_sources: 0
-    gal_slen: ${model.galaxy.slen}
-    decoder_file: ${paths.root}/data/galaxy_decoder_1_band.dat
-    psf_params_file: ${paths.root}/data/fitted_powerlaw_psf_params.npy
-    background_values: ${model.image.background}
 encoder:
   params:
-    n_bands: ${model.image.n_bands}
-    tile_slen: ${model.decoder.params.tile_slen}
     ptile_slen: 12
-    max_detections: ${model.decoder.params.max_sources}
-    n_galaxy_params: ${model.galaxy.latent_dim}

--- a/config/model/sleep_galaxy_one_tile.yaml
+++ b/config/model/sleep_galaxy_one_tile.yaml
@@ -1,34 +1,16 @@
 # @package _group_
-name: SleepPhase
 image:
   slen: 40
-  n_bands: 1
-  background:
-    - 686.0
-galaxy:
-  slen: 51
-  latent_dim: 8
 decoder:
   params:
-    n_bands: ${model.image.n_bands}
-    slen: ${model.image.slen}
     tile_slen: ${model.image.slen}
     ptile_slen: ${model.image.slen}
     prob_galaxy: 1.0
-    n_galaxy_params: ${model.galaxy.latent_dim}
     max_sources: 3
     mean_sources: 1.5
-    min_sources: 0
-    gal_slen: ${model.galaxy.slen}
     decoder_file: ${paths.root}/data/galaxy_decoder_1_band.dat
-    psf_params_file: ${paths.root}/data/fitted_powerlaw_psf_params.npy
-    background_values: ${model.image.background}
     loc_min: 0.25
     loc_max: 0.75
 encoder:
   params:
-    n_bands: ${model.image.n_bands}
-    tile_slen: ${model.decoder.params.tile_slen}
     ptile_slen: ${model.decoder.params.tile_slen}
-    max_detections: ${model.decoder.params.max_sources}
-    n_galaxy_params: ${model.galaxy.latent_dim}

--- a/config/model/sleep_star_basic.yaml
+++ b/config/model/sleep_star_basic.yaml
@@ -1,37 +1,6 @@
 # @package _group_
-name: SleepPhase
-image:
-  slen: 30
-  n_bands: 1
-  background:
-    - 686.0
-galaxy:
-  slen: 51
-  latent_dim: 8
-decoder:
-  params:
-    n_bands: ${model.image.n_bands}
-    slen: ${model.image.slen}
-    tile_slen: 2
-    ptile_slen: 6
-    prob_galaxy: 0.0
-    n_galaxy_params: ${model.galaxy.latent_dim}
-    max_sources: 1
-    mean_sources: 0.015
-    min_sources: 0
-    f_min: 1e5
-    f_max: 1e6
-    gal_slen: ${model.galaxy.slen}
-    decoder_file: null
-    psf_params_file: ${paths.root}/data/fitted_powerlaw_psf_params.npy
-    background_values: ${model.image.background}
 encoder:
   params:
-    n_bands: ${model.image.n_bands}
-    tile_slen: ${model.decoder.params.tile_slen}
-    ptile_slen: ${model.decoder.params.ptile_slen}
-    max_detections: ${model.decoder.params.max_sources}
-    n_galaxy_params: ${model.galaxy.latent_dim}
     enc_conv_c: 20
     enc_kern: 3
     enc_hidden: 256

--- a/config/model/sleep_star_one_tile.yaml
+++ b/config/model/sleep_star_one_tile.yaml
@@ -1,39 +1,17 @@
 # @package _group_
-name: SleepPhase
 image:
   slen: 10
-  n_bands: 1
-  background:
-    - 686.0
-galaxy:
-  slen: 51
-  latent_dim: 8
 decoder:
   params:
-    n_bands: ${model.image.n_bands}
-    slen: ${model.image.slen}
     tile_slen: ${model.image.slen}
     ptile_slen: ${model.image.slen}
-    prob_galaxy: 0.0
-    n_galaxy_params: ${model.galaxy.latent_dim}
     max_sources: 2
     mean_sources: 1.2
-    min_sources: 0
-    f_min: 1e5
-    f_max: 1e6
-    gal_slen: ${model.galaxy.slen}
-    decoder_file: null
-    psf_params_file: ${paths.root}/data/fitted_powerlaw_psf_params.npy
-    background_values: ${model.image.background}
     loc_min: 0.
     loc_max: 1.0
 encoder:
   params:
-    n_bands: ${model.image.n_bands}
-    tile_slen: ${model.decoder.params.tile_slen}
     ptile_slen: ${model.decoder.params.tile_slen}
-    max_detections: ${model.decoder.params.max_sources}
-    n_galaxy_params: ${model.galaxy.latent_dim}
     enc_conv_c: 20
     enc_kern: 3
     enc_hidden: 256


### PR DESCRIPTION
Since all `/config/model/sleep_*.yaml` are very similar, instead of having some values duplicated in all config files, I think it might be better to set them in `sleep_base.yaml` and re-use common values whenever possible. 

For now, this is done by force loading `sleep_base.yaml` before other more specific configs. Duplicated values in `sleep_base.yaml` are overwritten. 

This would introduce some unnecessary values when `model=galaxy_net`. This is fine for now as there are no duplicated keys. In the next release of Hydra, there will be more support for inheriting base config and this can be done more properly. 

For now, settings in `sleep_base.yaml` are just common settings shared by `sleep_*.yaml`. It might make more sense to split these based on model design.