### PR TITLE
Fix model checkpoint warning

### DIFF
--- a/tests/test_tune.py
+++ b/tests/test_tune.py
@@ -37,6 +37,7 @@ class TestTune:
         return overrides
 
     @pytest.mark.filterwarnings("ignore:.*PytestUnhandledThreadExceptionWarning.*")
+    @pytest.mark.filterwarnings("ignore:.*Relying on `self.log.*:DeprecationWarning")
     def test_tune_run(self, overrides, devices):
         with initialize(config_path="../config"):
             cfg = compose("config", overrides=overrides)


### PR DESCRIPTION
Close #238 
I think we can safely ignore this as it is triggered by Raytune callback internally and we are not using model checkpointing.