### PR TITLE
Use project root as the fixed working dir

### DIFF
--- a/bliss/main.py
+++ b/bliss/main.py
@@ -1,7 +1,10 @@
 import hydra
 
+from bliss.utils import fixed_workdir
+
 
 @hydra.main(config_path="../config", config_name="config")
+@fixed_workdir
 def main(cfg):
     if cfg.mode == "train":
         from bliss.train import train as task

--- a/bliss/utils.py
+++ b/bliss/utils.py
@@ -1,8 +1,18 @@
+import os
+
 import torch
 from pytorch_lightning.utilities import rank_zero_only
 from torch import nn
 from torch.distributions import Normal
 from torch.nn import functional as F
+
+
+def fixed_workdir(fn):
+    def wrapper(cfg):
+        os.chdir(cfg.paths.root)
+        return fn(cfg)
+
+    return wrapper
 
 
 def empty(*args, **kwargs):


### PR DESCRIPTION
close #330

The previously proposed approach was to manually convert relative paths to absolute paths, which is implemented in this [branch](https://github.com/prob-ml/bliss/tree/zp/run-bliss-from-non-root). However, this approach seems to be not very straightforward as it would still log the absolute path specific to the training machine in hyperparameters, unless we implemented our own `save_hyperparemters` that convert absolute paths back to the path relative to the project root.

The approach in this PR feels hacky but also clean at the same time. We just force the workdir to be at the project root and this would allow arbitrary workdir to run `bliss`. The implemented utility decorated should work elsewhere as well.