### PR TITLE
Remove `cuda` or `to` call

### DIFF
--- a/bliss/__init__.py
+++ b/bliss/__init__.py
@@ -1,4 +1,0 @@
-import torch
-
-use_cuda = torch.cuda.is_available()
-device = torch.device("cuda" if use_cuda else "cpu")

--- a/bliss/datasets/simulated.py
+++ b/bliss/datasets/simulated.py
@@ -20,8 +20,8 @@ class SimulatedDataset(pl.LightningDataModule, IterableDataset):
 
         self.n_batches = cfg.dataset.params.n_batches
         self.batch_size = cfg.dataset.params.batch_size
-        self.image_decoder = ImageDecoder(
-            generate_device = cfg.dataset.params.generate_device, **cfg.model.decoder.params
+        self.image_decoder = ImageDecoder(**cfg.model.decoder.params).to(
+            cfg.dataset.params.generate_device
         )
         self.image_decoder.requires_grad_(False)  # freeze decoder weights.
 

--- a/bliss/datasets/simulated.py
+++ b/bliss/datasets/simulated.py
@@ -20,7 +20,9 @@ class SimulatedDataset(pl.LightningDataModule, IterableDataset):
 
         self.n_batches = cfg.dataset.params.n_batches
         self.batch_size = cfg.dataset.params.batch_size
-        self.image_decoder = ImageDecoder(**cfg.model.decoder.params)
+        self.image_decoder = ImageDecoder(
+            generate_device = cfg.dataset.params.generate_device, **cfg.model.decoder.params
+        )
         self.image_decoder.requires_grad_(False)  # freeze decoder weights.
 
         # check sleep training will work.

--- a/bliss/main.py
+++ b/bliss/main.py
@@ -12,3 +12,6 @@ def main(cfg):
     else:
         raise KeyError
     task(cfg)
+
+if __name__ == "__main__":
+    main()

--- a/bliss/main.py
+++ b/bliss/main.py
@@ -13,5 +13,6 @@ def main(cfg):
         raise KeyError
     task(cfg)
 
+
 if __name__ == "__main__":
     main()

--- a/bliss/models/decoder.py
+++ b/bliss/models/decoder.py
@@ -8,7 +8,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributions import Poisson, Normal
 
-from .. import device
 from .encoder import get_is_on_from_n_sources
 from . import galaxy_net
 import pytorch_lightning as pl
@@ -39,8 +38,14 @@ class ImageDecoder(pl.LightningModule):
         background_values=(686.0, 1123.0),
         loc_min=0.0,
         loc_max=1.0,
+        generate_device=None
     ):
         super(ImageDecoder, self).__init__()
+        
+        if generate_device is None:
+            self.generate_device = self.device
+        else:
+            self.generate_device = generate_device
 
         # side-length in pixels of an image (image is assumed to be square)
         assert slen % 1 == 0, "slen must be an integer."
@@ -100,7 +105,7 @@ class ImageDecoder(pl.LightningModule):
         self.cached_grid = self.get_mgrid(self.ptile_slen)
 
         # misc
-        self.swap = torch.tensor([1, 0], device=device)
+        self.swap = torch.tensor([1, 0], device=self.generate_device)
 
         # background
         assert len(background_values) == n_bands
@@ -109,7 +114,7 @@ class ImageDecoder(pl.LightningModule):
             self.slen + 2 * self.border_padding,
             self.slen + 2 * self.border_padding,
         )
-        self.background = torch.zeros(background_shape, device=device)
+        self.background = torch.zeros(background_shape, device=self.generate_device)
         for i in range(n_bands):
             self.background[i] = background_values[i]
 
@@ -120,20 +125,20 @@ class ImageDecoder(pl.LightningModule):
         assert self.prob_galaxy > 0.0 or decoder_file is None
         if decoder_file is not None:
             dec = galaxy_net.CenteredGalaxyDecoder(gal_slen, n_galaxy_params, n_bands)
-            dec = dec.to(device)
-            dec.load_state_dict(torch.load(decoder_file, map_location=device))
+            dec = dec.to(self.generate_device)
+            dec.load_state_dict(torch.load(decoder_file, map_location=self.generate_device))
             dec.eval().requires_grad_(False)
             self.galaxy_decoder = dec
 
         # load psf params + grid
         ext = Path(psf_params_file).suffix
         if ext == ".npy":
-            psf_params = torch.from_numpy(np.load(psf_params_file)).to(device)
+            psf_params = torch.from_numpy(np.load(psf_params_file)).to(self.generate_device)
             psf_params = psf_params[list(range(n_bands))]
         elif ext == ".fits":
             assert n_bands == 2, "only 2 band fit files are supported."
             bands = (2, 3)
-            psf_params = self.get_fit_file_psf_params(psf_params_file, bands).to(device)
+            psf_params = self.get_fit_file_psf_params(psf_params_file, bands).to(self.generate_device)
         else:
             raise NotImplementedError(
                 "Only .npy and .fits extensions are supported for PSF params files."
@@ -168,7 +173,7 @@ class ImageDecoder(pl.LightningModule):
         # mgrid is between -1 and 1
         # then scale slightly because of the way f.grid_sample
         # parameterizes the edges: (0, 0) is center of edge pixel
-        return mgrid.float().to(device) * (slen - 1) / slen
+        return mgrid.float().to(self.generate_device) * (slen - 1) / slen
 
 
     def get_fit_file_psf_params(self, psf_fit_file, bands=(2, 3)):
@@ -187,10 +192,10 @@ class ImageDecoder(pl.LightningModule):
 
             psf_params[i] = torch.log(torch.tensor([sigma1, sigma2, sigmap, beta, b, p0]))
 
-        return psf_params.to(device)
+        return psf_params.to(self.generate_device)
 
     def _get_psf(self):
-        psf = torch.tensor([], device=device)
+        psf = torch.tensor([], device=self.generate_device)
         for i in range(self.n_bands):
             _psf = self._get_psf_single_band(self.params[i])
             _psf *= self.normalization_constant[i]
@@ -223,7 +228,7 @@ class ImageDecoder(pl.LightningModule):
         # output dimension is batch_size x n_tiles_per_image
 
         # always poisson distributed.
-        p = torch.full((1,), self.mean_sources, device=device, dtype=torch.float)
+        p = torch.full((1,), self.mean_sources, device=self.generate_device, dtype=torch.float)
         m = Poisson(p)
         n_sources = m.sample([batch_size, self.n_tiles_per_image])
 
@@ -242,7 +247,7 @@ class ImageDecoder(pl.LightningModule):
             self.max_sources,
             2,
         )
-        locs = torch.rand(*shape, device=device)
+        locs = torch.rand(*shape, device=self.generate_device)
         locs *= self.loc_max - self.loc_min
         locs += self.loc_min
         locs *= is_on_array.unsqueeze(-1)
@@ -257,7 +262,7 @@ class ImageDecoder(pl.LightningModule):
 
         batch_size = n_sources.size(0)
         uniform = torch.rand(
-            batch_size, self.n_tiles_per_image, self.max_sources, 1, device=device
+            batch_size, self.n_tiles_per_image, self.max_sources, 1, device=self.generate_device
         )
         galaxy_bool = uniform < self.prob_galaxy
         galaxy_bool = (galaxy_bool * is_on_array.unsqueeze(-1)).float()
@@ -275,7 +280,7 @@ class ImageDecoder(pl.LightningModule):
         # draw pareto conditioned on being less than f_max
 
         u_max = self._pareto_cdf(self.f_max)
-        uniform_samples = torch.rand(*shape, device=device) * u_max
+        uniform_samples = torch.rand(*shape, device=self.generate_device) * u_max
         return self.f_min / (1.0 - uniform_samples) ** (1 / self.alpha)
 
     def _sample_fluxes(self, n_stars, star_bool, batch_size):
@@ -295,7 +300,7 @@ class ImageDecoder(pl.LightningModule):
                 self.max_sources,
                 self.n_bands - 1,
             )
-            colors = torch.randn(*shape, device=device)
+            colors = torch.randn(*shape, device=self.generate_device)
             _fluxes = 10 ** (colors / 2.5) * base_fluxes
             fluxes = torch.cat((base_fluxes, _fluxes), dim=3)
             fluxes *= star_bool.float()
@@ -309,8 +314,8 @@ class ImageDecoder(pl.LightningModule):
 
         assert len(n_galaxies.shape) == 2
         batch_size = n_galaxies.size(0)
-        mean = torch.zeros(1, dtype=torch.float, device=device)
-        std = torch.ones(1, dtype=torch.float, device=device)
+        mean = torch.zeros(1, dtype=torch.float, device=self.generate_device)
+        std = torch.ones(1, dtype=torch.float, device=self.generate_device)
         p_z = Normal(mean, std)
         shape = (
             batch_size,
@@ -351,7 +356,7 @@ class ImageDecoder(pl.LightningModule):
     @staticmethod
     def _get_log_fluxes(fluxes):
         log_fluxes = torch.where(
-            fluxes > 0, fluxes, torch.ones(*fluxes.shape).to(device)
+            fluxes > 0, fluxes, torch.ones(*fluxes.shape).to(fluxes.device)
         )  # prevent log(0) errors.
         log_fluxes = torch.log(log_fluxes)
 
@@ -401,7 +406,7 @@ class ImageDecoder(pl.LightningModule):
 
         assert source_slen <= _slen, "Should be using trim source."
 
-        source_expanded = torch.zeros(source.shape[0], _slen, _slen, device=device)
+        source_expanded = torch.zeros(source.shape[0], _slen, _slen, device=self.generate_device)
         offset = int((_slen - source_slen) / 2)
 
         source_expanded[
@@ -482,7 +487,7 @@ class ImageDecoder(pl.LightningModule):
         n_ptiles = locs.shape[0]
         max_sources = locs.shape[1]
         ptile_shape = (n_ptiles, self.n_bands, self.ptile_slen, self.ptile_slen)
-        ptile = torch.zeros(ptile_shape, device=device)
+        ptile = torch.zeros(ptile_shape, device=self.generate_device)
 
         assert len(psf.shape) == 3  # the shape is (n_bands, ptile_slen, ptile_slen)
         assert psf.shape[0] == self.n_bands
@@ -513,8 +518,8 @@ class ImageDecoder(pl.LightningModule):
 
         # allocate memory
         _slen = self.ptile_slen + ((self.ptile_slen % 2) == 0) * 1
-        gal = torch.zeros(z.shape[0], self.n_bands, _slen, _slen, device=device)
-        var = torch.zeros(z.shape[0], self.n_bands, _slen, _slen, device=device)
+        gal = torch.zeros(z.shape[0], self.n_bands, _slen, _slen, device=self.generate_device)
+        var = torch.zeros(z.shape[0], self.n_bands, _slen, _slen, device=self.generate_device)
 
         # forward only galaxies that are on!
         gal_on, var_on = self.galaxy_decoder.forward(z[b == 1])
@@ -539,8 +544,8 @@ class ImageDecoder(pl.LightningModule):
         n_ptiles = locs.shape[0]
         max_sources = locs.shape[1]
         ptile_shape = (n_ptiles, self.n_bands, self.ptile_slen, self.ptile_slen)
-        ptile = torch.zeros(ptile_shape, device=device)
-        var_ptile = torch.zeros(ptile_shape, device=device)
+        ptile = torch.zeros(ptile_shape, device=self.generate_device)
+        var_ptile = torch.zeros(ptile_shape, device=self.generate_device)
 
         assert self.galaxy_decoder is not None
         assert galaxy_params.shape[0] == galaxy_bool.shape[0] == n_ptiles
@@ -603,8 +608,8 @@ class ImageDecoder(pl.LightningModule):
 
         # draw stars and galaxies
         stars = self._render_multiple_stars_on_ptile(_locs, _fluxes, _star_bool)
-        galaxies = torch.zeros(img_shape, device=device)
-        var_images = torch.zeros(img_shape, device=device)
+        galaxies = torch.zeros(img_shape, device=self.generate_device)
+        var_images = torch.zeros(img_shape, device=self.generate_device)
         if self.galaxy_decoder is not None:
             galaxies, var_images = self._render_multiple_galaxies_on_ptile(
                 _locs, _galaxy_params, _galaxy_bool
@@ -692,7 +697,7 @@ class ImageDecoder(pl.LightningModule):
             n_bands,
             ptile_slen,
             ptile_slen,
-            device=device,
+            device=image_ptiles.device,
         )
         zero_pads2 = torch.zeros(
             batch_size,
@@ -701,7 +706,7 @@ class ImageDecoder(pl.LightningModule):
             n_bands,
             ptile_slen,
             ptile_slen,
-            device=device,
+            device=image_ptiles.device,
         )
         image_tiles_4d = torch.cat((image_tiles_4d, zero_pads1), dim=1)
         image_tiles_4d = torch.cat((image_tiles_4d, zero_pads2), dim=2)
@@ -713,17 +718,17 @@ class ImageDecoder(pl.LightningModule):
             n_bands,
             (n_tiles + n_tiles1_in_ptile - 1) * tile_slen,
             (n_tiles + n_tiles1_in_ptile - 1) * tile_slen,
-            device=device,
+            device=image_ptiles.device,
         )
 
         # loop through all tiles in a ptile
         for i in range(n_tiles1_in_ptile):
             for j in range(n_tiles1_in_ptile):
                 indx_vec1 = torch.arange(
-                    start=i, end=n_tiles, step=n_tiles1_in_ptile, device=device
+                    start=i, end=n_tiles, step=n_tiles1_in_ptile, device=image_ptiles.device
                 )
                 indx_vec2 = torch.arange(
-                    start=j, end=n_tiles, step=n_tiles1_in_ptile, device=device
+                    start=j, end=n_tiles, step=n_tiles1_in_ptile, device=image_ptiles.device
                 )
 
                 canvas_len = len(indx_vec1) * ptile_slen

--- a/bliss/models/decoder.py
+++ b/bliss/models/decoder.py
@@ -150,7 +150,7 @@ class ImageDecoder(pl.LightningModule):
         assert self.prob_galaxy > 0.0 or decoder_file is None
         if decoder_file is not None:
             dec = galaxy_net.CenteredGalaxyDecoder(gal_slen, n_galaxy_params, n_bands)
-            dec.load_state_dict(torch.load(decoder_file))
+            dec.load_state_dict(torch.load(decoder_file, map_location=self.device))
             dec.eval().requires_grad_(False)
             self.galaxy_decoder = dec
 

--- a/bliss/models/decoder.py
+++ b/bliss/models/decoder.py
@@ -355,7 +355,7 @@ class ImageDecoder(pl.LightningModule):
     @staticmethod
     def _get_log_fluxes(fluxes):
         log_fluxes = torch.where(
-            fluxes > 0, fluxes, torch.ones(*fluxes.shape).to(fluxes.device)
+            fluxes > 0, fluxes, torch.ones_like(fluxes)
         )  # prevent log(0) errors.
         log_fluxes = torch.log(log_fluxes)
 

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -227,7 +227,7 @@ class ImageEncoder(nn.Module):
         # get index for prob_n_sources, assigned indices that were not used.
         indx_mats, last_indx = self._get_hidden_indices()
         for k, v in indx_mats.items():
-            self.register_buffer(k, v, persistent=False)
+            self.register_buffer(k+"_indx", v, persistent=False)
         self.register_buffer(
             "prob_n_source_indx",
             torch.arange(last_indx, self.dim_out_all),
@@ -360,7 +360,7 @@ class ImageEncoder(nn.Module):
 
         est_params = {}
         for k in self.variational_params:
-            indx_mat = getattr(self, k)
+            indx_mat = getattr(self, k+"_indx")
             param_dim = self.variational_params[k]["dim"]
             transform = self.variational_params[k]["transform"]
             _param = self._indx_h_for_n_sources(h, n_sources, indx_mat, param_dim)

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -5,8 +5,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributions import categorical
 
-from .. import device
-
 
 def get_is_on_from_n_sources(n_sources, max_sources):
     """Return a boolean array of shape=(batch_size, max_sources) whose (k,l)th entry indicates
@@ -17,7 +15,7 @@ def get_is_on_from_n_sources(n_sources, max_sources):
     assert torch.all(n_sources.le(max_sources))
 
     is_on_array = torch.zeros(
-        *n_sources.shape, max_sources, device=device, dtype=torch.float
+        *n_sources.shape, max_sources, device=n_sources.device, dtype=torch.float
     )
 
     for i in range(max_sources):
@@ -62,7 +60,7 @@ def get_full_params(slen: int, tile_params: dict):
     tile_slen = int(tile_slen)
 
     # coordinates on tiles.
-    tile_coords = _get_tile_coords(slen, tile_slen)
+    tile_coords = _get_tile_coords(slen, tile_slen).type_as(tile_locs)
     assert tile_coords.shape[0] == n_tiles_per_image, "# tiles one image don't match"
 
     # get is_on_array
@@ -128,7 +126,6 @@ def _get_tile_coords(slen, tile_slen):
         return [(i // nptiles1) * tile_slen, (i % nptiles1) * tile_slen]
 
     tile_coords = torch.LongTensor([return_coords(i) for i in range(n_ptiles)])
-    tile_coords = tile_coords.to(device)
 
     return tile_coords
 
@@ -228,11 +225,13 @@ class ImageEncoder(nn.Module):
         self.log_softmax = nn.LogSoftmax(dim=1)
 
         # get index for prob_n_sources, assigned indices that were not used.
-        self.indx_mats, last_indx = self._get_hidden_indices()
-        self.prob_n_source_indx = torch.arange(
-            last_indx,
-            self.dim_out_all,
-            device=device,
+        indx_mats, last_indx = self._get_hidden_indices()
+        for k, v in indx_mats.items():
+            self.register_buffer(k, v, persistent=False)
+        self.register_buffer(
+            "prob_n_source_indx",
+            torch.arange(last_indx, self.dim_out_all),
+            persistent=False,
         )
         assert self.prob_n_source_indx.shape[0] == self.max_detections + 1
 
@@ -245,12 +244,15 @@ class ImageEncoder(nn.Module):
         # These weights are set up and  cached during the __init__.
 
         ptile_slen2 = self.ptile_slen ** 2
-        self.tile_conv_weights = torch.zeros(
-            ptile_slen2 * self.n_bands,
-            self.n_bands,
-            self.ptile_slen,
-            self.ptile_slen,
-            device=device,
+        self.register_buffer(
+            "tile_conv_weights",
+            torch.zeros(
+                ptile_slen2 * self.n_bands,
+                self.n_bands,
+                self.ptile_slen,
+                self.ptile_slen,
+            ),
+            persistent=False,
         )
 
         for b in range(self.n_bands):
@@ -290,7 +292,6 @@ class ImageEncoder(nn.Module):
                 shape,
                 self.dim_out_all,
                 dtype=torch.long,
-                device=device,
             )
             indx_mats[k] = indx_mat
 
@@ -326,7 +327,7 @@ class ImageEncoder(nn.Module):
         n_samples = n_sources.size(0)
 
         # append null column, return zero if indx_mat returns null index (dim_out_all)
-        _h = torch.cat((h, torch.zeros(n_ptiles, 1, device=device)), dim=1)
+        _h = torch.cat((h, torch.zeros(n_ptiles, 1, device=h.device)), dim=1)
 
         # select the indices from _h indicated by indx_mat.
         var_param = torch.gather(
@@ -356,11 +357,10 @@ class ImageEncoder(nn.Module):
             loc_mean.shape = (n_sample x n_ptiles x max_detections x len(x,y))
         """
         assert len(n_sources.shape) == 2
-        assert bool(self.indx_mats)
 
         est_params = {}
         for k in self.variational_params:
-            indx_mat = self.indx_mats[k]
+            indx_mat = getattr(self, k)
             param_dim = self.variational_params[k]["dim"]
             transform = self.variational_params[k]["transform"]
             _param = self._indx_h_for_n_sources(h, n_sources, indx_mat, param_dim)

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -227,7 +227,7 @@ class ImageEncoder(nn.Module):
         # get index for prob_n_sources, assigned indices that were not used.
         indx_mats, last_indx = self._get_hidden_indices()
         for k, v in indx_mats.items():
-            self.register_buffer(k+"_indx", v, persistent=False)
+            self.register_buffer(k + "_indx", v, persistent=False)
         self.register_buffer(
             "prob_n_source_indx",
             torch.arange(last_indx, self.dim_out_all),
@@ -360,7 +360,7 @@ class ImageEncoder(nn.Module):
 
         est_params = {}
         for k in self.variational_params:
-            indx_mat = getattr(self, k+"_indx")
+            indx_mat = getattr(self, k + "_indx")
             param_dim = self.variational_params[k]["dim"]
             transform = self.variational_params[k]["transform"]
             _param = self._indx_h_for_n_sources(h, n_sources, indx_mat, param_dim)

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -10,7 +10,7 @@ from torch.nn import CrossEntropyLoss
 from torch.distributions import Normal
 from torch.optim import Adam
 
-from . import device, plotting
+from . import plotting
 from .models import encoder, decoder, galaxy_net
 from .models.encoder import get_star_bool, get_full_params
 from .metrics import eval_error_on_batch
@@ -37,7 +37,7 @@ def _get_log_probs_all_perms(
     max_detections = star_params_log_probs_all.size(-1)
 
     n_permutations = math.factorial(max_detections)
-    locs_log_probs_all_perm = torch.zeros(n_ptiles, n_permutations, device=device)
+    locs_log_probs_all_perm = torch.zeros(n_ptiles, n_permutations, device=locs_log_probs_all.device)
     star_params_log_probs_all_perm = locs_log_probs_all_perm.clone()
     galaxy_bool_log_probs_all_perm = locs_log_probs_all_perm.clone()
 

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -37,7 +37,9 @@ def _get_log_probs_all_perms(
     max_detections = star_params_log_probs_all.size(-1)
 
     n_permutations = math.factorial(max_detections)
-    locs_log_probs_all_perm = torch.zeros(n_ptiles, n_permutations, device=locs_log_probs_all.device)
+    locs_log_probs_all_perm = torch.zeros(
+        n_ptiles, n_permutations, device=locs_log_probs_all.device
+    )
     star_params_log_probs_all_perm = locs_log_probs_all_perm.clone()
     galaxy_bool_log_probs_all_perm = locs_log_probs_all_perm.clone()
 

--- a/bliss/train.py
+++ b/bliss/train.py
@@ -11,7 +11,7 @@ from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.callbacks import ModelCheckpoint
 import torch
 
-from bliss import use_cuda, sleep
+from bliss import sleep
 from bliss.datasets import simulated, catsim
 from bliss.models import galaxy_net
 
@@ -87,7 +87,7 @@ def main(cfg: DictConfig):
 
     # setup gpus
 
-    if cfg.training.trainer.gpus != None and use_cuda:
+    if cfg.training.trainer.gpus != None and torch.cuda.is_available():
         gpus = list(cfg.training.trainer.gpus)
         assert isinstance(gpus, list)
         assert len(gpus) == 1 and isinstance(gpus[0], int), "Only one GPU is supported."

--- a/bliss/tune.py
+++ b/bliss/tune.py
@@ -37,6 +37,7 @@ def sleep_trainable(search_space, cfg: DictConfig):
     # set up trainer
     logging.getLogger("lightning").setLevel(0)
     trainer = pl.Trainer(
+        limit_val_batches=cfg.tuning.limit_val_batches,
         weights_summary=None,
         max_epochs=cfg.tuning.n_epochs,
         gpus=cfg.tuning.gpus_per_trial,

--- a/config/dataset/cpu.yaml
+++ b/config/dataset/cpu.yaml
@@ -4,3 +4,4 @@ params:
   n_batches: 1
   batch_size: 2
   num_workers: 0
+  generate_device: "cpu"

--- a/config/dataset/default.yaml
+++ b/config/dataset/default.yaml
@@ -4,3 +4,4 @@ params:
   n_batches: 10
   batch_size: 32
   num_workers: 0
+  generate_device: "cuda:0"

--- a/config/dataset/m2.yaml
+++ b/config/dataset/m2.yaml
@@ -4,3 +4,4 @@ params:
   n_batches: 10
   batch_size: 20
   num_workers: 0
+  generate_device: "cuda:0"

--- a/config/dataset/single_tile.yaml
+++ b/config/dataset/single_tile.yaml
@@ -4,3 +4,5 @@ params:
   n_batches: 10
   batch_size: 6400
   num_workers: 0
+  generate_device: "cuda:0"
+

--- a/config/dataset/test_plotting.yaml
+++ b/config/dataset/test_plotting.yaml
@@ -4,3 +4,4 @@ params:
   n_batches: 1
   batch_size: 3
   num_workers: 0
+  generate_device: "cuda:0"

--- a/config/dataset/test_plotting.yaml
+++ b/config/dataset/test_plotting.yaml
@@ -4,4 +4,4 @@ params:
   n_batches: 1
   batch_size: 3
   num_workers: 0
-  generate_device: "cuda:0"
+  generate_device: "cpu"

--- a/config/training/default.yaml
+++ b/config/training/default.yaml
@@ -12,4 +12,4 @@ trainer:
   gpus: ${gpus}
   limit_train_batches: 1.0
   limit_val_batches: 1.0
-  check_val_every_n_epoch: 10
+  check_val_every_n_epoch: 1

--- a/config/training/default.yaml
+++ b/config/training/default.yaml
@@ -12,4 +12,4 @@ trainer:
   gpus: ${gpus}
   limit_train_batches: 1.0
   limit_val_batches: 1.0
-  check_val_every_n_epoch: 1
+  check_val_every_n_epoch: 10

--- a/config/tuning/m2.yaml
+++ b/config/tuning/m2.yaml
@@ -24,6 +24,7 @@ n_samples: 20
 verbose: 1
 seed: 42
 save: True
+limit_val_batches: 1
 best_config_save_path: ${paths.root}/config/tuning/m2_best_result.yaml
 log_path: ${paths.root}/temp/tuning
 

--- a/tests/test_encoder_forward.py
+++ b/tests/test_encoder_forward.py
@@ -78,10 +78,10 @@ class TestSourceEncoder:
             h_out = star_encoder._get_var_params_all(image_ptiles)
 
             # get index matrices
-            locs_mean_indx_mat = star_encoder.loc_mean
-            locs_var_indx_mat = star_encoder.loc_logvar
-            log_flux_mean_indx_mat = star_encoder.log_flux_mean
-            log_flux_var_indx_mat = star_encoder.log_flux_logvar
+            locs_mean_indx_mat = star_encoder.loc_mean_indx
+            locs_var_indx_mat = star_encoder.loc_logvar_indx
+            log_flux_mean_indx_mat = star_encoder.log_flux_mean_indx
+            log_flux_var_indx_mat = star_encoder.log_flux_logvar_indx
             prob_n_source_indx_mat = star_encoder.prob_n_source_indx
 
             for i in range(n_image_tiles):

--- a/tests/test_encoder_forward.py
+++ b/tests/test_encoder_forward.py
@@ -78,10 +78,10 @@ class TestSourceEncoder:
             h_out = star_encoder._get_var_params_all(image_ptiles)
 
             # get index matrices
-            locs_mean_indx_mat = star_encoder.indx_mats["loc_mean"]
-            locs_var_indx_mat = star_encoder.indx_mats["loc_logvar"]
-            log_flux_mean_indx_mat = star_encoder.indx_mats["log_flux_mean"]
-            log_flux_var_indx_mat = star_encoder.indx_mats["log_flux_logvar"]
+            locs_mean_indx_mat = star_encoder.loc_mean
+            locs_var_indx_mat = star_encoder.loc_logvar
+            log_flux_mean_indx_mat = star_encoder.log_flux_mean
+            log_flux_var_indx_mat = star_encoder.log_flux_logvar
             prob_n_source_indx_mat = star_encoder.prob_n_source_indx
 
             for i in range(n_image_tiles):

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,9 +1,13 @@
-import pytest
 from bliss import generate
 from hydra.experimental import initialize, compose
 
 
-def test_generate_run():
+def test_generate_run(devices):
+    overrides = {
+        "dataset.params.generate_device": "cuda:0" if devices.use_cuda else "cpu",
+    }
+    overrides = [f"{k}={v}" for k, v in overrides.items()]
     with initialize(config_path="../config"):
-        cfg = compose("config")
+
+        cfg = compose("config", overrides=overrides)
         generate.main(cfg)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -2,10 +2,12 @@ from bliss import train
 from hydra.experimental import initialize, compose
 
 
-class TestTrain:
-    def test_train_run(self, devices):
-        overrides = {"training": "default" if devices.use_cuda else "cpu"}
-        overrides = [f"{k}={v}" for k, v in overrides.items()]
-        with initialize(config_path="../config"):
-            cfg = compose("config", overrides=overrides)
-            train.main(cfg)
+def test_train_run(devices):
+    overrides = {
+        "training": "default" if devices.use_cuda else "cpu",
+        "dataset": "default" if devices.use_cuda else "cpu",
+    }
+    overrides = [f"{k}={v}" for k, v in overrides.items()]
+    with initialize(config_path="../config"):
+        cfg = compose("config", overrides=overrides)
+        train.main(cfg)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,5 +1,4 @@
 from bliss import train
-import pytest
 from hydra.experimental import initialize, compose
 
 

--- a/tests/test_wake.py
+++ b/tests/test_wake.py
@@ -91,7 +91,7 @@ class TestWake:
             hparams=dict({"lr": 1e-5, "n_samples": 2000}),
         ).to(devices.device)
 
-        n_epochs = 3000 if torch.cuda.is_available() else 2
+        n_epochs = 3000 if devices.use_cuda else 2
         wake_trainer = pl.Trainer(
             check_val_every_n_epoch=10000,
             max_epochs=n_epochs,


### PR DESCRIPTION
close #179 

The `device` and `use_cuda` in `__init__.py` are completely removed to avoid dependencies on global `device` variable that is not managed by pytorch-lightning or config. To achieve this, the following changes are made (the following changes are tested both on gpu and cpu on our server.). 
- For tensors initialized in `__init__()`, they are now managed by pytorch itself to move together with the whole model using `register_buffer()`.
- For tensors created after `__init__()` in a downstream pass, their `device` is inferred from `self.device` which is updated whenever the model gets moved to a new device by pytorch-lightning.
- For tensors created for operating with "input", their `device` is inferred from the "input" tensor.
- [For tensors registered as parameters](https://github.com/prob-ml/bliss/blob/1802f0aefdc44d0bb482f1575f328954b4ddfe4c/bliss/models/decoder.py#L158-L170), they would automatically be managed by pytorch along with other parameters, so we don't need to manually assign device.
- [For loaded submodules](https://github.com/prob-ml/bliss/blob/1802f0aefdc44d0bb482f1575f328954b4ddfe4c/bliss/models/decoder.py#L151-L155),  they would automatically be managed by pytorch along with other submodules, so we don't need to manually assign device.

One implementation detail is that `encoder.indx_mats` was previously created as a dictionary of tensors in `__init__()`. Pytorch doesn't support register a dictionary buffer, so tensors in `indx_mats` are now stored directly under `encoder` with their keys in `indx_mats` as attribute names. Those can be accessed, for example, by `self.loc_mean` or `getatter(self, "loc_mean")` depending on use case.

For our current training scheme. There are two `decoder` objects created, `SimulatedDataset.image_decoder` and `SleepPhase.image_decoder`. 
`SleepPhase.image_decoder` is managed by pytorch-lightning since it's passed along with `SleepPhase` in pytorch `Trainer` and pl should correctly manage it for multi-gpu since there's no hard-coded `device` outside.
`SimulatedDataset.image_decoder` is the one that we have to manually control since pl doesn't really have support for preparing data on gpu and `SimlulatedDataset.image_decoder` is not part of the training model.

There are two solutions in preparing for multi-gpu.
1. (implemented in this PR) Manually assign a device for dataloader for hosting `SleepPhase.image_decoder`. It would be initialized on cpu just as normal and then move to the assigned device. This operation itself should be fine as `nn.module` are normally moved like this and this only happens once. `SleepPhase.image_decoder` is automatically managed by pl and should run without problems. So now our dataloader is on a `generate_gpu` and maybe different from the gpu devices hosting models. This itself and the transferring data should also be fine since normally this is done with dataloader on `cpu` and models on gpus. Comparing to the next resolution, this requires less code change. But I'm not sure in DDP, how pl would manage multiple processes and dataloaders (now use gpu as well).
2. [Move data generation to model forward pass](https://github.com/prob-ml/bliss/issues/179#issuecomment-761842518). This should work smoothly with DDP and would require less footprint since we can potentially use only one `decoder` instance for both training and data generation. We just need to be careful with our computational graph. We would also need to create a dummy dataset and I'm not sure how much impact this would create for other things. 


Sorry for the late writeup, some of the information above might be relevant to your comments. @jeff-regier @ismael-mendoza 

**New update**: For a sanity check, I set `generate_device: "cuda:7"`. It also works. This way, the model is on `cuda:0` and the data generation is on `cuda:7`. So the communication and the way the device being setup should at least doesn't cause any error, whether it's efficient or not. I think solution 1 might worth a try. I'm not 100% sure, but I think, for DDP, pl would create several processes and dataloaders on `generate_device` and several models on all other free gpus. So the setup up would be something like `generate_device` hosting all dataloaders and each other free gpu has one model for training. Giving that loading data on gpu uses around 1100mb memory and only around 3% workload. I think 1 gpu dedicated to feeding data is enough for the amount of gpus we have on our server for now. But solution 2 is still the better long term approach in my opinion. 

**New update2**: This PR works out of the box with the default `ddp_spawn` DDP scheme using all gpus (one of the gpus has all dataloaders and one model, other gpus each has one model) for training.