### PR TITLE
Set BLISS_HOME on module load if not already set

### DIFF
--- a/bliss/__init__.py
+++ b/bliss/__init__.py
@@ -1,0 +1,6 @@
+from os import getenv, environ
+from pathlib import Path
+
+if getenv("BLISS_HOME") is None:
+    bliss_path = Path(__file__).resolve()
+    environ["BLISS_HOME"] = bliss_path.parent.parent.as_posix()


### PR DESCRIPTION
This is what I came up with to solve #186.  We check if the user has BLISS_HOME in their environment. If they don't, we set it to a reasonable default (the directory of the loaded bliss module). This should work without changing code elsewhere.