### PR TITLE
Remove BLISS_HOME dependency and improve path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ poetry install
 poetry shell
 ```
 
-4. Finally, set an environment variable called `BLISS_HOME` to the absolute path of the `bliss` directory.
-
 # Latest updates
 ### Galaxies
    - BLISS now includes a galaxy model based on a VAE that was trained on Galsim galaxies.

--- a/bliss/__init__.py
+++ b/bliss/__init__.py
@@ -1,6 +1,0 @@
-from os import environ, getenv
-from pathlib import Path
-
-if getenv("BLISS_HOME") is None:
-    bliss_path = Path(__file__).resolve()
-    environ["BLISS_HOME"] = bliss_path.parent.parent.as_posix()

--- a/case_studies/sdss_galaxies/main.py
+++ b/case_studies/sdss_galaxies/main.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
+from os import getenv, environ
+from pathlib import Path
+
 import hydra
+
+if not getenv("BLISS_HOME"):
+    project_path = Path(__file__).resolve()
+    bliss_home = project_path.parents[2]
+    environ["BLISS_HOME"] = bliss_home.as_posix()
 
 
 @hydra.main(config_path="./config", config_name="config")

--- a/case_studies/sdss_galaxies/tests/conftest.py
+++ b/case_studies/sdss_galaxies/tests/conftest.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import pytorch_lightning as pl
 import torch
@@ -9,8 +11,13 @@ from hydra.utils import instantiate
 
 
 def get_cfg(overrides, devices):
-    overrides.update({"gpus": devices.gpus})
-    overrides.update({"training.weight_save_path": None})
+    overrides.update(
+        {
+            "paths.root": Path(__file__).parents[3].as_posix(),
+            "gpus": devices.gpus,
+            "training.weight_save_path": None,
+        }
+    )
     overrides = [f"{k}={v}" if v is not None else f"{k}=null" for k, v in overrides.items()]
     with initialize(config_path="../config"):
         cfg = compose("config", overrides=overrides)
@@ -69,13 +76,6 @@ class ModelSetup:
         test_module = self.get_dataset_for_training(overrides)
         trainer = self.get_trainer(overrides)
         return trainer.test(model, datamodule=test_module)[0]
-
-
-@pytest.fixture(scope="session")
-def paths():
-    with initialize(config_path="../config"):
-        cfg = compose("config")
-    return cfg.paths
 
 
 @pytest.fixture(scope="session")

--- a/case_studies/sdss_galaxies/tests/test_generate.py
+++ b/case_studies/sdss_galaxies/tests/test_generate.py
@@ -11,7 +11,7 @@ class TestGenerate:
         return {
             "generate.dataset": "${datasets.simulated}",
             "datasets.simulated.generate_device": "cuda:0" if devices.use_cuda else "cpu",
-            "generate.file": "{paths.root}/example.pt",
+            "generate.file": "${paths.root}/example.pt",
             "generate.common": ["background", "slen"],
         }
 

--- a/case_studies/sdss_galaxies/tests/test_generate.py
+++ b/case_studies/sdss_galaxies/tests/test_generate.py
@@ -7,17 +7,17 @@ from bliss import generate
 
 class TestGenerate:
     @pytest.fixture(scope="class")
-    def overrides(self, devices, paths):
+    def overrides(self, devices):
         return {
             "generate.dataset": "${datasets.simulated}",
             "datasets.simulated.generate_device": "cuda:0" if devices.use_cuda else "cpu",
-            "generate.file": f"{paths['root']}/example.pt",
+            "generate.file": "{paths.root}/example.pt",
             "generate.common": ["background", "slen"],
         }
 
-    def test_generate_run(self, devices, paths, overrides, get_config):
+    def test_generate_run(self, devices, overrides, get_config):
         cfg = get_config(overrides, devices)
         generate.generate(cfg)
 
-        os.remove(f"{paths['root']}/example.pt")
-        os.remove(f"{paths['root']}/example_images.pdf")
+        os.remove(f"{cfg.paths.root}/example.pt")
+        os.remove(f"{cfg.paths.root}/example_images.pdf")

--- a/case_studies/sdss_galaxies/tests/test_reporting.py
+++ b/case_studies/sdss_galaxies/tests/test_reporting.py
@@ -18,7 +18,7 @@ def test_scene_metrics():
     reporting.scene_metrics(true_params, true_params, mag_cut=25, slack=1.0, mag_slack=0.25)
 
 
-def test_coadd(paths, devices, get_config):
+def test_coadd(devices, get_config):
 
     # get psf
     cfg = get_config({}, devices)
@@ -26,7 +26,7 @@ def test_coadd(paths, devices, get_config):
     psf = ds.psf
 
     # read file and get flux / hlr
-    coadd_cat_file = Path(paths["data"]).joinpath("coadd_catalog_94_1_12.fits")
+    coadd_cat_file = Path(cfg.paths.data).joinpath("coadd_catalog_94_1_12.fits")
     coadd_cat = Table.read(coadd_cat_file)[:5]
     coadd_cat.remove_column("hlr")
     _ = reporting.get_flux_coadd(coadd_cat)

--- a/case_studies/sdss_galaxies/tests/test_sdss.py
+++ b/case_studies/sdss_galaxies/tests/test_sdss.py
@@ -5,8 +5,9 @@ from bliss.datasets.sdss import SloanDigitalSkySurvey
 
 
 class TestSDSS:
-    def test_sdss(self, paths):
-        sdss_dir = paths["sdss"]
+    def test_sdss(self, devices, get_config):
+        cfg = get_config({}, devices)
+        sdss_dir = cfg.paths.sdss
         sdss_obj = SloanDigitalSkySurvey(
             sdss_dir,
             run=3900,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import pytorch_lightning as pl
 import torch
@@ -28,9 +30,7 @@ def pytest_collection_modifyitems(config, items):
 def get_cfg(overrides, devices):
     overrides.update({"gpus": devices.gpus})
     overrides.update(
-        {
-            "training.weight_save_path": None,
-        }
+        {"training.weight_save_path": None, "paths.root": Path(__file__).parents[1].as_posix()}
     )
     overrides = [f"{k}={v}" if v is not None else f"{k}=null" for k, v in overrides.items()]
     with initialize(config_path="../config"):

--- a/tests/m2/conftest.py
+++ b/tests/m2/conftest.py
@@ -5,7 +5,7 @@ from tests.conftest import ModelSetup
 
 
 def get_m2_cfg(overrides, devices):
-    overrides.update({"gpus": devices.gpus})
+    overrides.update({"gpus": devices.gpus, "paths.root": Path(__file__).parents[2].as_posix()})
     overrides = [f"{k}={v}" if v is not None else f"{k}=null" for k, v in overrides.items()]
     with initialize(config_path="."):
         cfg = compose("m2", overrides=overrides)
@@ -20,8 +20,3 @@ class M2ModelSetup(ModelSetup):
 @pytest.fixture(scope="session")
 def m2_model_setup(devices):
     return M2ModelSetup(devices)
-
-
-@pytest.fixture(scope="session")
-def paths(devices):
-    return get_m2_cfg({}, devices).paths

--- a/tests/m2/conftest.py
+++ b/tests/m2/conftest.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from hydra import compose, initialize
 

--- a/tests/m2/m2.yaml
+++ b/tests/m2/m2.yaml
@@ -14,7 +14,7 @@ mode: train
 gpus: 1 # use a single gpu by default.
 
 paths:
-  root: ${oc.env:BLISS_HOME}
+  root:
   output: ${paths.root}/output
   sdss: ${paths.root}/data/sdss
   data: ${paths.root}/data

--- a/tests/m2/test_m2.py
+++ b/tests/m2/test_m2.py
@@ -80,9 +80,9 @@ def get_map_estimate(image_encoder, images, slen: int, wlen: int = None):
 
 
 class TestStarSleepEncoderM2:
-    def test_star_sleep_m2(self, trained_star_encoder_m2, devices):
+    def test_star_sleep_m2(self, trained_star_encoder_m2, devices, m2_model_setup):
         device = devices.device
-
+        cfg = m2_model_setup.get_cfg({})
         # the trained star encoder
         trained_star_encoder_m2.eval()
 

--- a/tests/m2/test_m2.py
+++ b/tests/m2/test_m2.py
@@ -80,14 +80,14 @@ def get_map_estimate(image_encoder, images, slen: int, wlen: int = None):
 
 
 class TestStarSleepEncoderM2:
-    def test_star_sleep_m2(self, trained_star_encoder_m2, devices, paths):
+    def test_star_sleep_m2(self, trained_star_encoder_m2, devices):
         device = devices.device
 
         # the trained star encoder
         trained_star_encoder_m2.eval()
 
         # load hubble parameters and SDSS image
-        hubble_data = np.load(os.path.join(paths["data"], "true_hubble_m2.npz"))
+        hubble_data = np.load(os.path.join(cfg.paths.data, "true_hubble_m2.npz"))
 
         # the SDSS image
         test_image = torch.from_numpy(hubble_data["sdss_image"]).unsqueeze(0).to(device)

--- a/tests/m2/test_tune.py
+++ b/tests/m2/test_tune.py
@@ -27,7 +27,7 @@ class TestTune:
             "tuning.verbose": 0,
             "tuning.save": False,
             "tuning.n_samples": 2 if devices.use_cuda else 1,
-            "tuning.log_path": f"{paths['root']}/tuning",
+            "tuning.log_path": "${paths.root}/tuning",
         }
 
         if not devices.use_cuda:

--- a/tests/m2/test_tune.py
+++ b/tests/m2/test_tune.py
@@ -8,7 +8,7 @@ from bliss import tune
 
 class TestTune:
     @pytest.fixture(scope="class")
-    def overrides(self, devices, paths):
+    def overrides(self, devices):
         allocated_gpus = 0
         gpus_per_trial = 0
         if devices.use_cuda:
@@ -42,7 +42,7 @@ class TestTune:
         return overrides
 
     @pytest.mark.filterwarnings("ignore:.*Relying on `self.log.*:DeprecationWarning")
-    def test_tune_run(self, paths, overrides, m2_model_setup):
+    def test_tune_run(self, overrides, m2_model_setup):
         cfg = m2_model_setup.get_cfg(overrides)
         tune.tune(cfg)
-        shutil.rmtree(f"{paths['root']}/tuning")
+        shutil.rmtree(f"{cfg.paths.root}/tuning")


### PR DESCRIPTION
Closes #361. This will greatly simplify the pathing issue, since the need to set BLISS_HOME is delegated out to the specific folder directory. Along with the recent improvements to the Hydra configs, this will make setting different data directories outside the BLISS codebase trivial. (e.g. set "paths.sdss" to "/data/sdss").

To figure out where testing data files are, tests will use their own `__file__` absolute path.

