### PR TITLE
only need to crop = tile_slen not 2*tile_slen

### DIFF
--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -320,7 +320,7 @@ class ImageEncoder(nn.Module):
         assert tile_locs.shape[1] == 1
         assert image_ptiles.shape[-1] == self.ptile_slen
         n_ptiles = image_ptiles.shape[0]
-        crop_slen = 2 * self.tile_slen
+        crop_slen = self.tile_slen
         ptile_slen = self.ptile_slen
         assert tile_locs.shape[0] == n_ptiles
 

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -173,11 +173,11 @@ class SleepPhase(pl.LightningModule):
         if self.use_galaxy_encoder:
             assert galaxy_encoder_kwargs is not None, "Galaxy Encoder kwargs not provided."
             # NOTE: We crop and center each padded tile before passing it on to the galaxy_encoder
-            #       assume that crop_slen = 2*tile_slen (on each side)
+            #       assume that crop_slen = tile_slen (on each side)
             # TODO: for now only, 1 galaxy per tile is supported. Even though multiple stars per
             #       tile should work but there is no easy way to enforce this.
             self.galaxy_encoder = galaxy_net.CenteredGalaxyEncoder(**galaxy_encoder_kwargs)
-            self.cropped_slen = self.image_encoder.ptile_slen - 4 * self.image_encoder.tile_slen
+            self.cropped_slen = self.image_encoder.ptile_slen - 2 * self.image_encoder.tile_slen
             assert self.cropped_slen >= 20, "Cropped slen not reasonable"
             assert self.galaxy_encoder.slen == self.cropped_slen
             assert self.galaxy_encoder.latent_dim == self.image_decoder.n_galaxy_params

--- a/config/model/1galaxy_measure.yaml
+++ b/config/model/1galaxy_measure.yaml
@@ -31,7 +31,7 @@ kwargs:
     max_detections: ${model.kwargs.decoder_kwargs.max_sources}
   galaxy_encoder_kwargs:
     latent_dim: ${model.galaxy.latent_dim}
-    slen: 36
+    slen: 44
     n_bands: 1
     hidden: 256
   use_galaxy_encoder: True

--- a/config/model/sleep_sdss_measure_simple.yaml
+++ b/config/model/sleep_sdss_measure_simple.yaml
@@ -40,7 +40,7 @@ kwargs:
     hidden: 128
   galaxy_encoder_kwargs:
     latent_dim: ${model.galaxy.latent_dim}
-    slen: 36
+    slen: 44
     n_bands: 1
     hidden: 256
   use_galaxy_encoder: True


### PR DESCRIPTION
I realized that we only need to crop `tile_slen` instead of `2*tile_slen` in the `encoder.center_ptiles` function. 

Recall that in each padded tile which contains exactly one galaxy, we center the padded tile on that galaxy using the `grid_sample` function to train the galaxy encoder in the sleep phase. We decided to crop this "centered padded tile" in order to avoid sharp boundaries with 0s after the `grid_sample`. I thought that I needed to crop `2*tile_slen` on each side of this padded tile to avoid the sharp boundaries, but I realized I only need to crop half! The reason is that if a galaxy is at the border of a tile, the maximum distance it can be from the center of tile is `sqrt(2)/ 2 * tile_slen` which means that `grid_sample` only shifts the image by at most this quantity and `sqrt(2)/ 2 < 1`  :)

This change will throw away less information from going to the padded tiles -> centered padded tiles. This could potentially improve improve the galaxy encoder performance since more information will be available to it. (I still need to test)

Does this make sense @jeff-regier and @Runjing-Liu120 ? If not, we can discuss in the next meeting too. Also, please let me know if I'm misunderstanding grid_sample? 
