### PR TITLE
Refactoring with Einops

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -40,6 +40,7 @@ disable=too-many-ancestors,
 	too-many-arguments,
 	too-many-locals,
 	too-many-instance-attributes,
+	too-many-statements,
 
 	# we should remove fixme comments
 	fixme,
@@ -57,4 +58,3 @@ disable=too-many-ancestors,
 
 # Minimum lines number of a similarity to report duplicate-code
 min-similarity-lines=11
-

--- a/.pylintrc
+++ b/.pylintrc
@@ -40,7 +40,6 @@ disable=too-many-ancestors,
 	too-many-arguments,
 	too-many-locals,
 	too-many-instance-attributes,
-	too-many-statements,
 
 	# we should remove fixme comments
 	fixme,

--- a/bliss/datasets/sdss.py
+++ b/bliss/datasets/sdss.py
@@ -6,6 +6,7 @@ from math import floor, ceil
 import numpy as np
 import torch
 import torch.nn.functional as F
+from einops import rearrange
 from scipy.interpolate import RegularGridInterpolator
 from torch.utils.data import Dataset
 from astropy.io import fits
@@ -68,7 +69,9 @@ class StarStamper:
         G_x = torch.stack([torch.from_numpy(grid_x)] * self.stampsize, dim=0)
         G_y = torch.stack([torch.from_numpy(grid_y)] * self.stampsize, dim=1)
 
-        G = torch.stack([G_x, G_y], dim=2).unsqueeze(0)
+        G_old = torch.stack([G_x, G_y], dim=2).unsqueeze(0)
+        G = rearrange([G_x, G_y], "n x y -> 1 x y n")
+        assert torch.allclose(G_old, G)
 
         return G.type(self.grid_dtype)
 
@@ -327,7 +330,9 @@ class SloanDigitalSkySurvey(Dataset):
 
             sky_y = sky_y.clip(0, sky_small.shape[0] - 1)
             sky_x = sky_x.clip(0, sky_small.shape[1] - 1)
-            large_points = np.stack(np.meshgrid(sky_y, sky_x)).transpose()
+            large_points_old = np.stack(np.meshgrid(sky_y, sky_x)).transpose()
+            large_points = rearrange(np.meshgrid(sky_y, sky_x), "n x y -> y x n")
+            assert np.allclose(large_points, large_points_old)
             large_sky = sky_interp(large_points)
             large_sky_nelec = large_sky * gain[b]
 

--- a/bliss/datasets/sdss.py
+++ b/bliss/datasets/sdss.py
@@ -69,9 +69,7 @@ class StarStamper:
         G_x = torch.stack([torch.from_numpy(grid_x)] * self.stampsize, dim=0)
         G_y = torch.stack([torch.from_numpy(grid_y)] * self.stampsize, dim=1)
 
-        G_old = torch.stack([G_x, G_y], dim=2).unsqueeze(0)
         G = rearrange([G_x, G_y], "n x y -> 1 x y n")
-        assert torch.allclose(G_old, G)
 
         return G.type(self.grid_dtype)
 

--- a/bliss/datasets/sdss.py
+++ b/bliss/datasets/sdss.py
@@ -328,9 +328,7 @@ class SloanDigitalSkySurvey(Dataset):
 
             sky_y = sky_y.clip(0, sky_small.shape[0] - 1)
             sky_x = sky_x.clip(0, sky_small.shape[1] - 1)
-            large_points_old = np.stack(np.meshgrid(sky_y, sky_x)).transpose()
             large_points = rearrange(np.meshgrid(sky_y, sky_x), "n x y -> y x n")
-            assert np.allclose(large_points, large_points_old)
             large_sky = sky_interp(large_points)
             large_sky_nelec = large_sky * gain[b]
 

--- a/bliss/metrics.py
+++ b/bliss/metrics.py
@@ -25,11 +25,8 @@ def inner_join_locs(locs1, locs2):
     # mse of locs:
     # entry (i,j) is l1 distance between of ith loc in locs1
     # and to jth loc in locs2
-    locs_err_old = (locs1.view(-1, 1, 2) - locs2.view(1, -1, 2)).abs().sum(2)
     locs_err = (rearrange(locs1, "i j -> i 1 j") - rearrange(locs2, "i j -> 1 i j")).abs()
     locs_err = reduce(locs_err, "i j k -> i j", "sum")
-
-    assert torch.allclose(locs_err, locs_err_old)
 
     # find minimal permutation
     row_indx, col_indx = sp_optim.linear_sum_assignment(locs_err.detach().cpu())
@@ -112,13 +109,9 @@ def eval_error_on_batch(true_params, est_params, slen):
     count_bool = true_params["n_sources"].eq(est_params["n_sources"])
 
     # accuracy of galaxy counts
-    est_n_gal_old = est_params["galaxy_bool"].view(batch_size, -1).sum(-1)
     est_n_gal = reduce(est_params["galaxy_bool"], "b n 1 -> b", "sum")
-    assert torch.allclose(est_n_gal, est_n_gal_old)
 
-    true_n_gal_old = true_params["galaxy_bool"].view(batch_size, -1).sum(-1)
     true_n_gal = reduce(true_params["galaxy_bool"], "b n 1 -> b", "sum")
-    assert torch.allclose(true_n_gal, true_n_gal_old)
 
     galaxy_counts_bool = est_n_gal.eq(true_n_gal)
 

--- a/bliss/models/decoder.py
+++ b/bliss/models/decoder.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributions import Poisson
 import pytorch_lightning as pl
+from einops import rearrange, reduce
 
 from .encoder import get_is_on_from_n_sources, get_mgrid
 from . import galaxy_net
@@ -212,7 +213,9 @@ class ImageDecoder(pl.LightningModule):
 
         # long() here is necessary because used for indexing and one_hot encoding.
         n_sources = n_sources.clamp(max=self.max_sources, min=self.min_sources)
-        n_sources = n_sources.long().view(batch_size, self.n_tiles_per_image)
+        n_sources_old = n_sources.long().view(batch_size, self.n_tiles_per_image)
+        n_sources = rearrange(n_sources.long(), "b n 1 -> b n")
+        assert torch.allclose(n_sources, n_sources_old)
         return n_sources
 
     def _sample_locs(self, is_on_array, batch_size):
@@ -308,7 +311,15 @@ class ImageDecoder(pl.LightningModule):
 
         # first get random subset of indices to extract from self.latents
         indices = torch.randint(0, len(self.latents), (total_latent,), device=galaxy_bool.device)
-        galaxy_params = self.latents[indices].reshape(shape)
+        galaxy_params_old = self.latents[indices].reshape(shape)
+        galaxy_params = rearrange(
+            self.latents[indices],
+            "(b n s) g -> b n s g",
+            n=self.n_tiles_per_image,
+            s=self.max_sources,
+            g=self.n_galaxy_params,
+        )
+        assert torch.allclose(galaxy_params, galaxy_params_old)
         return galaxy_params * galaxy_bool
 
     @staticmethod
@@ -342,6 +353,8 @@ class ImageDecoder(pl.LightningModule):
 
         # returns the ptiles with shape =
         # (batch_size x n_tiles_per_image x n_bands x ptile_slen x ptile_slen)
+
+        # b: batch, n: n_tiles_per_image, s: max_sources
         n_tiles_per_image = n_sources.shape[1]
         max_sources = locs.shape[2]
         assert (n_sources <= max_sources).all()
@@ -349,16 +362,31 @@ class ImageDecoder(pl.LightningModule):
         n_ptiles = batch_size * n_tiles_per_image
 
         # view parameters being explicit about shapes
-        _n_sources = n_sources.view(n_ptiles)
-        _locs = locs.view(n_ptiles, max_sources, 2)
-        _galaxy_bool = galaxy_bool.view(n_ptiles, max_sources, 1)
-        _fluxes = fluxes.view(n_ptiles, max_sources, self.n_bands)
+        _n_sources_old = n_sources.view(n_ptiles)
+        _n_sources = rearrange(n_sources, "b t -> (b t)")
+        assert torch.allclose(_n_sources, _n_sources_old)
+
+        _locs_old = locs.view(n_ptiles, max_sources, 2)
+        _locs = rearrange(locs, "b t s xy -> (b t) s xy", xy=2)
+        assert torch.allclose(_locs, _locs_old)
+
+        _galaxy_bool_old = galaxy_bool.view(n_ptiles, max_sources, 1)
+        _galaxy_bool = rearrange(galaxy_bool, "b t s 1 -> (b t) s 1")
+        assert torch.allclose(_galaxy_bool, _galaxy_bool_old)
+
+        _fluxes_old = fluxes.view(n_ptiles, max_sources, self.n_bands)
+        _fluxes = rearrange(fluxes, "b t s band -> (b t) s band")
+        assert torch.allclose(_fluxes, _fluxes_old)
 
         # draw stars and galaxies
         _is_on_array = get_is_on_from_n_sources(_n_sources, max_sources)
-        _is_on_array = _is_on_array.view(n_ptiles, max_sources, 1)
+        _is_on_array_old = _is_on_array.view(n_ptiles, max_sources, 1)
+        _is_on_array = rearrange(_is_on_array, "bt s -> bt s 1")
+        assert torch.allclose(_is_on_array, _is_on_array_old)
+
         _star_bool = (1 - _galaxy_bool) * _is_on_array
-        _star_bool = _star_bool.view(n_ptiles, max_sources, 1)
+        # _star_bool = _star_bool.view(n_ptiles, max_sources, 1)
+        assert _star_bool.shape == (n_ptiles, max_sources, 1)
 
         # final shapes of images.
         img_shape = (
@@ -466,6 +494,13 @@ class ImageDecoder(pl.LightningModule):
 
                 image_tile_rows = image_tiles_4d[:, indx_vec1]
                 image_tile_cols = image_tile_rows[:, :, indx_vec2]
+                image_tile_cols_old = image_tile_cols.permute(0, 3, 1, 4, 2, 5).reshape(
+                    batch_size, n_bands, canvas_len, canvas_len
+                )
+                image_tile_cols = rearrange(
+                    image_tile_cols, "b x1 y1 band x2 y2 -> b band (x1 x2) (y1 y2)"
+                )
+                assert torch.allclose(image_tile_cols, image_tile_cols_old)
 
                 # get canvas
                 canvas[
@@ -473,9 +508,7 @@ class ImageDecoder(pl.LightningModule):
                     :,
                     (i * tile_slen) : (i * tile_slen + canvas_len),
                     (j * tile_slen) : (j * tile_slen + canvas_len),
-                ] += image_tile_cols.permute(0, 3, 1, 4, 2, 5).reshape(
-                    batch_size, n_bands, canvas_len, canvas_len
-                )
+                ] += image_tile_cols
 
         # trim to original image size
         x0 = n_tiles_of_padding * tile_slen - border_padding
@@ -521,11 +554,16 @@ class Tiler(nn.Module):
         locs = locs * (self.tile_slen / self.ptile_slen) + (padding / self.ptile_slen)
         # scale locs so they take values between -1 and 1 for grid sample
         locs = (locs - 0.5) * 2
-        _grid = self.cached_grid.view(1, self.ptile_slen, self.ptile_slen, 2)
+        _grid_old = self.cached_grid.view(1, self.ptile_slen, self.ptile_slen, 2)
+        _grid = rearrange(self.cached_grid, "s1 s2 xy -> 1 s1 s2 xy")
+        assert torch.allclose(_grid, _grid_old)
 
         locs_swapped = locs.index_select(1, self.swap)
-        grid_loc = _grid - locs_swapped.view(n_ptiles, 1, 1, 2)
+        locs_swapped_old = locs_swapped.view(n_ptiles, 1, 1, 2)
+        locs_swapped = rearrange(locs_swapped, "np xy -> np 1 1 xy")
+        assert torch.allclose(locs_swapped_old, locs_swapped)
 
+        grid_loc = _grid - locs_swapped
         source_rendered = F.grid_sample(source, grid_loc, align_corners=True)
         return source_rendered
 
@@ -655,16 +693,29 @@ class StarTileDecoder(nn.Module):
 
         # all stars are just the PSF so we copy it.
         expanded_psf = psf.expand(n_ptiles, max_sources, self.n_bands, -1, -1)
-        sources = expanded_psf * fluxes.unsqueeze(-1).unsqueeze(-1)
-        sources *= star_bool.unsqueeze(-1).unsqueeze(-1)
+
+        sources_old = expanded_psf * fluxes.unsqueeze(-1).unsqueeze(-1)
+        sources_old *= star_bool.unsqueeze(-1).unsqueeze(-1)
+
+        sources = expanded_psf * rearrange(fluxes, "np ms nb -> np ms nb 1 1")
+        sources *= rearrange(star_bool, "np ms 1 -> np ms 1 1 1")
+        assert torch.allclose(sources, sources_old)
 
         return self.tiler.render_tile(locs, sources)
 
     def psf_forward(self):
         psf = self._get_psf()
-        init_psf_sum = psf.sum(-1).sum(-1).detach()
-        norm = psf.sum(-1).sum(-1)
-        psf *= (init_psf_sum / norm).unsqueeze(-1).unsqueeze(-1)
+        init_psf_sum_old = psf.sum(-1).sum(-1).detach()
+        init_psf_sum = reduce(psf, "n m k -> n", "sum").detach()
+        assert torch.allclose(init_psf_sum, init_psf_sum_old)
+
+        norm_old = psf.sum(-1).sum(-1)
+        norm = reduce(psf, "n m k -> n", "sum")
+        assert torch.allclose(norm_old, norm)
+
+        psf_old = psf * (init_psf_sum / norm).unsqueeze(-1).unsqueeze(-1)
+        psf *= rearrange(init_psf_sum / norm, "n -> n 1 1")
+        assert torch.allclose(psf, psf_old)
         return psf
 
     @staticmethod

--- a/bliss/models/decoder.py
+++ b/bliss/models/decoder.py
@@ -360,7 +360,6 @@ class ImageDecoder(pl.LightningModule):
         # draw stars and galaxies
         _is_on_array = get_is_on_from_n_sources(_n_sources, max_sources)
         _is_on_array = rearrange(_is_on_array, "bt s -> bt s 1")
-
         _star_bool = (1 - _galaxy_bool) * _is_on_array
         # _star_bool = _star_bool.view(n_ptiles, max_sources, 1)
         assert _star_bool.shape == (n_ptiles, max_sources, 1)

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -112,12 +112,10 @@ def get_full_params(tile_params: dict, slen: int, wlen: int = None):
             # make sure works galaxy bool has same format as well.
             tile_param = tile_params[param_name]
             assert len(tile_param.shape) == 4
-
             param = rearrange(tile_param, "b t d k -> b (t d) k")
             param = torch.gather(
                 param, 1, repeat(_indx_sort, "b n -> b n r", r=tile_param.shape[-1])
             )
-
             param = param[:, 0:max_sources, ...]
             params[param_name] = param
     return params
@@ -388,8 +386,6 @@ class ImageEncoder(nn.Module):
         assert h.size(0) == n_sources.size(1)
         assert h.size(1) == self.dim_out_all
         n_ptiles = h.size(0)
-
-        # append null column, return zero if indx_mat returns null index (dim_out_all)
         _h = torch.cat((h, torch.zeros(n_ptiles, 1, device=h.device)), dim=1)
 
         # select the indices from _h indicated by indx_mat.
@@ -403,7 +399,7 @@ class ImageEncoder(nn.Module):
         var_param = rearrange(
             var_param,
             "np (ns d pd) -> ns np d pd",
-            np=h.size(0),
+            np=n_ptiles,
             ns=n_sources.size(0),
             d=self.max_detections,
             pd=param_dim,

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -612,7 +612,7 @@ class ImageEncoder(nn.Module):
 
         # MAP (for n_sources) prediction on var params on each tile
         tile_n_sources = self.tile_map_n_sources(image_ptiles)
-        pred = self.forward(image_ptiles, tile_n_sources)
+        pred = self(image_ptiles, tile_n_sources)
 
         return self.tile_map_estimate_from_var_params(pred, n_tiles_per_image, batch_size)
 

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -1,5 +1,6 @@
 import torch
 from omegaconf import DictConfig
+from einops import rearrange
 
 from bliss.datasets import sdss
 from bliss import sleep
@@ -23,7 +24,9 @@ def predict(cfg: DictConfig):
     # image for prediction from SDSS
     image = sdss_obj[0]["image"][bands[0]]
     h, w = image.shape
-    image = torch.from_numpy(image.reshape(1, 1, h, w))
+    image_old = torch.from_numpy(image.reshape(1, 1, h, w))
+    image = rearrange(torch.from_numpy(image), "h w -> 1 1 h w")
+    assert torch.allclose(image_old, image)
 
     # move everything to specified GPU
     sleep_net.to(cfg.predict.device)

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -24,9 +24,7 @@ def predict(cfg: DictConfig):
     # image for prediction from SDSS
     image = sdss_obj[0]["image"][bands[0]]
     h, w = image.shape
-    image_old = torch.from_numpy(image.reshape(1, 1, h, w))
     image = rearrange(torch.from_numpy(image), "h w -> 1 1 h w")
-    assert torch.allclose(image_old, image)
 
     # move everything to specified GPU
     sleep_net.to(cfg.predict.device)

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -214,6 +214,7 @@ class SleepPhase(pl.LightningModule):
         if self.use_galaxy_encoder:
             batch_size = images.shape[0]
             max_detections = 1
+            # NOTE: tile_est["locs"].shape = (2, 100, 1, 2)
             tile_locs = tile_est["locs"].reshape(-1, max_detections, 2)
             image_ptiles = self.image_encoder.get_images_in_tiles(images)
             tile_galaxy_params = self.forward_galaxy(image_ptiles, tile_locs)
@@ -224,6 +225,7 @@ class SleepPhase(pl.LightningModule):
                 max_detections,
                 n_galaxy_params,
             )
+            # NOTE: tile_est["locs"].shape = (2, 100, 1, 8)
             tile_est["galaxy_params"] = tile_galaxy_params
 
         return tile_est
@@ -265,7 +267,10 @@ class SleepPhase(pl.LightningModule):
         )
 
         recon_losses = -Normal(recon_mean, recon_var.sqrt()).log_prob(images)
-        recon_losses = recon_losses.view(batch_size, -1).sum()
+        recon_losses_old = recon_losses.view(batch_size, -1).sum()
+        # NOTE: why do we need .view here
+        recon_losses = recon_losses.sum()
+        assert torch.allclose(recon_losses_old, recon_losses)
 
         return recon_losses
 

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -338,19 +338,19 @@ class SleepPhase(pl.LightningModule):
         # b: batch, s: n_tiles_per_image
         true_tile_locs_old = true_tile_locs.view(n_ptiles, max_sources, 2)
         true_tile_locs = rearrange(true_tile_locs, "b n s xy -> (b n) s xy", xy=2)
-        torch.allclose(true_tile_locs, true_tile_locs_old)
+        assert torch.allclose(true_tile_locs, true_tile_locs_old)
 
         true_tile_log_fluxes_old = true_tile_log_fluxes.view(n_ptiles, max_sources, n_bands)
         true_tile_log_fluxes = rearrange(true_tile_log_fluxes, "b n s bands -> (b n) s bands")
-        torch.allclose(true_tile_log_fluxes, true_tile_log_fluxes_old)
+        assert torch.allclose(true_tile_log_fluxes, true_tile_log_fluxes_old)
 
         true_tile_galaxy_bool_old = true_tile_galaxy_bool.view(n_ptiles, max_sources)
         true_tile_galaxy_bool = rearrange(true_tile_galaxy_bool, "b n s 1 -> (b n) s")
-        torch.allclose(true_tile_galaxy_bool, true_tile_galaxy_bool_old)
+        assert torch.allclose(true_tile_galaxy_bool, true_tile_galaxy_bool_old)
 
         true_tile_n_sources_old = true_tile_n_sources.view(n_ptiles)
         true_tile_n_sources = rearrange(true_tile_n_sources, "b n -> (b n)")
-        torch.allclose(true_tile_n_sources, true_tile_n_sources_old)
+        assert torch.allclose(true_tile_n_sources, true_tile_n_sources_old)
 
         true_tile_is_on_array = encoder.get_is_on_from_n_sources(true_tile_n_sources, max_sources)
 
@@ -377,7 +377,7 @@ class SleepPhase(pl.LightningModule):
         )
         prob_galaxy_old = pred["prob_galaxy"].view(n_ptiles, max_sources)
         prob_galaxy = rearrange(pred["prob_galaxy"], "bn s 1 -> bn s")
-        torch.allclose(prob_galaxy, prob_galaxy_old)
+        assert torch.allclose(prob_galaxy, prob_galaxy_old)
 
         # inside _get_min_perm_loss is where the matching happens:
         # we construct a bijective map from each estimated source to each true source

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -223,7 +223,6 @@ class SleepPhase(pl.LightningModule):
             tile_galaxy_params = rearrange(
                 tile_galaxy_params, "(b n d) p -> b n d p", b=batch_size, d=max_detections
             )
-
             tile_est["galaxy_params"] = tile_galaxy_params
 
         return tile_est
@@ -324,13 +323,9 @@ class SleepPhase(pl.LightningModule):
         # flatten so first dimension is ptile
         # b: batch, s: n_tiles_per_image
         true_tile_locs = rearrange(true_tile_locs, "b n s xy -> (b n) s xy", xy=2)
-
         true_tile_log_fluxes = rearrange(true_tile_log_fluxes, "b n s bands -> (b n) s bands")
-
         true_tile_galaxy_bool = rearrange(true_tile_galaxy_bool, "b n s 1 -> (b n) s")
-
         true_tile_n_sources = rearrange(true_tile_n_sources, "b n -> (b n)")
-
         true_tile_is_on_array = encoder.get_is_on_from_n_sources(true_tile_n_sources, max_sources)
 
         # extract image tiles

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -16,6 +16,7 @@ import pytorch_lightning as pl
 import torch
 from torch.nn import CrossEntropyLoss
 from torch.distributions import Normal
+from einops import rearrange
 
 from bliss import plotting
 from bliss.optimizer import get_optimizer
@@ -322,10 +323,23 @@ class SleepPhase(pl.LightningModule):
         true_tile_n_sources = true_tile_n_sources.clamp(max=max_sources)
 
         # flatten so first dimension is ptile
-        true_tile_locs = true_tile_locs.view(n_ptiles, max_sources, 2)
-        true_tile_log_fluxes = true_tile_log_fluxes.view(n_ptiles, max_sources, n_bands)
-        true_tile_galaxy_bool = true_tile_galaxy_bool.view(n_ptiles, max_sources)
-        true_tile_n_sources = true_tile_n_sources.view(n_ptiles)
+        # b: batch, s: n_tiles_per_image
+        true_tile_locs_old = true_tile_locs.view(n_ptiles, max_sources, 2)
+        true_tile_locs = rearrange(true_tile_locs, "b n s xy -> (b n) s xy", xy=2)
+        torch.allclose(true_tile_locs, true_tile_locs_old)
+
+        true_tile_log_fluxes_old = true_tile_log_fluxes.view(n_ptiles, max_sources, n_bands)
+        true_tile_log_fluxes = rearrange(true_tile_log_fluxes, "b n s bands -> (b n) s bands")
+        torch.allclose(true_tile_log_fluxes, true_tile_log_fluxes_old)
+
+        true_tile_galaxy_bool_old = true_tile_galaxy_bool.view(n_ptiles, max_sources)
+        true_tile_galaxy_bool = rearrange(true_tile_galaxy_bool, "b n s 1 -> (b n) s")
+        torch.allclose(true_tile_galaxy_bool, true_tile_galaxy_bool_old)
+
+        true_tile_n_sources_old = true_tile_n_sources.view(n_ptiles)
+        true_tile_n_sources = rearrange(true_tile_n_sources, "b n -> (b n)")
+        torch.allclose(true_tile_n_sources, true_tile_n_sources_old)
+
         true_tile_is_on_array = encoder.get_is_on_from_n_sources(true_tile_n_sources, max_sources)
 
         # extract image tiles
@@ -349,7 +363,9 @@ class SleepPhase(pl.LightningModule):
         star_params_log_probs_all = _get_params_logprob_all_combs(
             true_tile_log_fluxes, pred["log_flux_mean"], pred["log_flux_logvar"]
         )
-        prob_galaxy = pred["prob_galaxy"].view(n_ptiles, max_sources)
+        prob_galaxy_old = pred["prob_galaxy"].view(n_ptiles, max_sources)
+        prob_galaxy = rearrange(pred["prob_galaxy"], "bn s 1 -> bn s")
+        torch.allclose(prob_galaxy, prob_galaxy_old)
 
         # inside _get_min_perm_loss is where the matching happens:
         # we construct a bijective map from each estimated source to each true source

--- a/bliss/wake.py
+++ b/bliss/wake.py
@@ -85,7 +85,7 @@ class WakeNet(pl.LightningModule):
 
     def get_loss(self, batch):
         img = batch.unsqueeze(0)
-        recon_mean = self.forward(img)
+        recon_mean = self(img)
         error = -Normal(recon_mean, recon_mean.sqrt()).log_prob(img)
 
         image_indx_start = self.border_padding

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,7 +15,7 @@ general:
   overwrite: False
 
 gpus:
-  - 4
+  - 0
 
 paths:
   root: ${env:BLISS_HOME}

--- a/tests/test_tune.py
+++ b/tests/test_tune.py
@@ -19,7 +19,7 @@ class TestTune:
         overrides = {
             "model": "m2",
             "dataset": "m2" if devices.use_cuda else "cpu",
-            "dataset.kwargs.n_batches": 2 if devices.use_cuda else 10,
+            "dataset.kwargs.n_batches": 10 if devices.use_cuda else 2,
             "training": "m2" if devices.use_cuda else "cpu",
             "optimizer": "m2",
             "tuning.n_epochs": 2 if devices.use_cuda else 1,


### PR DESCRIPTION
close #249
close #248 

This PR refactors `.view`, `.reshape`, `.squeeze`, `.sum`,  `.repeat` to `einops` counterparts except when:
- shapes were inferred somewhere else and it's already clear what each dimension represents. [example](https://github.com/prob-ml/bliss/blob/64d9f1138949ec8061ac7daf85d2f16c0a0d3faa/bliss/models/decoder.py#L392-L408)
- squeeze or unsqueeze for broadcasting. [example](https://github.com/prob-ml/bliss/blob/64d9f1138949ec8061ac7daf85d2f16c0a0d3faa/bliss/models/decoder.py#L184-L185) [example](https://github.com/prob-ml/bliss/blob/64d9f1138949ec8061ac7daf85d2f16c0a0d3faa/bliss/models/decoder.py#L234)

I disabled the "too many statements" pylint check so that I can make line-by-line assertions making sure I don't change anything. I'll remove the old implementation and enable the "too many statements" back altogether at the end.

UPDATE:
@jeff-regier @ismael-mendoza There are a few questions I left in in-line comments that I need some help with. 
Also, I didn't touch `/case_studies/starnet/plotting.py` because I'm not sure if it's still maintained. Please let me know what you think. Thank you very much.