### PR TITLE
Refactor get_full_params() 

### DIFF
--- a/bliss/models/binary.py
+++ b/bliss/models/binary.py
@@ -209,7 +209,7 @@ class BinaryEncoder(pl.LightningModule):
         tile_est["star_bool"] = pred["star_bool"]
         tile_est["prob_galaxy"] = pred["prob_galaxy"]
         est = get_full_params(tile_est, slen)
-        est2 = get_full_params_from_tiles(tile_params, self.tile_slen)
+        est2 = get_full_params_from_tiles(tile_est, self.tile_slen)
         for k in est:
             assert k in est2
             assert torch.allclose(est[k], est2[k])

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -133,14 +133,9 @@ def get_full_params_from_tiles(tile_params, tile_slen):
     tile_n_sources = tile_params["n_sources"]
     tile_locs = tile_params["locs"]
 
-    n_samples = tile_locs.shape[0]
     max_detections = tile_locs.shape[2]
-
     indx_sort = get_indx_sort(tile_n_sources, max_detections)
-    plocs, locs, slen, wlen = full_locs_from_tile_locs(tile_locs, tile_n_sources, tile_slen)
-
-    # get is_on_array
-
+    plocs, locs = full_locs_from_tile_locs(tile_locs, tile_n_sources, tile_slen)
 
     n_sources = reduce(tile_params["n_sources"], "b n -> b", "sum")
     params = {"n_sources": n_sources}

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import numpy as np
 import torch
@@ -140,9 +140,9 @@ def get_full_locs_from_tiles(
         tile_locs:
             A tensor of shape `n_samples x n_tiles_per_image x max_detections x 2`,
             representing the locations in each tile.
-        tile_slen ([type]):
+        tile_slen:
             The side-length of each tile.
-        n_tiles_w :
+        n_tiles_w:
             Defaults to None. Can directly specify the number of tiles in width.
             This is necessary when the original image was not square.
 
@@ -181,20 +181,22 @@ def get_indices_of_on_sources(tile_n_sources: Tensor, max_detections: int) -> Te
     """Get the indices of detected sources from each tile.
 
     Args:
-        tile_n_sources: A Tensor of shape `n_samples x n_tiles_per_image`, containing the
+        tile_n_sources:
+            A Tensor of shape `n_samples x n_tiles_per_image`, containing the
             number of detected sources in a given tile.
-        max_detections: The maximum number of detections allowed in a given tile.
+        max_detections:
+            The maximum number of detections allowed in a given tile.
 
     Returns:
-        A 2-D tensor of integers with shape `n_samples x max(n_sources)`, where `max(n_sources)` is the
-        maximum number of sources detected across all samples.
+        A 2-D tensor of integers with shape `n_samples x max(n_sources)`,
+        where `max(n_sources)` is the maximum number of sources detected across all samples.
 
         Each element of this tensor is an index of a particular source within a particular tile.
         For a particular sample i that had N detections,
         the first N indices of indices_sorted[i. :] will be the detected sources.
         This is accomplishied by flattening the n_tiles_per_image and max_detections.
-        For example, if we had 3 tiles with a maximum of two sources each, the elements of this tensor
-        would take values from 0 up to and including 5.
+        For example, if we had 3 tiles with a maximum of two sources each,
+        the elements of this tensor would take values from 0 up to and including 5.
     """
     tile_is_on_array_sampled = get_is_on_from_n_sources(tile_n_sources, max_detections)
     n_sources = tile_is_on_array_sampled.sum(dim=(1, 2))  # per sample.
@@ -346,7 +348,6 @@ class ImageEncoder(nn.Module):
             "locs": tile_locs,
             "log_fluxes": tile_log_fluxes,
             "fluxes": tile_fluxes,
-            "n_sources": tile_n_sources,
         }
 
     def max_a_post(self, var_params: Tensor) -> Dict[str, Tensor]:

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -192,28 +192,12 @@ def full_locs_from_tile_locs(tile_locs, tile_n_sources, tile_slen):
 
 
 def get_indices_of_on_sources(tile_n_sources, max_detections):
-    # get is_on_array
     tile_is_on_array_sampled = get_is_on_from_n_sources(tile_n_sources, max_detections)
     n_sources = tile_is_on_array_sampled.sum(dim=(1, 2))  # per sample.
     max_sources = n_sources.max().int().item()
-    # tile_is_on_array = rearrange(tile_is_on_array_sampled, "b n d -> (b n) d")
     tile_is_on_array = rearrange(tile_is_on_array_sampled, "b n d -> b (n d)")
-    # locs *= tile_is_on_array.unsqueeze(2)
-
-    # # sort locs and clip
-    # locs = locs.view(n_samples, -1, 2)
-    indx_sort = _argfront(tile_is_on_array, dim=1)
-    # locs = torch.gather(locs, 1, repeat(indx_sort, "b n -> b n r", r=2))
-    # locs = locs[:, 0:max_sources]
-    # params = {"n_sources": n_sources, "locs": locs}
-    return indx_sort[:, :max_sources]
-
-
-def _argfront(is_on_array, dim):
-    # return indices that sort pushing all zeroes of tensor to the back.
-    # dim is dimension along which do the ordering.
-    assert len(is_on_array.shape) == 2
-    return (is_on_array != 0).long().argsort(dim=dim, descending=True)
+    indices_sorted = tile_is_on_array.long().argsort(dim=1, descending=True)
+    return indices_sorted[:, :max_sources]
 
 
 class ImageEncoder(nn.Module):

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -149,9 +149,8 @@ def get_full_params_from_tiles(tile_params, tile_slen, optional):
 
     # now do the same for the rest of the parameters (without scaling or biasing)
     # for same reason no need to multiply times is_on_array
-    for param_name, val in tile_params.items():
+    for param_name, tile_param in tile_params.items():
         if param_name in optional:
-            tile_param = val
             assert len(tile_param.shape) == 4
             param = rearrange(tile_param, "b t d k -> b (t d) k")
             param = torch.gather(

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -181,7 +181,7 @@ def full_locs_from_tile_locs(tile_locs, tile_n_sources, tile_slen):
     locs[..., 0] /= slen
     locs[..., 1] /= wlen
 
-    return plocs, locs, slen, wlen
+    return plocs, locs
 
 
 def get_indx_sort(tile_n_sources, max_detections):

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -143,8 +143,6 @@ def get_full_params_from_tiles(tile_params, tile_slen, optional):
     tile_is_on_array_sampled = get_is_on_from_n_sources(tile_n_sources, max_detections)
     n_sources = tile_is_on_array_sampled.sum(dim=(1, 2))  # per sample.
     max_sources = n_sources.max().int().item()
-    tile_is_on_array = rearrange(tile_is_on_array_sampled, "b n d -> (b n) d")
-    locs *= tile_is_on_array.unsqueeze(2)
 
     locs = rearrange(locs, "(b n) d xy -> b (n d) xy", b=n_samples)
     locs = torch.gather(locs, dim=1, index=repeat(indx_sort, "b n -> b n r", r=2))

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -102,23 +102,12 @@ def get_full_params(
 
     # check dictionary of tile_params is consistent and has no extraneous keys.
     required = {"n_sources", "locs"}
-    optional = {"galaxy_bool", "star_bool", "galaxy_params", "fluxes", "log_fluxes", "prob_galaxy"}
     assert required.issubset(tile_params.keys())
 
-    for pname in tile_params:
-        assert pname in required or pname in optional or pname == "prob_n_sources"
-
     # tile_locs shape = (n_samples x n_tiles_per_image x max_detections x 2)
-    tile_n_sources = tile_params["n_sources"]
     tile_locs = tile_params["locs"]
     assert len(tile_locs.shape) == 4
-    n_samples = tile_locs.shape[0]
     n_tiles_per_image = tile_locs.shape[1]
-    max_detections = tile_locs.shape[2]
-
-    # otherwise prob_n_sources makes no sense globally
-    if max_detections == 1:
-        optional.add("prob_n_sources")
 
     # calculate tile_slen
     tile_slen = np.sqrt(slen * wlen / n_tiles_per_image)

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -97,7 +97,7 @@ def get_full_params_from_tiles(tile_params, tile_slen):
         k = tile_param.shape[-1]
         param = rearrange(tile_param, "b t d k -> b (t d) k", k=k)
         indices_for_param = repeat(indices_to_retrieve, "b n -> b n k", k=k)
-        param = torch.gather(param, 1, indices_for_param)
+        param = torch.gather(param, dim=1, index=indices_for_param)
         params[param_name] = param
 
     params["n_sources"] = reduce(tile_params["n_sources"], "b n -> b", "sum")

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -70,11 +70,6 @@ def get_is_on_from_n_sources(n_sources, max_sources):
 def get_full_params_from_tiles(tile_params, tile_slen):
     tile_n_sources = tile_params["n_sources"]
     tile_locs = tile_params["locs"]
-    plocs, locs = get_full_locs_from_tiles(tile_locs, tile_n_sources, tile_slen)
-    tile_params_to_gather = {
-        "locs": locs,
-        "plocs": plocs,
-    }
 
     param_names_to_gather = {
         "galaxy_bool",
@@ -87,6 +82,12 @@ def get_full_params_from_tiles(tile_params, tile_slen):
     max_detections = tile_locs.shape[2]
     if max_detections == 1:
         param_names_to_gather.add("prob_n_sources")
+
+    plocs, locs = get_full_locs_from_tiles(tile_locs, tile_n_sources, tile_slen)
+    tile_params_to_gather = {
+        "locs": locs,
+        "plocs": plocs,
+    }
     tile_params_to_gather.update(
         {k: tile_params[k] for k in param_names_to_gather if k in tile_params}
     )

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -83,7 +83,7 @@ def get_full_params_from_tiles(tile_params, tile_slen):
     if max_detections == 1:
         param_names_to_gather.add("prob_n_sources")
 
-    plocs, locs = get_full_locs_from_tiles(tile_locs, tile_n_sources, tile_slen)
+    plocs, locs = get_full_locs_from_tiles(tile_locs, tile_slen)
     tile_params_to_gather = {
         "locs": locs,
         "plocs": plocs,
@@ -106,7 +106,7 @@ def get_full_params_from_tiles(tile_params, tile_slen):
     return params
 
 
-def get_full_locs_from_tiles(tile_locs, tile_n_sources, tile_slen, n_tiles_w=None):
+def get_full_locs_from_tiles(tile_locs, tile_slen, n_tiles_w=None):
     n_samples, n_tiles_per_image, _, _ = tile_locs.shape
 
     n_tiles_h = int(np.sqrt(n_tiles_per_image))
@@ -116,8 +116,8 @@ def get_full_locs_from_tiles(tile_locs, tile_n_sources, tile_slen, n_tiles_w=Non
     slen = n_tiles_h * tile_slen
     wlen = n_tiles_w * tile_slen
     # coordinates on tiles.
-    x_coords = torch.arange(0, slen, tile_slen, device=tile_n_sources.device).long()
-    y_coords = torch.arange(0, wlen, tile_slen, device=tile_n_sources.device).long()
+    x_coords = torch.arange(0, slen, tile_slen, device=tile_locs.device).long()
+    y_coords = torch.arange(0, wlen, tile_slen, device=tile_locs.device).long()
     tile_coords = torch.cartesian_prod(x_coords, y_coords)
 
     # recenter and renormalize locations.

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -96,26 +96,29 @@ def get_full_params(
     # NOTE: off sources should have tile_locs == 0.
     # NOTE: assume that each param in each tile is already pushed to the front.
 
-    # check slen, wlen
-    wlen = slen if wlen is None else wlen
-    assert isinstance(slen, int) and isinstance(wlen, int)
-
     # check dictionary of tile_params is consistent and has no extraneous keys.
     required = {"n_sources", "locs"}
     assert required.issubset(tile_params.keys())
 
+    tile_slen = get_tile_slen(tile_params, slen, wlen)
+    return get_full_params_from_tiles(tile_params, tile_slen)
+
+
+def get_tile_slen(tile_params, slen, wlen=None):
+    # check slen, wlen
+    wlen = slen if wlen is None else wlen
+    assert isinstance(slen, int) and isinstance(wlen, int)
     # tile_locs shape = (n_samples x n_tiles_per_image x max_detections x 2)
     tile_locs = tile_params["locs"]
     assert len(tile_locs.shape) == 4
     n_tiles_per_image = tile_locs.shape[1]
-
     # calculate tile_slen
     tile_slen = np.sqrt(slen * wlen / n_tiles_per_image)
     assert tile_slen % 1 == 0, "Image cannot be subdivided into tiles!"
     assert slen % tile_slen == 0 and wlen % tile_slen == 0, "incompatible side lengths."
     tile_slen = int(tile_slen)
 
-    return get_full_params_from_tiles(tile_params, tile_slen)
+    return tile_slen
 
 
 def get_full_params_from_tiles(tile_params, tile_slen):

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -70,7 +70,7 @@ def get_is_on_from_n_sources(n_sources, max_sources):
 def get_full_params_from_tiles(tile_params, tile_slen):
     tile_n_sources = tile_params["n_sources"]
     tile_locs = tile_params["locs"]
-    plocs, locs = full_locs_from_tile_locs(tile_locs, tile_n_sources, tile_slen)
+    plocs, locs = get_full_locs_from_tiles(tile_locs, tile_n_sources, tile_slen)
     tile_params_to_gather = {
         "locs": locs,
         "plocs": plocs,
@@ -105,7 +105,7 @@ def get_full_params_from_tiles(tile_params, tile_slen):
     return params
 
 
-def full_locs_from_tile_locs(tile_locs, tile_n_sources, tile_slen, n_tiles_w=None):
+def get_full_locs_from_tiles(tile_locs, tile_n_sources, tile_slen, n_tiles_w=None):
     n_samples, n_tiles_per_image, _, _ = tile_locs.shape
 
     n_tiles_h = int(np.sqrt(n_tiles_per_image))

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -126,10 +126,10 @@ def get_full_params(
     assert slen % tile_slen == 0 and wlen % tile_slen == 0, "incompatible side lengths."
     tile_slen = int(tile_slen)
 
-    return get_full_params_from_tiles(tile_params, tile_slen, optional)
+    return get_full_params_from_tiles(tile_params, tile_slen)
 
 
-def get_full_params_from_tiles(tile_params, tile_slen, optional):
+def get_full_params_from_tiles(tile_params, tile_slen):
     tile_n_sources = tile_params["n_sources"]
     tile_locs = tile_params["locs"]
 
@@ -149,8 +149,19 @@ def get_full_params_from_tiles(tile_params, tile_slen, optional):
 
     # now do the same for the rest of the parameters (without scaling or biasing)
     # for same reason no need to multiply times is_on_array
+    params_to_gather = {
+        "galaxy_bool",
+        "star_bool",
+        "galaxy_params",
+        "fluxes",
+        "log_fluxes",
+        "prob_galaxy",
+    }
+    if max_detections == 1:
+        params_to_gather.add("prob_n_sources")
+
     for param_name, tile_param in tile_params.items():
-        if param_name in optional:
+        if param_name in params_to_gather:
             assert len(tile_param.shape) == 4
             param = rearrange(tile_param, "b t d k -> b (t d) k")
             param = torch.gather(

--- a/bliss/models/encoder.py
+++ b/bliss/models/encoder.py
@@ -100,16 +100,15 @@ def get_full_params(
     required = {"n_sources", "locs"}
     assert required.issubset(tile_params.keys())
 
-    tile_slen = get_tile_slen(tile_params, slen, wlen)
+    tile_slen = get_tile_slen(tile_params["locs"], slen, wlen)
     return get_full_params_from_tiles(tile_params, tile_slen)
 
 
-def get_tile_slen(tile_params, slen, wlen=None):
+def get_tile_slen(tile_locs, slen, wlen=None):
     # check slen, wlen
     wlen = slen if wlen is None else wlen
     assert isinstance(slen, int) and isinstance(wlen, int)
     # tile_locs shape = (n_samples x n_tiles_per_image x max_detections x 2)
-    tile_locs = tile_params["locs"]
     assert len(tile_locs.shape) == 4
     n_tiles_per_image = tile_locs.shape[1]
     # calculate tile_slen

--- a/bliss/models/galaxy_encoder.py
+++ b/bliss/models/galaxy_encoder.py
@@ -7,7 +7,7 @@ from torch.nn import functional as F
 
 from bliss.models.prior import ImagePrior
 from bliss.models.decoder import ImageDecoder, get_mgrid
-from bliss.models.encoder import get_full_params, get_images_in_tiles, get_full_params_from_tiles
+from bliss.models.encoder import get_images_in_tiles, get_full_params_from_tiles
 from bliss.models.galaxy_net import OneCenteredGalaxyAE
 from bliss.optimizer import load_optimizer
 from bliss.reporting import plot_image, plot_image_and_locs
@@ -185,11 +185,7 @@ class GalaxyEncoder(pl.LightningModule):
         tile_est = {
             k: (v if k != "galaxy_params" else tile_galaxy_params) for k, v in tile_params.items()
         }
-        est = get_full_params(tile_est, slen)
-        est2 = get_full_params_from_tiles(tile_est, self.tile_slen)
-        for k in est:
-            assert k in est2
-            assert torch.allclose(est[k], est2[k])
+        est = get_full_params_from_tiles(tile_est, self.tile_slen)
 
         # draw all reconstruction images.
         # render_images automatically accounts for tiles with no galaxies.

--- a/bliss/models/galaxy_encoder.py
+++ b/bliss/models/galaxy_encoder.py
@@ -7,7 +7,7 @@ from torch.nn import functional as F
 
 from bliss.models.prior import ImagePrior
 from bliss.models.decoder import ImageDecoder, get_mgrid
-from bliss.models.encoder import get_full_params, get_images_in_tiles
+from bliss.models.encoder import get_full_params, get_images_in_tiles, get_full_params_from_tiles
 from bliss.models.galaxy_net import OneCenteredGalaxyAE
 from bliss.optimizer import load_optimizer
 from bliss.reporting import plot_image, plot_image_and_locs
@@ -186,6 +186,10 @@ class GalaxyEncoder(pl.LightningModule):
             k: (v if k != "galaxy_params" else tile_galaxy_params) for k, v in tile_params.items()
         }
         est = get_full_params(tile_est, slen)
+        est2 = get_full_params_from_tiles(tile_params, self.tile_slen)
+        for k in est:
+            assert k in est2
+            assert torch.allclose(est[k], est2[k])
 
         # draw all reconstruction images.
         # render_images automatically accounts for tiles with no galaxies.

--- a/bliss/models/galaxy_encoder.py
+++ b/bliss/models/galaxy_encoder.py
@@ -186,7 +186,7 @@ class GalaxyEncoder(pl.LightningModule):
             k: (v if k != "galaxy_params" else tile_galaxy_params) for k, v in tile_params.items()
         }
         est = get_full_params(tile_est, slen)
-        est2 = get_full_params_from_tiles(tile_params, self.tile_slen)
+        est2 = get_full_params_from_tiles(tile_est, self.tile_slen)
         for k in est:
             assert k in est2
             assert torch.allclose(est[k], est2[k])

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -12,6 +12,7 @@ from bliss.models.encoder import (
     get_is_on_from_n_sources,
     get_images_in_tiles,
     get_params_in_batches,
+    get_full_params_from_tiles,
 )
 from bliss.models.galaxy_encoder import GalaxyEncoder
 from bliss.models.galaxy_net import OneCenteredGalaxyDecoder
@@ -97,6 +98,10 @@ def predict_on_image(
 
     # full parameters on chunk
     full_map = get_full_params(tile_map, h - 2 * bp, w - 2 * bp)
+    full_map2 = get_full_params_from_tiles(tile_map, image_encoder.tile_slen)
+    for k in full_map:
+        assert k in full_map2
+        assert torch.allclose(full_map[k], full_map2[k])
 
     return tile_map, full_map, var_params_n_sources
 

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -8,7 +8,6 @@ from bliss.datasets import sdss
 from bliss.models import encoder
 from bliss.models.binary import BinaryEncoder
 from bliss.models.encoder import (
-    get_full_params,
     get_is_on_from_n_sources,
     get_images_in_tiles,
     get_params_in_batches,
@@ -97,11 +96,7 @@ def predict_on_image(
     tile_map["galaxy_params"] = galaxy_param_mean
 
     # full parameters on chunk
-    full_map = get_full_params(tile_map, h - 2 * bp, w - 2 * bp)
-    full_map2 = get_full_params_from_tiles(tile_map, image_encoder.tile_slen)
-    for k in full_map:
-        assert k in full_map2
-        assert torch.allclose(full_map[k], full_map2[k])
+    full_map = get_full_params_from_tiles(tile_map, image_encoder.tile_slen)
 
     return tile_map, full_map, var_params_n_sources
 

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -50,10 +50,6 @@ def predict_on_image(
     assert image.shape[1] == image_encoder.n_bands == 1
     assert image_encoder.max_detections == 1
 
-    # prepare dimensions
-    h, w = image.shape[-2], image.shape[-1]
-    bp = image_encoder.border_padding
-
     # get padded tiles.
     ptiles = get_images_in_tiles(image, image_encoder.tile_slen, image_encoder.ptile_slen)
 

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -348,7 +348,7 @@ class SleepPhase(pl.LightningModule):
         slen = int(batch["slen"].unique().item())
         true_tile_params = {k: v for k, v in batch.items() if k not in exclude}
         true_params = get_full_params(true_tile_params, slen)
-        true_params2 = get_full_params_from_tiles(true_tile_params, self.tile_slen)
+        true_params2 = get_full_params_from_tiles(true_tile_params, self.image_encoder.tile_slen)
         for k in true_params:
             assert k in true_params2
             assert torch.allclose(true_params[k], true_params2[k])
@@ -356,10 +356,10 @@ class SleepPhase(pl.LightningModule):
         # estimate
         tile_estimate = self.tile_map_estimate(batch)
         est_params = get_full_params(tile_estimate, slen)
-        est_params2 = get_full_params_from_tiles(true_tile_params, self.tile_slen)
+        est_params2 = get_full_params_from_tiles(tile_estimate, self.image_encoder.tile_slen)
         for k in est_params:
             assert k in est_params2
-            assert torch.allclose(est_params[k], est_params2)
+            assert torch.allclose(est_params[k], est_params2[k])
 
         return true_params, est_params, slen
 

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -24,6 +24,7 @@ from bliss.models.encoder import (
     get_is_on_from_n_sources,
     get_images_in_tiles,
     get_params_in_batches,
+    get_full_params_from_tiles,
 )
 from bliss.optimizer import load_optimizer
 from bliss.reporting import DetectionMetrics, plot_image_and_locs
@@ -347,10 +348,18 @@ class SleepPhase(pl.LightningModule):
         slen = int(batch["slen"].unique().item())
         true_tile_params = {k: v for k, v in batch.items() if k not in exclude}
         true_params = get_full_params(true_tile_params, slen)
+        true_params2 = get_full_params_from_tiles(true_tile_params, self.tile_slen)
+        for k in true_params:
+            assert k in true_params2
+            assert torch.allclose(true_params[k], true_params2[k])
 
         # estimate
         tile_estimate = self.tile_map_estimate(batch)
         est_params = get_full_params(tile_estimate, slen)
+        est_params2 = get_full_params_from_tiles(true_tile_params, self.tile_slen)
+        for k in est_params:
+            assert k in est_params2
+            assert torch.allclose(est_params[k], est_params2)
 
         return true_params, est_params, slen
 

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -20,7 +20,6 @@ from bliss.models.prior import ImagePrior
 from bliss.models.decoder import ImageDecoder
 from bliss.models.encoder import (
     ImageEncoder,
-    get_full_params,
     get_is_on_from_n_sources,
     get_images_in_tiles,
     get_params_in_batches,
@@ -347,20 +346,11 @@ class SleepPhase(pl.LightningModule):
         exclude = {"images", "slen", "background"}
         slen = int(batch["slen"].unique().item())
         true_tile_params = {k: v for k, v in batch.items() if k not in exclude}
-        true_params = get_full_params(true_tile_params, slen)
-        true_params2 = get_full_params_from_tiles(true_tile_params, self.image_encoder.tile_slen)
-        for k in true_params:
-            assert k in true_params2
-            assert torch.allclose(true_params[k], true_params2[k])
+        true_params = get_full_params_from_tiles(true_tile_params, self.image_encoder.tile_slen)
 
         # estimate
         tile_estimate = self.tile_map_estimate(batch)
-        est_params = get_full_params(tile_estimate, slen)
-        est_params2 = get_full_params_from_tiles(tile_estimate, self.image_encoder.tile_slen)
-        for k in est_params:
-            assert k in est_params2
-            assert torch.allclose(est_params[k], est_params2[k])
-
+        est_params = get_full_params_from_tiles(tile_estimate, self.image_encoder.tile_slen)
         return true_params, est_params, slen
 
     # pylint: disable=too-many-statements

--- a/tests/test_m2.py
+++ b/tests/test_m2.py
@@ -5,7 +5,6 @@ import pytest
 import torch
 
 from bliss.models.encoder import (
-    get_full_params,
     get_images_in_tiles,
     get_params_in_batches,
     get_full_params_from_tiles,
@@ -64,11 +63,7 @@ def get_map_estimate(image_encoder, images, slen: int, wlen: int = None):
     tile_map = get_params_in_batches(tile_map, images.shape[0])
     tile_map["prob_n_sources"] = tile_map["prob_n_sources"].unsqueeze(-2)
 
-    est = get_full_params(tile_map, slen, wlen)
-    est2 = get_full_params_from_tiles(tile_map, image_encoder.tile_slen)
-    for k in est:
-        assert k in est2
-        assert torch.allclose(est[k], est2[k])
+    est = get_full_params_from_tiles(tile_map, image_encoder.tile_slen)
     return est
 
 

--- a/tests/test_m2.py
+++ b/tests/test_m2.py
@@ -4,7 +4,12 @@ import numpy as np
 import pytest
 import torch
 
-from bliss.models.encoder import get_full_params, get_images_in_tiles, get_params_in_batches
+from bliss.models.encoder import (
+    get_full_params,
+    get_images_in_tiles,
+    get_params_in_batches,
+    get_full_params_from_tiles,
+)
 
 
 def _get_tpr_ppv(true_locs, true_mag, est_locs, est_mag, slack=1.0):
@@ -59,7 +64,12 @@ def get_map_estimate(image_encoder, images, slen: int, wlen: int = None):
     tile_map = get_params_in_batches(tile_map, images.shape[0])
     tile_map["prob_n_sources"] = tile_map["prob_n_sources"].unsqueeze(-2)
 
-    return get_full_params(tile_map, slen, wlen)
+    est = get_full_params(tile_map, slen, wlen)
+    est2 = get_full_params_from_tiles(tile_map, image_encoder.tile_slen)
+    for k in est:
+        assert k in est2
+        assert torch.allclose(est[k], est2)
+    return est
 
 
 class TestStarSleepEncoderM2:

--- a/tests/test_m2.py
+++ b/tests/test_m2.py
@@ -68,7 +68,7 @@ def get_map_estimate(image_encoder, images, slen: int, wlen: int = None):
     est2 = get_full_params_from_tiles(tile_map, image_encoder.tile_slen)
     for k in est:
         assert k in est2
-        assert torch.allclose(est[k], est2)
+        assert torch.allclose(est[k], est2[k])
     return est
 
 

--- a/tests/test_m2.py
+++ b/tests/test_m2.py
@@ -63,8 +63,7 @@ def get_map_estimate(image_encoder, images, slen: int, wlen: int = None):
     tile_map = get_params_in_batches(tile_map, images.shape[0])
     tile_map["prob_n_sources"] = tile_map["prob_n_sources"].unsqueeze(-2)
 
-    est = get_full_params_from_tiles(tile_map, image_encoder.tile_slen)
-    return est
+    return get_full_params_from_tiles(tile_map, image_encoder.tile_slen)
 
 
 class TestStarSleepEncoderM2:


### PR DESCRIPTION
This refactors `get_full_params()` by splitting the functionality into smaller methods to disentangle what it does. Hopefully this will make it easier to maintain.

Another key change is that `get_full_params()` takes in only the `tile_slen` and infers the other variables (`slen`, `wlen`, etc). Before we were using `slen`, `wlen`, and the tile parameters to infer `tile_slen`. The latter was more complicated because we needed to check a lot of assertions (i.e. that `n_tiles_per_image` divided evenly into `slen**2`).