### PR TITLE
fixes isort/black clashing

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+profile = black
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+ensure_newline_before_comments = True
+line_length = 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
         entry: isort
         language: system
         types: [python]
-        args: [--profile black, --line-length 100, --multi-line 3]
       - id: pylint
         name: pylint
         entry: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,10 +23,10 @@ repos:
         exclude: ^(.*fits|.*pt|.*npz|.*ckpt|.*png|.*inv|.*npy)
       - id: isort
         name: isort
-        entry: isort --line-length 100
+        entry: isort
         language: system
         types: [python]
-        args: [--profile black, --line-length 100]
+        args: [--profile black, --line-length 100, --multi-line 3]
       - id: pylint
         name: pylint
         entry: pylint

--- a/bliss/encoder.py
+++ b/bliss/encoder.py
@@ -2,15 +2,15 @@
 from typing import Dict, Optional
 
 import torch
-from torch import nn, Tensor
+from torch import Tensor, nn
 
 from bliss.models.binary import BinaryEncoder
+from bliss.models.galaxy_encoder import GalaxyEncoder
 from bliss.models.location_encoder import (
     LocationEncoder,
     get_images_in_tiles,
     get_is_on_from_n_sources,
 )
-from bliss.models.galaxy_encoder import GalaxyEncoder
 
 
 class Encoder(nn.Module):
@@ -82,7 +82,7 @@ class Encoder(nn.Module):
 
         Returns:
             A dictionary of the maximum a posteriori
-            of the catalog. Specifically, this dictionary comprises:
+            of the catalog in tiles. Specifically, this dictionary comprises:
             - The output of LocationEncoder.max_a_post()
             - 'galaxy_bool', 'star_bool', and 'prob_galaxy' from BinaryEncoder.
             - 'galaxy_param' from GalaxyEncoder.

--- a/bliss/inference.py
+++ b/bliss/inference.py
@@ -1,16 +1,16 @@
 import math
-from typing import List, Dict, Tuple
+from typing import Dict, List, Tuple
 
 import torch
+from einops import rearrange, repeat
 from torch import Tensor
 from torch.nn import functional as F
-from einops import rearrange, repeat
 from tqdm import tqdm
 
+from bliss.datasets.sdss_blended_galaxies import cpu
 from bliss.encoder import Encoder
 from bliss.models.decoder import ImageDecoder
 from bliss.models.location_encoder import get_full_params_from_tiles, get_params_in_batches
-from bliss.datasets.sdss_blended_galaxies import cpu
 
 
 def reconstruct_scene_at_coordinates(

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -1,22 +1,22 @@
 """Scripts to produce BLISS estimates on survey images. Currently only SDSS is supported."""
 import torch
 from einops import rearrange
+from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 from tqdm import tqdm
-from hydra.utils import instantiate
 
 from bliss.datasets import sdss
 from bliss.models.binary import BinaryEncoder
-from bliss.models.location_encoder import (
-    LocationEncoder,
-    get_is_on_from_n_sources,
-    get_images_in_tiles,
-    get_n_tiles_hw,
-    get_params_in_batches,
-    get_full_params_from_tiles,
-)
 from bliss.models.galaxy_encoder import GalaxyEncoder
 from bliss.models.galaxy_net import OneCenteredGalaxyDecoder
+from bliss.models.location_encoder import (
+    LocationEncoder,
+    get_full_params_from_tiles,
+    get_images_in_tiles,
+    get_is_on_from_n_sources,
+    get_n_tiles_hw,
+    get_params_in_batches,
+)
 
 
 def predict_on_image(


### PR DESCRIPTION
Fixes very annoying error when doing multi-line imports that basically makes committing impossible. 

Not sure if better to get rid of multi-line imports, but since the functions names are very explicit and long I think this is better. 