### PR TITLE
Convert model checkpoints to state dicts and utilize Hydra's instantiate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,8 @@ data/*.pkl filter=lfs diff=lfs merge=lfs -text
 data/*.npy filter=lfs diff=lfs merge=lfs -text
 data/simulated_sdss_individual_galaxies.pt filter=lfs diff=lfs merge=lfs -text
 models/sdss_galaxy_encoder_real.ckpt filter=lfs diff=lfs merge=lfs -text
+models/sdss_autoencoder.pt filter=lfs diff=lfs merge=lfs -text
+models/sdss_binary.pt filter=lfs diff=lfs merge=lfs -text
+models/sdss_galaxy_encoder.pt filter=lfs diff=lfs merge=lfs -text
+models/sdss_galaxy_encoder_real.pt filter=lfs diff=lfs merge=lfs -text
+models/sdss_sleep.pt filter=lfs diff=lfs merge=lfs -text

--- a/bliss/datasets/sdss_blended_galaxies.py
+++ b/bliss/datasets/sdss_blended_galaxies.py
@@ -26,6 +26,8 @@ class SdssBlendedGalaxies(pl.LightningDataModule):
 
     def __init__(
         self,
+        sleep: SleepPhase,
+        binary_encoder: BinaryEncoder,
         sleep_ckpt: str,
         binary_ckpt: str,
         sdss_dir: str = "data/sdss",
@@ -45,8 +47,10 @@ class SdssBlendedGalaxies(pl.LightningDataModule):
         """Initializes SDSSBlendedGalaxies.
 
         Args:
-            sleep_ckpt: Checkpoint file for sleep-phase-trained encoder.
-            binary_ckpt: Checkpoint file for binary encoder.
+            sleep: A SleepPhase model for getting the locations of sources.
+            binary_encoder: A BinaryEncoder model.
+            sleep_ckpt: Path of saved state_dict for sleep-phase-trained encoder.
+            binary_ckpt: Path of saved state_dict for binary encoder.
             sdss_dir: Location of data storage for SDSS. Defaults to "data/sdss".
             run: SDSS run.
             camcol: SDSS camcol.
@@ -96,10 +100,10 @@ class SdssBlendedGalaxies(pl.LightningDataModule):
             (w_start - self.bp) : (w_start + scene_size + self.bp),
         ]
 
-        sleep = SleepPhase.load_from_checkpoint(sleep_ckpt)
+        sleep.load_state_dict(torch.load(sleep_ckpt))
         image_encoder = sleep.image_encoder
 
-        binary_encoder = BinaryEncoder.load_from_checkpoint(binary_ckpt)
+        binary_encoder.load_state_dict(torch.load(binary_ckpt))
         self.encoder = Encoder(image_encoder.eval(), binary_encoder.eval())
         cache_file = (
             Path(cache_path + f"_h{h_start}w{w_start}s{scene_size}.pt")

--- a/bliss/datasets/sdss_blended_galaxies.py
+++ b/bliss/datasets/sdss_blended_galaxies.py
@@ -100,10 +100,10 @@ class SdssBlendedGalaxies(pl.LightningDataModule):
             (w_start - self.bp) : (w_start + scene_size + self.bp),
         ]
 
-        sleep.load_state_dict(torch.load(sleep_ckpt))
+        sleep.load_state_dict(torch.load(sleep_ckpt, map_location=torch.device("cpu")))
         image_encoder = sleep.image_encoder
 
-        binary_encoder.load_state_dict(torch.load(binary_ckpt))
+        binary_encoder.load_state_dict(torch.load(binary_ckpt, map_location=torch.device("cpu")))
         self.encoder = Encoder(image_encoder.eval(), binary_encoder.eval())
         cache_file = (
             Path(cache_path + f"_h{h_start}w{w_start}s{scene_size}.pt")

--- a/bliss/datasets/simulated.py
+++ b/bliss/datasets/simulated.py
@@ -15,13 +15,19 @@ warnings.filterwarnings(
 
 class SimulatedDataset(pl.LightningDataModule, IterableDataset):
     def __init__(
-        self, prior, decoder, n_batches=10, batch_size=32, generate_device="cpu", testing_file=None
+        self,
+        prior: ImagePrior,
+        decoder,
+        n_batches=10,
+        batch_size=32,
+        generate_device="cpu",
+        testing_file=None,
     ):
         super().__init__()
 
         self.n_batches = n_batches
         self.batch_size = batch_size
-        self.image_prior = ImagePrior(**prior).to(generate_device)
+        self.image_prior = prior.to(generate_device)
         self.image_prior.requires_grad_(False)  # freeze decoder weights.
         self.image_decoder = ImageDecoder(**decoder).to(generate_device)
         self.image_decoder.requires_grad_(False)  # freeze decoder weights.

--- a/bliss/datasets/simulated.py
+++ b/bliss/datasets/simulated.py
@@ -17,7 +17,7 @@ class SimulatedDataset(pl.LightningDataModule, IterableDataset):
     def __init__(
         self,
         prior: ImagePrior,
-        decoder,
+        decoder: ImageDecoder,
         n_batches=10,
         batch_size=32,
         generate_device="cpu",
@@ -29,7 +29,7 @@ class SimulatedDataset(pl.LightningDataModule, IterableDataset):
         self.batch_size = batch_size
         self.image_prior = prior.to(generate_device)
         self.image_prior.requires_grad_(False)  # freeze decoder weights.
-        self.image_decoder = ImageDecoder(**decoder).to(generate_device)
+        self.image_decoder = decoder.to(generate_device)
         self.image_decoder.requires_grad_(False)  # freeze decoder weights.
         self.testing_file = testing_file
 

--- a/bliss/models/decoder.py
+++ b/bliss/models/decoder.py
@@ -84,7 +84,9 @@ class ImageDecoder(pl.LightningModule):
 
         if prob_galaxy > 0.0:
             assert autoencoder_ckpt is not None
-            autoencoder.load_state_dict(torch.load(autoencoder_ckpt))
+            autoencoder.load_state_dict(
+                torch.load(autoencoder_ckpt, map_location=torch.device("cpu"))
+            )
             autoencoder.eval().requires_grad_(False)
             galaxy_decoder = autoencoder.get_decoder()
             self.galaxy_tile_decoder = GalaxyTileDecoder(

--- a/bliss/models/galaxy_encoder.py
+++ b/bliss/models/galaxy_encoder.py
@@ -54,7 +54,7 @@ def center_ptiles(
 class GalaxyEncoder(pl.LightningModule):
     def __init__(
         self,
-        prior,
+        prior: ImagePrior,
         decoder,
         hidden: int = 256,
         optimizer_params: dict = None,
@@ -70,7 +70,7 @@ class GalaxyEncoder(pl.LightningModule):
         self.max_flux_valid_plots = max_flux_valid_plots
 
         # to produce images to train on.
-        self.image_prior = ImagePrior(**prior)
+        self.image_prior = prior
         self.image_decoder = ImageDecoder(**decoder)
         self.image_decoder.requires_grad_(False)
 

--- a/bliss/models/galaxy_encoder.py
+++ b/bliss/models/galaxy_encoder.py
@@ -88,7 +88,9 @@ class GalaxyEncoder(pl.LightningModule):
 
         # will be trained.
         if autoencoder_ckpt is not None:
-            autoencoder.load_state_dict(torch.load(autoencoder_ckpt))
+            autoencoder.load_state_dict(
+                torch.load(autoencoder_ckpt, map_location=torch.device("cpu"))
+            )
         self.enc = autoencoder.get_encoder(allow_pad=True)
         self.latent_dim = autoencoder.latent_dim
 
@@ -100,7 +102,9 @@ class GalaxyEncoder(pl.LightningModule):
         assert self.slen >= 20, "Cropped slen is not reasonable for average sized galaxies."
 
         if checkpoint_path is not None:
-            self.load_state_dict(torch.load(Path(checkpoint_path)))
+            self.load_state_dict(
+                torch.load(Path(checkpoint_path), map_location=torch.device("cpu"))
+            )
 
     def center_ptiles(self, image_ptiles, tile_locs):
         return center_ptiles(

--- a/bliss/models/galaxy_encoder.py
+++ b/bliss/models/galaxy_encoder.py
@@ -55,7 +55,7 @@ class GalaxyEncoder(pl.LightningModule):
     def __init__(
         self,
         prior: ImagePrior,
-        decoder,
+        decoder: ImageDecoder,
         autoencoder: OneCenteredGalaxyAE,
         autoencoder_ckpt: str = None,
         hidden: int = 256,
@@ -73,7 +73,7 @@ class GalaxyEncoder(pl.LightningModule):
 
         # to produce images to train on.
         self.image_prior = prior
-        self.image_decoder = ImageDecoder(**decoder)
+        self.image_decoder = decoder
         self.image_decoder.requires_grad_(False)
 
         # extract useful info from image_decoder

--- a/bliss/models/galaxy_encoder.py
+++ b/bliss/models/galaxy_encoder.py
@@ -56,6 +56,8 @@ class GalaxyEncoder(pl.LightningModule):
         self,
         prior: ImagePrior,
         decoder,
+        autoencoder: OneCenteredGalaxyAE,
+        autoencoder_ckpt: str = None,
         hidden: int = 256,
         optimizer_params: dict = None,
         crop_loss_at_border=False,
@@ -85,8 +87,8 @@ class GalaxyEncoder(pl.LightningModule):
         self.slen = self.ptile_slen - 2 * self.tile_slen  # will always crop 2 * tile_slen
 
         # will be trained.
-        autoencoder_ckpt = decoder["autoencoder_ckpt"]
-        autoencoder = OneCenteredGalaxyAE.load_from_checkpoint(autoencoder_ckpt)
+        if autoencoder_ckpt is not None:
+            autoencoder.load_state_dict(torch.load(autoencoder_ckpt))
         self.enc = autoencoder.get_encoder(allow_pad=True)
         self.latent_dim = autoencoder.latent_dim
 
@@ -98,9 +100,7 @@ class GalaxyEncoder(pl.LightningModule):
         assert self.slen >= 20, "Cropped slen is not reasonable for average sized galaxies."
 
         if checkpoint_path is not None:
-            ge = GalaxyEncoder.load_from_checkpoint(Path(checkpoint_path))
-            self.load_state_dict(ge.state_dict())
-            print(f"INFO: Loaded model weights from checkout at {checkpoint_path}")
+            self.load_state_dict(torch.load(Path(checkpoint_path)))
 
     def center_ptiles(self, image_ptiles, tile_locs):
         return center_ptiles(

--- a/bliss/models/prior.py
+++ b/bliss/models/prior.py
@@ -90,7 +90,9 @@ class ImagePrior(pl.LightningModule):
 
         self.prob_galaxy = float(prob_galaxy)
         if prob_galaxy > 0.0:
-            autoencoder.load_state_dict(torch.load(autoencoder_ckpt))
+            autoencoder.load_state_dict(
+                torch.load(autoencoder_ckpt, map_location=torch.device("cpu"))
+            )
             latents = get_galaxy_latents(latents_file, n_latent_batches, autoencoder)
         else:
             latents = torch.zeros(1, 1)

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -250,9 +250,15 @@ def predict(cfg: DictConfig):
     binary_encoder = instantiate(cfg.models.binary)
 
     # Load weights
-    sleep_net.load_state_dict(torch.load(cfg.predict.sleep_checkpoint))
-    galaxy_encoder.load_state_dict(torch.load(cfg.predict.galaxy_checkpoint))
-    binary_encoder.load_state_dict(torch.load(cfg.predict.binary_checkpoint))
+    sleep_net.load_state_dict(
+        torch.load(cfg.predict.sleep_checkpoint, map_location=torch.device("cpu"))
+    )
+    galaxy_encoder.load_state_dict(
+        torch.load(cfg.predict.galaxy_checkpoint, map_location=torch.device("cpu"))
+    )
+    binary_encoder.load_state_dict(
+        torch.load(cfg.predict.binary_checkpoint, map_location=torch.device("cpu"))
+    )
 
     # move everything to specified GPU
     image_encoder = sleep_net.image_encoder.eval().to(device)

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -123,7 +123,7 @@ class SleepPhase(pl.LightningModule):
 
     def __init__(
         self,
-        encoder: dict,
+        encoder: LocationEncoder,
         prior: ImagePrior,
         decoder: dict,
         annotate_probs: bool = False,
@@ -143,7 +143,7 @@ class SleepPhase(pl.LightningModule):
         super().__init__()
         self.save_hyperparameters()
 
-        self.image_encoder = LocationEncoder(**encoder)
+        self.image_encoder = encoder
         self.image_prior = prior
         self.image_decoder = ImageDecoder(**decoder)
         self.image_decoder.requires_grad_(False)

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -124,7 +124,7 @@ class SleepPhase(pl.LightningModule):
     def __init__(
         self,
         encoder: dict,
-        prior: dict,
+        prior: ImagePrior,
         decoder: dict,
         annotate_probs: bool = False,
         slack=1.0,
@@ -134,7 +134,7 @@ class SleepPhase(pl.LightningModule):
 
         Args:
             encoder: keyword arguments to instantiate ImageEncoder
-            prior: keyword arguments to instantiate ImagePrior
+            prior: ImagePrior module
             decoder: keyword arguments to instantiate ImageDecoder
             annotate_probs: Should probabilities be annotated on plot? Defaults to False.
             slack: Threshold distance in pixels for matching objects.
@@ -144,7 +144,7 @@ class SleepPhase(pl.LightningModule):
         self.save_hyperparameters()
 
         self.image_encoder = LocationEncoder(**encoder)
-        self.image_prior = ImagePrior(**prior)
+        self.image_prior = prior
         self.image_decoder = ImageDecoder(**decoder)
         self.image_decoder.requires_grad_(False)
 

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -125,7 +125,7 @@ class SleepPhase(pl.LightningModule):
         self,
         encoder: LocationEncoder,
         prior: ImagePrior,
-        decoder: dict,
+        decoder: ImageDecoder,
         annotate_probs: bool = False,
         slack=1.0,
         optimizer_params: dict = None,  # pylint: disable=unused-argument
@@ -145,7 +145,7 @@ class SleepPhase(pl.LightningModule):
 
         self.image_encoder = encoder
         self.image_prior = prior
-        self.image_decoder = ImageDecoder(**decoder)
+        self.image_decoder = decoder
         self.image_decoder.requires_grad_(False)
 
         # consistency

--- a/bliss/train.py
+++ b/bliss/train.py
@@ -1,7 +1,6 @@
 from typing import Optional
 from pathlib import Path
 
-
 import torch
 import pytorch_lightning as pl
 from hydra.utils import instantiate
@@ -94,7 +93,7 @@ def train(cfg: DictConfig):
     if cfg.training.testing.file is not None:
         _ = trainer.test(model, datamodule=dataset)
 
-    ## Load best weights from checkpoint
+    # Load best weights from checkpoint
     if cfg.training.weight_save_path is not None:
         model_to_save = type(model).load_from_checkpoint(checkpoint_callback.best_model_path)
         model_to_save.state_dict()

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -186,3 +186,4 @@ training:
         file: null
         batch_size: 32
         num_workers: 0
+    weight_save_path: "${paths.root}/models/${training.name}.pt"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -110,7 +110,8 @@ models:
         latent_dim: 64
         n_bands: 1
         residual_delay_n_steps: 500
-    prior: 
+    prior:
+        _target_: bliss.models.prior.ImagePrior
         n_bands: 1
         slen: 40
         tile_slen: 4
@@ -121,7 +122,8 @@ models:
         f_max: 1e6
         alpha: 0.5
         prob_galaxy: 0.7
-        autoencoder_ckpt: models/sdss_autoencoder.ckpt
+        autoencoder: ${models.galaxy_net}
+        autoencoder_ckpt: models/sdss_autoencoder.pt
         latents_file: data/latents_simulated_sdss_galaxies.pt
     sleep:
         _target_: bliss.sleep.SleepPhase

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -80,6 +80,7 @@ models:
         spatial_dropout: 0.0
         dropout: 0.0
     decoder:
+        _target_: bliss.models.decoder.ImageDecoder
         n_bands: 1
         slen: 40
         tile_slen: 4

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,8 +24,10 @@ paths:
 datasets:
     sdss_blended_galaxies:
         _target_: bliss.datasets.sdss_blended_galaxies.SdssBlendedGalaxies
-        sleep_ckpt: models/sdss_sleep.ckpt
-        binary_ckpt: models/sdss_binary.ckpt
+        sleep: ${models.sleep}
+        binary_encoder: ${models.binary}
+        sleep_ckpt: models/sdss_sleep.pt
+        binary_ckpt: models/sdss_binary.pt
         prerender_device: "cuda"
     sdss_galaxies:
         _target_: bliss.datasets.galsim_galaxies.SDSSGalaxies
@@ -85,7 +87,8 @@ models:
         border_padding: 24
         psf_params_file: data/sdss/94/1/12/psField-000094-1-0012.fits
         prob_galaxy: 0.7
-        autoencoder_ckpt: models/sdss_autoencoder.ckpt
+        autoencoder: ${models.galaxy_net}
+        autoencoder_ckpt: models/sdss_autoencoder.pt
         background_values:
             - 865.0
         sdss_bands:
@@ -103,6 +106,8 @@ models:
         _target_: bliss.models.galaxy_encoder.GalaxyEncoder
         prior: ${models.prior}
         decoder: ${models.decoder}
+        autoencoder: ${models.galaxy_net}
+        autoencoder_ckpt: models/sdss_autoencoder.pt
         hidden: 256
     galaxy_net:
         _target_: bliss.models.galaxy_net.OneCenteredGalaxyAE
@@ -155,9 +160,9 @@ predict:
     clen: 300
 
     # i/o parameters
-    sleep_checkpoint: models/sdss_sleep.ckpt
-    galaxy_checkpoint: models/sdss_galaxy_encoder.ckpt
-    binary_checkpoint: models/sdss_binary.ckpt
+    sleep_checkpoint: models/sdss_sleep.pt
+    galaxy_checkpoint: models/sdss_galaxy_encoder.pt
+    binary_checkpoint: models/sdss_binary.pt
     device: "cuda:0"
     output_file: null
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -94,6 +94,7 @@ models:
         sdss_bands:
             - 2
     encoder:
+        _target_: bliss.models.location_encoder.LocationEncoder
         n_bands: ${models.decoder.n_bands}
         tile_slen: ${models.decoder.tile_slen}
         ptile_slen: 52

--- a/config/training/sdss_autoencoder.yaml
+++ b/config/training/sdss_autoencoder.yaml
@@ -1,3 +1,4 @@
+name: "sdss_autoencoder"
 model: ${models.galaxy_net}
 dataset: ${datasets.sdss_galaxies}
 optimizer:

--- a/config/training/sdss_binary.yaml
+++ b/config/training/sdss_binary.yaml
@@ -1,3 +1,4 @@
+name: "sdss_binary"
 model: ${models.binary}
 dataset: ${datasets.simulated}
 optimizer:

--- a/config/training/sdss_galaxy_encoder.yaml
+++ b/config/training/sdss_galaxy_encoder.yaml
@@ -7,6 +7,7 @@ datasets:
         batch_size: 8
 
 training:
+    name: "sdss_galaxy_encoder"
     model: ${models.galaxy_encoder}
     dataset: ${datasets.simulated}
     optimizer:

--- a/config/training/sdss_galaxy_encoder_real.yaml
+++ b/config/training/sdss_galaxy_encoder_real.yaml
@@ -5,7 +5,7 @@ dataset:
 models:
   galaxy_encoder:
     crop_loss_at_border: True
-    checkpoint_path: "models/sdss_galaxy_encoder.ckpt"
+    checkpoint_path: "models/sdss_galaxy_encoder.pt"
     max_flux_valid_plots: 1200
   prior:
     mean_sources: 0.04

--- a/config/training/sdss_galaxy_encoder_real.yaml
+++ b/config/training/sdss_galaxy_encoder_real.yaml
@@ -11,6 +11,7 @@ models:
     mean_sources: 0.04
 
 training:
+  name: "sdss_galaxy_encoder_real"
   model: ${models.galaxy_encoder}
   dataset: ${datasets.sdss_blended_galaxies}
   optimizer:

--- a/config/training/sdss_sleep.yaml
+++ b/config/training/sdss_sleep.yaml
@@ -1,5 +1,6 @@
 # @package _global_
 training:
+  name: "sdss_sleep"
   model: ${models.sleep}
   dataset: ${datasets.simulated}
   optimizer:

--- a/models/Makefile
+++ b/models/Makefile
@@ -1,19 +1,19 @@
 OUTPUT_DIR:=../output/train_all
 
-all: sdss_autoencoder.ckpt sdss_binary.ckpt sdss_galaxy_encoder.ckpt sdss_sleep.ckpt
+all: sdss_autoencoder.pt sdss_binary.pt sdss_galaxy_encoder.pt sdss_sleep.pt
 
-sdss_autoencoder.ckpt: 
+sdss_autoencoder.pt:
 	./run_experiment.sh $(OUTPUT_DIR) sdss_autoencoder
 	rm -f ../data/latents_simulated_sdss_galaxies.pt
 
-sdss_binary.ckpt: sdss_autoencoder.ckpt
+sdss_binary.pt: sdss_autoencoder.pt
 	./run_experiment.sh $(OUTPUT_DIR) sdss_binary
 
-sdss_galaxy_encoder.ckpt: sdss_autoencoder.ckpt
+sdss_galaxy_encoder.pt: sdss_autoencoder.pt
 	./run_experiment.sh $(OUTPUT_DIR) sdss_galaxy_encoder
 
-sdss_sleep.ckpt: sdss_autoencoder.ckpt
+sdss_sleep.pt: sdss_autoencoder.pt
 	./run_experiment.sh $(OUTPUT_DIR) sdss_sleep
 
-sdss_galaxy_encoder_real.ckpt: sdss_sleep.ckpt sdss_autoencoder.ckpt
+sdss_galaxy_encoder_real.pt: sdss_sleep.pt sdss_autoencoder.pt
 	./run_experiment.sh $(OUTPUT_DIR) sdss_galaxy_encoder_real

--- a/models/convert_checkpoints.py
+++ b/models/convert_checkpoints.py
@@ -6,7 +6,13 @@ from bliss.models.galaxy_encoder import GalaxyEncoder
 from bliss.sleep import SleepPhase
 
 models = [OneCenteredGalaxyAE, BinaryEncoder, GalaxyEncoder, SleepPhase, GalaxyEncoder]
-checkpoints = ["sdss_autoencoder", "sdss_binary", "sdss_galaxy_encoder", "sdss_sleep", "sdss_galaxy_encoder_real"]
+checkpoints = [
+    "sdss_autoencoder",
+    "sdss_binary",
+    "sdss_galaxy_encoder",
+    "sdss_sleep",
+    "sdss_galaxy_encoder_real",
+]
 
 for model, checkpoint in zip(models, checkpoints):
     m = model.load_from_checkpoint("models/" + checkpoint + ".ckpt")

--- a/models/convert_checkpoints.py
+++ b/models/convert_checkpoints.py
@@ -1,0 +1,13 @@
+import torch
+
+from bliss.models.galaxy_net import OneCenteredGalaxyAE
+from bliss.models.binary import BinaryEncoder
+from bliss.models.galaxy_encoder import GalaxyEncoder
+from bliss.sleep import SleepPhase
+
+models = [OneCenteredGalaxyAE, BinaryEncoder, GalaxyEncoder, SleepPhase, GalaxyEncoder]
+checkpoints = ["sdss_autoencoder", "sdss_binary", "sdss_galaxy_encoder", "sdss_sleep", "sdss_galaxy_encoder_real"]
+
+for model, checkpoint in zip(models, checkpoints):
+    m = model.load_from_checkpoint("models/" + checkpoint + ".ckpt")
+    torch.save(m.state_dict(), "models/" + checkpoint + ".pt")

--- a/models/run_experiment.sh
+++ b/models/run_experiment.sh
@@ -7,9 +7,3 @@ echo "Starting $EXPERIMENT..."
 EXP_DIR=$OUTPUT_DIR/default/$EXPERIMENT
 rm -rf $EXP_DIR
 bliss mode=train training=$EXPERIMENT training.save_top_k=1 paths.output=`realpath $OUTPUT_DIR` training.version=$EXPERIMENT
-CKPT=`find $EXP_DIR/checkpoints | tail -n 1`
-cp $CKPT ./$EXPERIMENT.ckpt
-RESULTS=${EXPERIMENT}_results
-echo $EXPERIMENT > ./${RESULTS}
-basename $CKPT >> ./${RESULTS}
-echo >> ./${RESULTS}

--- a/models/sdss_autoencoder.ckpt
+++ b/models/sdss_autoencoder.ckpt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8f356ad35df4d36be507a21a5dd01afe4698eb7ff61bac0d3be48e0c48b65ed
-size 39412862

--- a/models/sdss_autoencoder.pt
+++ b/models/sdss_autoencoder.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b0e081ae6ce889916ef9f640e1546114d0c0512978d7aed4f5f80b5897eda23
+size 13175406

--- a/models/sdss_binary.ckpt
+++ b/models/sdss_binary.ckpt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0783c08e56118169e759cb97138ab8b48fa18f0f2cf0fb694437ff030922c1e2
-size 7098256

--- a/models/sdss_binary.pt
+++ b/models/sdss_binary.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10f8dc14e2378a139ed139b8f2ee9a48d0eaa0d2ad25f6e6a46d649d5586baf3
+size 2384548

--- a/models/sdss_galaxy_encoder.ckpt
+++ b/models/sdss_galaxy_encoder.ckpt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73f7fd76b8c397d190cba6acd76ccb02042c9e3f401ee41294b5c69ede6cca8c
-size 36818015

--- a/models/sdss_galaxy_encoder.pt
+++ b/models/sdss_galaxy_encoder.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ececf3264380adee2bf0b680faef5afe3842ca94bb92605ff80fd0621c16430c
+size 20964669

--- a/models/sdss_galaxy_encoder_real.ckpt
+++ b/models/sdss_galaxy_encoder_real.ckpt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86c516a256c8d3ec303512ad75799f5684cf12a6f6e3e0718fe80d2b5fee6b82
-size 36816785

--- a/models/sdss_galaxy_encoder_real.pt
+++ b/models/sdss_galaxy_encoder_real.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfe45453c4cde1b2bc79b60645e1abfb552966bd0ebd8c0ff6e3395aca83782a
+size 20964294

--- a/models/sdss_sleep.ckpt
+++ b/models/sdss_sleep.ckpt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9589cdecfdebe44461f14246ab41a2de3e9abc7320b5d2e02170405432bef709
-size 22511402

--- a/models/sdss_sleep.pt
+++ b/models/sdss_sleep.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bde1228c3e4ec8ae11aacf3999c7e9a6f3515e0fb09cd004c1ba53c764ed9f3
+size 16209013

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,11 @@ def pytest_collection_modifyitems(config, items):
 
 def get_cfg(overrides, devices):
     overrides.update({"gpus": devices.gpus})
+    overrides.update(
+        {
+            "training.weight_save_path": None,
+        }
+    )
     overrides = [f"{k}={v}" if v is not None else f"{k}=null" for k, v in overrides.items()]
     with initialize(config_path="../config"):
         cfg = compose("config", overrides=overrides)
@@ -58,7 +63,6 @@ class ModelSetup:
                 "training.trainer.logger": False,
                 "training.trainer.check_val_every_n_epoch": 1001,
                 "training.trainer.deterministic": True,
-                "training.weight_save_path": None,
             }
         )
         cfg = self.get_cfg(overrides)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ class ModelSetup:
                 "training.trainer.logger": False,
                 "training.trainer.check_val_every_n_epoch": 1001,
                 "training.trainer.deterministic": True,
+                "training.weight_save_path": None,
             }
         )
         cfg = self.get_cfg(overrides)

--- a/tests/m2/m2.yaml
+++ b/tests/m2/m2.yaml
@@ -45,6 +45,7 @@ models:
           - 2
           - 3
     encoder:
+        _target_: bliss.models.location_encoder.LocationEncoder
         n_bands: ${models.decoder.n_bands}
         tile_slen: ${models.decoder.tile_slen}
         ptile_slen: 8

--- a/tests/m2/m2.yaml
+++ b/tests/m2/m2.yaml
@@ -54,6 +54,7 @@ models:
         dropout: 0.013123
         hidden: 185
     prior: 
+        _target_: bliss.models.prior.ImagePrior
         n_bands: 2
         slen: 100
         tile_slen: 2
@@ -94,6 +95,7 @@ training:
       gpus: ${gpus}
       log_every_n_steps: 10
       deterministic: False
+    weight_save_path:
 
 tuning:
     model: "{models.sleep}"

--- a/tests/m2/m2.yaml
+++ b/tests/m2/m2.yaml
@@ -31,6 +31,7 @@ datasets:
 
 models:
     decoder:
+        _target_: bliss.models.decoder.ImageDecoder
         n_bands: 2
         slen: 100
         tile_slen: 2


### PR DESCRIPTION
This change converts the stored model checkpoints for the sdss_galaxy project into state dicts. 

A PyTorch Lightning checkpoint stores everything associated with a model (initial arguments, optimizer state, state_dict), while a Torch state_dict is just the states of the trained parameters. Effectively, this means that the PL checkpoint is storing both configuration and state, while the Torch checkpoint is just storing state.

With the change to the Hydra config (#396), we can now just load the config with Hydra and only save the state of each trained object. These saved state_dict files take up much less space on disk, and now configuration is no longer hidden in the checkpoint file; all configuration is in the Hydra config.