### PR TITLE
Fix poetry-core=1.0.0 in github action 

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Install Poetry
         run: |
           pip install --upgrade pip
-          pip install "poetry >=1.1.4, <2.0.0"
+          pip install "poetry-core==1.0.0"
+          pip install "poetry==1.1.4"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Fixes the poetry-core package at version 1.0.0 in Github Actions. This is due to issue 3650 on the poetry Github repo (no direct link to avoid cross referencing on Github).