### PR TITLE
Add custom loggiing to all loggers

### DIFF
--- a/bliss/train.py
+++ b/bliss/train.py
@@ -7,6 +7,8 @@ from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.profiler import AdvancedProfiler
 
+from bliss.utils import log_hyperparameters
+
 
 def setup_seed(cfg):
     if cfg.training.trainer.deterministic:
@@ -72,6 +74,9 @@ def train(cfg: DictConfig):
     trainer = instantiate(
         cfg.training.trainer, logger=logger, profiler=profiler, callbacks=callbacks
     )
+
+    if logger:
+        log_hyperparameters(config=cfg, model=model, trainer=trainer)
 
     # train!
     trainer.fit(model, datamodule=dataset)

--- a/bliss/utils.py
+++ b/bliss/utils.py
@@ -24,9 +24,6 @@ def log_hyperparameters(config, model, trainer) -> None:
     hparams["dataset"] = config["dataset"]
     hparams["optimizer"] = config["optimizer"]
 
-    if hparams["mode"] == "tune":
-        hparams["tunning"] = config["tuning"]
-
     # save number of model parameters
     hparams["model/params_total"] = sum(p.numel() for p in model.parameters())
     hparams["model/params_trainable"] = sum(

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,14 +1,19 @@
+import shutil
+
 from hydra import compose, initialize
 
 from bliss import train
 
 
-def test_train_run():
+def test_train_run(paths):
     overrides = {
         "training": "cpu",
+        "training.experiment": "unittest",
+        "training.trainer.logger": True,
         "dataset": "cpu",
     }
     overrides = [f"{k}={v}" for k, v in overrides.items()]
     with initialize(config_path="../config"):
         cfg = compose("config", overrides=overrides)
         train.train(cfg)
+    shutil.rmtree(f'{paths["output"]}/unittest')


### PR DESCRIPTION
This PR adds the ability to log custom information to all the loggers in `pl.trainer`. Currently, it logs `mode`, `gpus`, `training`, `model`, `dataset` and `optimizer` from `Hydra` config and the number of parameters in the model using `Tensorboard` in the file `hparams.yaml`.


---
Example `hparams.yaml` logged by Tensorboard from running `bliss mode=train`
- Master branch
```yaml
encoder:
  n_bands: 1
  tile_slen: 2
  ptile_slen: 6
  max_detections: 1
  channel: 17
  spatial_dropout: 0.11399
  dropout: 0.013123
  hidden: 185
decoder:
  n_bands: 1
  slen: 30
  tile_slen: 2
  ptile_slen: 6
  prob_galaxy: 0.0
  max_sources: 1
  mean_sources: 0.015
  min_sources: 0
  f_min: 100000.0
  f_max: 1000000.0
  psf_params_file: data/sdss/94/1/12/psField-000094-1-0012.fits
  background_values:
  - 865.0
annotate_probs: false
optimizer_params:
  name: Adam
  kwargs:
    lr: 0.001
    weight_decay: 
```
- This PR
```yaml
mode: train
gpus: 1
training:
  n_epochs: 121
  experiment: default
  version: null
  save_top_k: 1
  trainer:
    _target_: pytorch_lightning.Trainer
    logger: true
    checkpoint_callback: false
    profiler: null
    reload_dataloaders_every_epoch: false
    max_epochs: 121
    min_epochs: 121
    gpus: 1
    limit_train_batches: 1.0
    limit_val_batches: 1.0
    check_val_every_n_epoch: 10
    log_every_n_steps: 10
    deterministic: false
model:
  decoder:
    n_bands: 1
    slen: 30
    tile_slen: 2
    ptile_slen: 6
    prob_galaxy: 0.0
    max_sources: 1
    mean_sources: 0.015
    min_sources: 0
    f_min: 100000.0
    f_max: 1000000.0
    psf_params_file: data/sdss/94/1/12/psField-000094-1-0012.fits
    background_values:
    - 865.0
  encoder:
    n_bands: 1
    tile_slen: 2
    ptile_slen: 6
    max_detections: 1
    channel: 17
    spatial_dropout: 0.11399
    dropout: 0.013123
    hidden: 185
  _target_: bliss.sleep.SleepPhase
  optimizer_params:
    name: Adam
    kwargs:
      lr: 0.001
      weight_decay: 0
  annotate_probs: false
dataset:
  _target_: bliss.datasets.simulated.SimulatedDataset
  decoder:
    n_bands: 1
    slen: 30
    tile_slen: 2
    ptile_slen: 6
    prob_galaxy: 0.0
    max_sources: 1
    mean_sources: 0.015
    min_sources: 0
    f_min: 100000.0
    f_max: 1000000.0
    psf_params_file: data/sdss/94/1/12/psField-000094-1-0012.fits
    background_values:
    - 865.0
  n_batches: 10
  batch_size: 32
  generate_device: cuda:0
  testing_file: null
optimizer:
  name: Adam
  kwargs:
    lr: 0.001
    weight_decay: 0
model/params_total: 394593
model/params_trainable: 394587
model/params_not_trainable: 
```

