### PR TITLE
fixes some pylint warnings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,3 +4,18 @@
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
 generated-members=numpy.*,torch.*
+
+# We get too-many-ancestors warnings whenever we inherit LightningModule:
+# it's not really a problem and there isn't really anything we could do
+# about it anyway
+disable=too-many-ancestors,
+	# We get these arguments-differ warnings when we override
+	# PyTorch Lightnings dataload methods because we have fewer
+	# arguments, but if we include all the arguments, we'd
+	# get unused variable warnings instead
+	arguments-differ,
+	# these not-callable warnings come from an issue with pytorch
+	# that may be resolved in pytorch version 1.7.2
+	not-callable,
+	# we often don't want to override lightning's abstract methods
+	abstract-method

--- a/.pylintrc
+++ b/.pylintrc
@@ -18,4 +18,13 @@ disable=too-many-ancestors,
 	# that may be resolved in pytorch version 1.7.2
 	not-callable,
 	# we often don't want to override lightning's abstract methods
-	abstract-method
+	abstract-method,
+	# we have too a lot of short variable names, and fixing them doesn't
+	# seem urgent
+	invalid-name,
+	# we don't have comprehensive documentation yet, let's suppress
+	# these warnings until that's something we're focused on
+	missing-function-docstring,
+	missing-module-docstring,
+	missing-class-docstring,
+

--- a/bliss/datasets/catsim.py
+++ b/bliss/datasets/catsim.py
@@ -13,7 +13,7 @@ def filter_bounds(cat, param, min_val=-np.inf, max_val=np.inf):
     return cat[(cat[param] >= min_val) & (cat[param] <= max_val)]
 
 
-class SurveyObs(object):
+class SurveyObs:
     def __init__(self, renderer):
         """Returns a list of :class:`Survey` objects, each of them has an image attribute which is
         where images are written to by iso_render_engine.render_galaxy.
@@ -60,7 +60,7 @@ class SurveyObs(object):
             )
 
 
-class CatsimRenderer(object):
+class CatsimRenderer:
     def __init__(
         self,
         survey_name="LSST",
@@ -218,7 +218,7 @@ class CatsimGalaxies(pl.LightningDataModule, Dataset):
         and returns a galaxy drawn from the catalog with realistic seeing conditions using
         functions from WeakLensingDeblending.
         """
-        super(CatsimGalaxies, self).__init__()
+        super().__init__()
         self.renderer = CatsimRenderer(**cfg.dataset.renderer)
         self.background = self.renderer.background
 
@@ -291,7 +291,7 @@ class CatsimGalaxies(pl.LightningDataModule, Dataset):
 
 class SavedCatsim(pl.LightningDataModule, Dataset):
     def __init__(self, cfg):
-        super(SavedCatsim, self).__init__()
+        super().__init__()
         params = cfg.dataset.params
         self.data = torch.load(params.filepath)
         self.images = self.data["images"]

--- a/bliss/datasets/sdss.py
+++ b/bliss/datasets/sdss.py
@@ -1,7 +1,7 @@
-import torch
 import pathlib
 import pickle
 import warnings
+
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -125,7 +125,7 @@ class SloanDigitalSkySurvey(Dataset):
         overwrite_cache=False,
         center_subpixel=True,
     ):
-        super(SloanDigitalSkySurvey, self).__init__()
+        super().__init__()
 
         self.sdss_path = pathlib.Path(sdss_dir)
         self.rcfgcs = []
@@ -288,7 +288,7 @@ class SloanDigitalSkySurvey(Dataset):
             return ret, cache_path
 
         for b, bl in enumerate("ugriz"):
-            if not (b in self.bands):
+            if b not in self.bands:
                 continue
 
             frame_name = "frame-{}-{:06d}-{:d}-{:04d}.fits".format(

--- a/bliss/datasets/sdss.py
+++ b/bliss/datasets/sdss.py
@@ -1,6 +1,7 @@
 import pathlib
 import pickle
 import warnings
+from math import floor, ceil
 
 import numpy as np
 import torch
@@ -10,7 +11,6 @@ from scipy.interpolate import RegularGridInterpolator
 from torch.utils.data import Dataset
 from astropy.io import fits
 from astropy.wcs import WCS, FITSFixedWarning
-from math import floor, ceil
 
 
 def construct_subpixel_grid_base(size_x, size_y):
@@ -86,11 +86,11 @@ def psf_at_points(x, y, psf_data):
     # http://photo.astro.princeton.edu/photoop_doc.html#SDSS_PSF_RECON
     #   acoeff_k = SUM_i{ SUM_j{ (0.001*ROWC)^i * (0.001*COLC)^j * C_k_ij } }
     #   psfimage = SUM_k{ acoeff_k * RROWS_k }
-    for k in range(len(psf)):
-        nrb = psf[k]["nrow_b"]
-        ncb = psf[k]["ncol_b"]
+    for k, psf_k in enumerate(psf):
+        nrb = psf_k["nrow_b"]
+        ncb = psf_k["ncol_b"]
 
-        c = psf[k]["c"].reshape(5, 5)
+        c = psf_k["c"].reshape(5, 5)
         c = c[:nrb, :ncb]
 
         (gridi, gridj) = np.meshgrid(range(nrb), range(ncb))

--- a/bliss/datasets/simulated.py
+++ b/bliss/datasets/simulated.py
@@ -32,7 +32,7 @@ class SimulatedDataset(pl.LightningDataModule, IterableDataset):
         return self.batch_generator()
 
     def batch_generator(self):
-        for i in range(self.n_batches):
+        for _ in range(self.n_batches):
             yield self.get_batch()
 
     def get_batch(self):

--- a/bliss/datasets/simulated.py
+++ b/bliss/datasets/simulated.py
@@ -1,10 +1,8 @@
+import warnings
 from omegaconf import DictConfig
 import pytorch_lightning as pl
-import warnings
-
 import torch
 from torch.utils.data import IterableDataset, Dataset, DataLoader
-
 from bliss.models.decoder import ImageDecoder
 
 # prevent pytorch_lightning warning for num_workers = 0 in dataloaders with IterableDataset

--- a/bliss/generate.py
+++ b/bliss/generate.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
+
 import os
 import math
+from pathlib import Path
+
 import torch
 import matplotlib.pyplot as plt
 from omegaconf import DictConfig, OmegaConf
-from pathlib import Path
 
 from bliss.datasets import simulated, catsim
 from bliss import plotting

--- a/bliss/generate.py
+++ b/bliss/generate.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import os
 import math
 from pathlib import Path
@@ -70,7 +68,3 @@ def main(cfg: DictConfig):
     # save batch and images as pdf for visualization purposes.
     torch.save(fbatch, filepath)
     visualize(fbatch, imagepath, cfg.generate.n_plots)
-
-
-if __name__ == "__main__":
-    main()

--- a/bliss/main.py
+++ b/bliss/main.py
@@ -12,7 +12,3 @@ def main(cfg):
     else:
         raise KeyError
     task(cfg)
-
-
-if __name__ == "__main__":
-    main()

--- a/bliss/models/decoder.py
+++ b/bliss/models/decoder.py
@@ -420,8 +420,7 @@ class ImageDecoder(pl.LightningModule):
 
         if self.ptile_slen >= psf.shape[-1]:
             return self._expand_source(psf)
-        else:
-            return self._trim_source(psf)
+        return self._trim_source(psf)
 
     def _size_galaxy(self, galaxy):
         # galaxy should be shape n_galaxies x n_bands x galaxy_slen x galaxy_slen

--- a/bliss/models/decoder.py
+++ b/bliss/models/decoder.py
@@ -1,8 +1,8 @@
 import warnings
 from pathlib import Path
+
 import numpy as np
 from astropy.io import fits
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -56,7 +56,7 @@ class ImageDecoder(pl.LightningModule):
         loc_min=0.0,
         loc_max=1.0,
     ):
-        super(ImageDecoder, self).__init__()
+        super().__init__()
 
         # side-length in pixels of an image (image is assumed to be square)
         assert slen % 1 == 0, "slen must be an integer."

--- a/bliss/models/galaxy_net.py
+++ b/bliss/models/galaxy_net.py
@@ -151,7 +151,7 @@ class OneCenteredGalaxy(pl.LightningModule):
     # Training
     # ----------------
 
-    def training_step(self, batch, batch_idx):
+    def training_step(self, batch, batch_idx):  # pylint: disable=unused-argument
         images, background = batch["images"], batch["background"]
         recon_mean, recon_var, kl_z = self(images, background)
         loss = self.get_loss(images, recon_mean, recon_var, kl_z)
@@ -162,7 +162,7 @@ class OneCenteredGalaxy(pl.LightningModule):
     # Validation
     # ----------------
 
-    def validation_step(self, batch, batch_idx):
+    def validation_step(self, batch, batch_idx):  # pylint: disable=unused-argument
         images, background = batch["images"], batch["background"]
         recon_mean, recon_var, kl_z = self(images, background)
         loss = self.get_loss(images, recon_mean, recon_var, kl_z)

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -376,7 +376,9 @@ class SleepPhase(pl.LightningModule):
 
         return opt
 
-    def training_step(self, batch, batch_idx, optimizer_idx=0):  # pylint: disable=unused-argument
+    def training_step(
+        self, batch, batch_idx, optimizer_idx=0
+    ):  # pylint: disable=unused-argument
         loss = 0.0
 
         if optimizer_idx == 0:  # image_encoder

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -10,7 +10,6 @@ import torch
 from torch.nn import CrossEntropyLoss
 from torch.distributions import Normal
 from torch.optim import Adam
-import torch.nn.functional as F
 
 from . import plotting
 from .models import encoder, decoder, galaxy_net
@@ -140,8 +139,9 @@ class SleepPhase(pl.LightningModule):
         self.galaxy_encoder = None
         if self.use_galaxy_encoder:
             # NOTE: We crop and center each padded tile before passing it on to the galaxy_encoder
-            # assume that crop_slen = 2*tile_slen (on each side)
-            # TODO: for now only, 1 galaxy per tile is supported. Even though multiple stars per tile should work but there is no easy way to enforce this.
+            #       assume that crop_slen = 2*tile_slen (on each side)
+            # TODO: for now only, 1 galaxy per tile is supported. Even though multiple stars per
+            #       tile should work but there is no easy way to enforce this.
             self.galaxy_encoder = galaxy_net.CenteredGalaxyEncoder(
                 **cfg.model.galaxy_encoder.params
             )

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -1,6 +1,7 @@
 import math
-import numpy as np
 from itertools import permutations
+
+import numpy as np
 import matplotlib.pyplot as plt
 from omegaconf import DictConfig
 import pytorch_lightning as pl
@@ -121,7 +122,7 @@ def _get_params_logprob_all_combs(true_params, param_mean, param_logvar):
 
 class SleepPhase(pl.LightningModule):
     def __init__(self, cfg: DictConfig):
-        super(SleepPhase, self).__init__()
+        super().__init__()
         self.save_hyperparameters(cfg)
 
         self.image_encoder = encoder.ImageEncoder(**cfg.model.encoder.params)
@@ -615,7 +616,7 @@ class SleepPhase(pl.LightningModule):
                 title = f"Val Images {self.current_epoch}"
                 self.logger.experiment.add_figure(title, fig)
             elif kind == "testing":
-                self.logger.experiment.add_figure(f"Test Images", fig)
+                self.logger.experiment.add_figure("Test Images", fig)
             else:
                 raise NotImplementedError()
         plt.close(fig)

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -376,7 +376,7 @@ class SleepPhase(pl.LightningModule):
 
         return opt
 
-    def training_step(self, batch, batch_idx, optimizer_idx=0):
+    def training_step(self, batch, batch_idx, optimizer_idx=0):  # pylint: disable=unused-argument
         loss = 0.0
 
         if optimizer_idx == 0:  # image_encoder
@@ -389,7 +389,7 @@ class SleepPhase(pl.LightningModule):
 
         return loss
 
-    def validation_step(self, batch, batch_indx):
+    def validation_step(self, batch, batch_idx):  # pylint: disable=unused-argument
         (
             detection_loss,
             counter_loss,
@@ -426,7 +426,7 @@ class SleepPhase(pl.LightningModule):
         if self.plotting and self.current_epoch > 1:
             self.make_plots(outputs[-1], kind="validation")
 
-    def test_step(self, batch, batch_indx):
+    def test_step(self, batch, batch_idx):  # pylint: disable=unused-argument
         metrics = self.get_metrics(batch)
         self.log("acc_counts", metrics["counts_acc"])
         self.log("acc_gal_counts", metrics["galaxy_counts_acc"])

--- a/bliss/train.py
+++ b/bliss/train.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from pathlib import Path
 import shutil
 
@@ -110,7 +109,3 @@ def main(cfg: DictConfig):
     # test!
     if cfg.testing.file is not None:
         _ = trainer.test(model, datamodule=dataset)
-
-
-if __name__ == "__main__":
-    main()

--- a/bliss/train.py
+++ b/bliss/train.py
@@ -9,7 +9,6 @@ import pytorch_lightning as pl
 from pytorch_lightning.profiler import AdvancedProfiler
 from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.callbacks import ModelCheckpoint
-import torch
 
 from bliss import sleep
 from bliss.datasets import simulated, catsim

--- a/bliss/tune.py
+++ b/bliss/tune.py
@@ -157,7 +157,3 @@ def main(cfg: DictConfig, local_mode=False):
         OmegaConf.save(
             conf, hydra.utils.to_absolute_path(cfg.tuning.best_config_save_path)
         )
-
-
-if __name__ == "__main__":
-    main()

--- a/bliss/tune.py
+++ b/bliss/tune.py
@@ -1,11 +1,10 @@
 import os
-import numpy as np
 import logging
 
+import numpy as np
 import hydra
 from omegaconf import OmegaConf
 from omegaconf import DictConfig
-
 import pytorch_lightning as pl
 
 import ray

--- a/bliss/wake.py
+++ b/bliss/wake.py
@@ -18,7 +18,7 @@ class WakeNet(pl.LightningModule):
         observed_img,
         hparams,
     ):
-        super(WakeNet, self).__init__()
+        super().__init__()
 
         self.star_encoder = star_encoder
         self.image_decoder = image_decoder

--- a/bliss/wake.py
+++ b/bliss/wake.py
@@ -99,11 +99,11 @@ class WakeNet(pl.LightningModule):
         )
         return loss
 
-    def training_step(self, batch, batch_idx):
+    def training_step(self, batch, batch_idx):  # pylint: disable=unused-argument
         loss = self.get_loss(batch)
         self.log("train_loss", loss)
         return loss
 
-    def validation_step(self, batch, batch_idx):
+    def validation_step(self, batch, batch_idx):  # pylint: disable=unused-argument
         loss = self.get_loss(batch)
         self.log("validation_loss", loss)


### PR DESCRIPTION
I made some minor changes to reduce the number of pylint warnings.

With these changes our code quality rating is 9.49 / 10. The following pylint warnings are still around:
```
+-----------------------------+------------+
|message id                   |occurrences |
+=============================+============+
|too-many-locals              |15          |
+-----------------------------+------------+
|too-many-arguments           |10          |
+-----------------------------+------------+
|import-outside-toplevel      |9           |
+-----------------------------+------------+
|fixme                        |8           |
+-----------------------------+------------+
|too-many-instance-attributes |6           |
+-----------------------------+------------+
|import-error                 |6           |
+-----------------------------+------------+
|line-too-long                |4           |
+-----------------------------+------------+
|too-many-statements          |3           |
+-----------------------------+------------+
|unused-variable              |2           |
+-----------------------------+------------+
|consider-using-enumerate     |2           |
+-----------------------------+------------+
|unused-argument              |1           |
+-----------------------------+------------+
|raise-missing-from           |1           |
+-----------------------------+------------+
|dangerous-default-value      |1           |
+-----------------------------+------------+
```