### PR TITLE
get_full_params_from_tiles(): Allow for non-square images

### DIFF
--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -10,6 +10,7 @@ from bliss.models.binary import BinaryEncoder
 from bliss.models.encoder import (
     get_is_on_from_n_sources,
     get_images_in_tiles,
+    get_n_tiles_hw,
     get_params_in_batches,
     get_full_params_from_tiles,
 )
@@ -92,7 +93,10 @@ def predict_on_image(
     tile_map["galaxy_params"] = galaxy_param_mean
 
     # full parameters on chunk
-    full_map = get_full_params_from_tiles(tile_map, image_encoder.tile_slen)
+    _, nw = get_n_tiles_hw(
+        image.shape[2], image.shape[3], image_encoder.ptile_slen, image_encoder.tile_slen
+    )
+    full_map = get_full_params_from_tiles(tile_map, image_encoder.tile_slen, n_tiles_w=nw)
 
     return tile_map, full_map, var_params_n_sources
 


### PR DESCRIPTION
This change allows for get_full_params_from_tiles() to work
when the original image was not square. This fixes a bug in
predict.py introduced by the refactoring of get_full_params()
in 23fe0e4a5e2e0384d3991c8b930f93c0f3b5f0ad