### PR TITLE
Refactor tiling

### DIFF
--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -299,11 +299,12 @@ class ImageEncoder(nn.Module):
         # misc
         self.register_buffer("swap", torch.tensor([1, 0]), persistent=False)
 
-    def make_patch(self, image):
+    def get_images_in_tiles_new(self, image):
         channels = image.shape[1]
         window = self.ptile_slen
         stride = self.tile_slen
         tiles = F.unfold(image, kernel_size=window, stride=stride)
+        # b=batch, c=channel, h=tile_height, w=tiles_width, n=num_of_tiles_for_each_batch
         tiles = rearrange(tiles, "b (c h w) n -> (b n) c h w", c=channels, h=window, w=window)
         return tiles
 
@@ -359,7 +360,7 @@ class ImageEncoder(nn.Module):
         old_implementation = output.reshape(
             n_ptiles, self.n_bands, self.ptile_slen, self.ptile_slen
         )
-        new_implementation = self.make_patch(images)
+        new_implementation = self.get_images_in_tiles_new(images)
         assert torch.allclose(old_implementation, new_implementation)
         return new_implementation
 

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -300,12 +300,10 @@ class ImageEncoder(nn.Module):
         self.register_buffer("swap", torch.tensor([1, 0]), persistent=False)
 
     def get_images_in_tiles_new(self, images):
-        channel = images.shape[1]
         window = self.ptile_slen
-        stride = self.tile_slen
-        tiles = F.unfold(images, kernel_size=window, stride=stride)
+        tiles = F.unfold(images, kernel_size=window, stride=self.tile_slen)
         # b=batch, c=channel, h=tile_height, w=tile_width, n=num_of_tiles_for_each_batch
-        tiles = rearrange(tiles, "b (c h w) n -> (b n) c h w", c=channel, h=window, w=window)
+        tiles = rearrange(tiles, "b (c h w) n -> (b n) c h w", c=self.n_bands, h=window, w=window)
         return tiles
 
     def _cache_tiling_conv_weights(self):
@@ -361,6 +359,7 @@ class ImageEncoder(nn.Module):
             n_ptiles, self.n_bands, self.ptile_slen, self.ptile_slen
         )
         new_implementation = self.get_images_in_tiles_new(images)
+        assert new_implementation.shape == old_implementation.shape
         assert torch.allclose(old_implementation, new_implementation)
         return new_implementation
 

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -250,7 +250,6 @@ class ImageEncoder(nn.Module):
         self.border_padding = int(border_padding)
 
         # cache the weights used for the tiling convolution
-        self._cache_tiling_conv_weights()
 
         self.enc_conv = EncoderCNN(n_bands, channel, spatial_dropout)
 
@@ -299,69 +298,16 @@ class ImageEncoder(nn.Module):
         # misc
         self.register_buffer("swap", torch.tensor([1, 0]), persistent=False)
 
-    def get_images_in_tiles_new(self, images):
+    def get_images_in_tiles(self, images):
+        """
+        Divide a batch of full images into padded tiles similar to nn.conv2d
+        with a sliding window=self.ptile_slen and stride=self.tile_slen
+        """
         window = self.ptile_slen
         tiles = F.unfold(images, kernel_size=window, stride=self.tile_slen)
-        # b=batch, c=channel, h=tile_height, w=tile_width, n=num_of_tiles_for_each_batch
+        # b: batch, c: channel, h: tile height, w: tile width, n: num of total tiles for each batch
         tiles = rearrange(tiles, "b (c h w) n -> (b n) c h w", c=self.n_bands, h=window, w=window)
         return tiles
-
-    def _cache_tiling_conv_weights(self):
-        # this function sets up weights for the "identity" convolution
-        # used to divide a full-image into padded tiles.
-        # (see get_images_in_tiles).
-
-        # It has a for-loop, but only needs to be set up once.
-        # These weights are set up and  cached during the __init__.
-
-        ptile_slen2 = self.ptile_slen ** 2
-        self.register_buffer(
-            "tile_conv_weights",
-            torch.zeros(
-                ptile_slen2 * self.n_bands,
-                self.n_bands,
-                self.ptile_slen,
-                self.ptile_slen,
-            ),
-            persistent=False,
-        )
-
-        for b in range(self.n_bands):
-            for i in range(ptile_slen2):
-                self.tile_conv_weights[
-                    i + b * ptile_slen2, b, i // self.ptile_slen, i % self.ptile_slen
-                ] = 1
-
-    def get_images_in_tiles(self, images):
-        # divide a full-image into padded tiles using conv2d
-        # and weights cached in `_cache_tiling_conv_weights`.
-
-        assert len(images.shape) == 4  # should be batch_size x n_bands x pslen x pslen
-        assert images.shape[1] == self.n_bands
-        batch_size = images.shape[0]
-
-        output = F.conv2d(
-            images,
-            self.tile_conv_weights,
-            stride=self.tile_slen,
-            padding=0,
-        ).permute([0, 2, 3, 1])
-
-        # shape = (n_ptiles x n_bands x ptile_slen, ptile_slen)
-        # not borded slen
-        pslen, pwlen = images.shape[-2:]
-        slen = pslen - self.border_padding * 2
-        wlen = pwlen - self.border_padding * 2
-        n_ptiles_per_image = slen * wlen / self.tile_slen ** 2
-        assert n_ptiles_per_image % 1 == 0, "n_ptiles_per_image must be an int"
-        n_ptiles = int(n_ptiles_per_image * batch_size)
-        old_implementation = output.reshape(
-            n_ptiles, self.n_bands, self.ptile_slen, self.ptile_slen
-        )
-        new_implementation = self.get_images_in_tiles_new(images)
-        assert new_implementation.shape == old_implementation.shape
-        assert torch.allclose(old_implementation, new_implementation)
-        return new_implementation
 
     def center_ptiles(self, image_ptiles, tile_locs):
         # assume there is at most one source per tile

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -299,13 +299,13 @@ class ImageEncoder(nn.Module):
         # misc
         self.register_buffer("swap", torch.tensor([1, 0]), persistent=False)
 
-    def get_images_in_tiles_new(self, image):
-        channels = image.shape[1]
+    def get_images_in_tiles_new(self, images):
+        channel = images.shape[1]
         window = self.ptile_slen
         stride = self.tile_slen
-        tiles = F.unfold(image, kernel_size=window, stride=stride)
-        # b=batch, c=channel, h=tile_height, w=tiles_width, n=num_of_tiles_for_each_batch
-        tiles = rearrange(tiles, "b (c h w) n -> (b n) c h w", c=channels, h=window, w=window)
+        tiles = F.unfold(images, kernel_size=window, stride=stride)
+        # b=batch, c=channel, h=tile_height, w=tile_width, n=num_of_tiles_for_each_batch
+        tiles = rearrange(tiles, "b (c h w) n -> (b n) c h w", c=channel, h=window, w=window)
         return tiles
 
     def _cache_tiling_conv_weights(self):

--- a/poetry.lock
+++ b/poetry.lock
@@ -373,6 +373,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "einops"
+version = "0.3.0"
+description = "A new flavour of deep learning operations"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "entrypoints"
 version = "0.3"
 description = "Discover and load entry points from installed packages."
@@ -390,11 +398,11 @@ python-versions = "*"
 
 [[package]]
 name = "fsspec"
-version = "0.8.7"
+version = "0.9.0"
 description = "File-system specification"
 category = "main"
 optional = false
-python-versions = ">3.6"
+python-versions = ">=3.6"
 
 [package.dependencies]
 aiohttp = {version = "*", optional = true, markers = "extra == \"http\""}
@@ -409,7 +417,7 @@ gcs = ["gcsfs"]
 git = ["pygit2"]
 github = ["requests"]
 gs = ["gcsfs"]
-hdfs = ["pyarrow"]
+hdfs = ["pyarrow (>=1)"]
 http = ["requests", "aiohttp"]
 s3 = ["s3fs"]
 sftp = ["paramiko"]
@@ -2211,7 +2219,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "057607131ec521d7d26614be6c9d340d88d6e585141079dcf377ed98090a0ac5"
+content-hash = "b31db20626160d3de1471a50fd8c9145b9912d8c94da7384d4e315bdaf4308ae"
 
 [metadata.files]
 absl-py = [
@@ -2536,6 +2544,10 @@ docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
+einops = [
+    {file = "einops-0.3.0-py2.py3-none-any.whl", hash = "sha256:a91c6190ceff7d513d74ca9fd701dfa6a1ffcdd98ea0ced14350197c07f75c73"},
+    {file = "einops-0.3.0.tar.gz", hash = "sha256:a3b0935a4556f012cd5fa1851373f63366890a3f6698d117afea55fd2a40c1fc"},
+]
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
     {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
@@ -2545,8 +2557,8 @@ filelock = [
     {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
 ]
 fsspec = [
-    {file = "fsspec-0.8.7-py3-none-any.whl", hash = "sha256:65dbf8244a3a3d23342109925f9f588c7551b2b01a5f47e555043b17e2b32d62"},
-    {file = "fsspec-0.8.7.tar.gz", hash = "sha256:4b11557a90ac637089b10afa4c77adf42080c0696f6f2771c41ce92d73c41432"},
+    {file = "fsspec-0.9.0-py3-none-any.whl", hash = "sha256:7e98ea66f3f0156601e126fb2799e5d0ed87c3108b519f64c834b4284509fc82"},
+    {file = "fsspec-0.9.0.tar.gz", hash = "sha256:3f7a62547e425b0b336a6ac2c2e6c6ac824648725bc8391af84bb510a63d1a56"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
@@ -3424,6 +3436,7 @@ pyzmq = [
     {file = "pyzmq-22.0.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:b62ea18c0458a65ccd5be90f276f7a5a3f26a6dea0066d948ce2fa896051420f"},
     {file = "pyzmq-22.0.3-cp38-cp38-win32.whl", hash = "sha256:81e7df0da456206201e226491aa1fc449da85328bf33bbeec2c03bb3a9f18324"},
     {file = "pyzmq-22.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:f52070871a0fd90a99130babf21f8af192304ec1e995bec2a9533efc21ea4452"},
+    {file = "pyzmq-22.0.3-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:c5e29fe4678f97ce429f076a2a049a3d0b2660ada8f2c621e5dc9939426056dd"},
     {file = "pyzmq-22.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d18ddc6741b51f3985978f2fda57ddcdae359662d7a6b395bc8ff2292fca14bd"},
     {file = "pyzmq-22.0.3-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4231943514812dfb74f44eadcf85e8dd8cf302b4d0bce450ce1357cac88dbfdc"},
     {file = "pyzmq-22.0.3-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:23a74de4b43c05c3044aeba0d1f3970def8f916151a712a3ac1e5cd9c0bc2902"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ python = "^3.8"
 pytorch-lightning = "^1.0.8"
 scipy = "^1.4.1"
 torch = "1.7.1"
+einops = "^0.3.0"
 
 [tool.poetry.dev-dependencies]
 Cython = "^0.29.21"


### PR DESCRIPTION
This PR refactors our tiling mechanism in `encoder.py`

The previous implementation uses an "identity" conv2d to make tiles, which requires ~50 lines of code and need to store a sparse weight matrix.
This new implementation uses 5 lines of code and might be more readable.

PS:
- We don't have to use `einops.rearrange` but I think it's more readable. I can change it to use the more standard chains of reshape and permute if you think `einops` is unnecessary.
- I haven't removed the old implementation so that I can assert that I don't accidentally change anything. If this looks good, I can remove the old ones and merge.