### PR TITLE
Cache Poetry Folder on Github Actions

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -43,6 +43,13 @@ jobs:
       - name: Install fftw3
         run: |
           sudo apt-get install libfftw3-dev
+          
+      - name: Poetry cache
+        uses: actions/cache@v2
+        with:
+          path: |
+              ~/.julia
+          key: ${{ runner.os }}-${{ hashFiles('./poetry.lock') }}
 
       - name: Install poetry dependencies
         run: |

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           sudo apt-get install libfftw3-dev
           
-      - name: Poetry cache #test comment
+      - name: Poetry cache
         uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-              ~/.julia
+              ~/.cache/pypoetry
           key: ${{ runner.os }}-${{ hashFiles('./poetry.lock') }}
 
       - name: Install poetry dependencies

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           sudo apt-get install libfftw3-dev
           
-      - name: Poetry cache
+      - name: Poetry cache #test comment
         uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
This adds caching of the poetry cache folder, which should greatly speed up subsequent runs on Github Actions.

The cache will be regenerated every time the poetry.lock file is changed. We actually don't need to do this, but we don't want this cache folder getting too big since Github has a 5GB limit on cache sizes. 