### PR TITLE
Ignore deprecation warning in `tests/test_tune.py`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 filterwarnings =
     ignore:.*does not have many workers which may be a bottleneck.*:UserWarning
     ignore:.*Found no NVIDIA driver on your system.*:UserWarning
+    ignore:.*Using or importing the ABCs from.*:DeprecationWarning
+    ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning


### PR DESCRIPTION
Close #171 
Two warnings should be harmless. Add ignore in pytest.