### PR TITLE
Simplify SloanDigitalSkyDataset by removing bright stars functionality

### DIFF
--- a/bliss/datasets/sdss.py
+++ b/bliss/datasets/sdss.py
@@ -77,11 +77,7 @@ class SloanDigitalSkySurvey(Dataset):
                 ret[k] = np.stack(data_per_band)
             else:
                 ret[k] = data_per_band
-        ret.update(
-            {
-                "field": field,
-            }
-        )
+        ret.update({"field": field})
         return ret
 
     def read_frame_for_band(self, bl, field_dir, run, camcol, field, gain):

--- a/bliss/datasets/sdss.py
+++ b/bliss/datasets/sdss.py
@@ -23,138 +23,138 @@ def convert_flux_to_mag(flux, nelec_per_nmgy=987.31):
     return 22.5 - 2.5 * np.log10(flux / nelec_per_nmgy)
 
 
-class StarStamper:
-    def __init__(self, stampsize, center_subpixel=True, grid_dtype=torch.float):
-        self.stampsize = stampsize
-        self.center_subpixel = center_subpixel
-        self.grid_dtype = grid_dtype
-        if self.center_subpixel:
-            self.G = self._construct_subpixel_grid_base()
-        else:
-            self.G = None
+# class StarStamper:
+#     def __init__(self, stampsize, center_subpixel=True, grid_dtype=torch.float):
+#         self.stampsize = stampsize
+#         self.center_subpixel = center_subpixel
+#         self.grid_dtype = grid_dtype
+#         if self.center_subpixel:
+#             self.G = self._construct_subpixel_grid_base()
+#         else:
+#             self.G = None
 
-    def __call__(self, img, pts, prs, bg=None):
-        stamps = []
-        is_edge = []
-        bgs = []
-        for (pt, pr) in zip(pts, prs):
-            pti, pri = int(pt + 0.5), int(pr + 0.5)
+#     def __call__(self, img, pts, prs, bg=None):
+#         stamps = []
+#         is_edge = []
+#         bgs = []
+#         for (pt, pr) in zip(pts, prs):
+#             pti, pri = int(pt + 0.5), int(pr + 0.5)
 
-            row_lower = pri - self.stampsize // 2
-            row_upper = pri + self.stampsize // 2 + 1
-            col_lower = pti - self.stampsize // 2
-            col_upper = pti + self.stampsize // 2 + 1
+#             row_lower = pri - self.stampsize // 2
+#             row_upper = pri + self.stampsize // 2 + 1
+#             col_lower = pti - self.stampsize // 2
+#             col_upper = pti + self.stampsize // 2 + 1
 
-            edge_stamp = (
-                (row_lower < 0)
-                or (row_upper > img.shape[0])
-                or (col_lower < 0)
-                or (col_upper > img.shape[1])
-            )
+#             edge_stamp = (
+#                 (row_lower < 0)
+#                 or (row_upper > img.shape[0])
+#                 or (col_lower < 0)
+#                 or (col_upper > img.shape[1])
+#             )
 
-            is_edge.append(edge_stamp)
+#             is_edge.append(edge_stamp)
 
-            if not edge_stamp:
-                stamp = img[row_lower:row_upper, col_lower:col_upper]
-                stamps.append(stamp)
-                if bg is not None:
-                    stamp_bg = bg[row_lower:row_upper, col_lower:col_upper]
-                    bgs.append(stamp_bg)
+#             if not edge_stamp:
+#                 stamp = img[row_lower:row_upper, col_lower:col_upper]
+#                 stamps.append(stamp)
+#                 if bg is not None:
+#                     stamp_bg = bg[row_lower:row_upper, col_lower:col_upper]
+#                     bgs.append(stamp_bg)
 
-        stamps = torch.stack(stamps)
-        is_edge = torch.tensor(is_edge, device=img.device)
-        if self.center_subpixel:
-            stamps = self._center_stamps_subpixel(stamps, pts[~is_edge], prs[~is_edge])
+#         stamps = torch.stack(stamps)
+#         is_edge = torch.tensor(is_edge, device=img.device)
+#         if self.center_subpixel:
+#             stamps = self._center_stamps_subpixel(stamps, pts[~is_edge], prs[~is_edge])
 
-        return (
-            stamps,
-            None if bg is None else torch.stack(bgs),
-            is_edge,
-        )
+#         return (
+#             stamps,
+#             None if bg is None else torch.stack(bgs),
+#             is_edge,
+#         )
 
-    def _construct_subpixel_grid_base(self):
-        grid_x = np.linspace(-1.0, 1.0, num=self.stampsize)
-        grid_y = np.linspace(-1.0, 1.0, num=self.stampsize)
+#     def _construct_subpixel_grid_base(self):
+#         grid_x = np.linspace(-1.0, 1.0, num=self.stampsize)
+#         grid_y = np.linspace(-1.0, 1.0, num=self.stampsize)
 
-        G_x = torch.stack([torch.from_numpy(grid_x)] * self.stampsize, dim=0)
-        G_y = torch.stack([torch.from_numpy(grid_y)] * self.stampsize, dim=1)
+#         G_x = torch.stack([torch.from_numpy(grid_x)] * self.stampsize, dim=0)
+#         G_y = torch.stack([torch.from_numpy(grid_y)] * self.stampsize, dim=1)
 
-        G = rearrange([G_x, G_y], "n x y -> 1 x y n")
+#         G = rearrange([G_x, G_y], "n x y -> 1 x y n")
 
-        return G.type(self.grid_dtype)
+#         return G.type(self.grid_dtype)
 
-    def _center_stamps_subpixel(
-        self,
-        stamps,
-        pts,
-        prs,
-    ):
-        locs = torch.stack([pts, prs], dim=1)
-        shifts = (
-            2
-            * (locs - (locs + 0.5).trunc())
-            / torch.tensor(stamps.shape[1:], device=stamps.device).unsqueeze(0)
-        )
-        if self.G.device is not shifts.device:
-            self.G = self.G.to(shifts.device)
-        shifts = shifts.type(self.G.dtype)
-        G_shift = self.G + shifts.unsqueeze(1).unsqueeze(1)
-        stamps_shifted = F.grid_sample(stamps.unsqueeze(1), G_shift, align_corners=False)
-        return stamps_shifted.squeeze(1)
+#     def _center_stamps_subpixel(
+#         self,
+#         stamps,
+#         pts,
+#         prs,
+#     ):
+#         locs = torch.stack([pts, prs], dim=1)
+#         shifts = (
+#             2
+#             * (locs - (locs + 0.5).trunc())
+#             / torch.tensor(stamps.shape[1:], device=stamps.device).unsqueeze(0)
+#         )
+#         if self.G.device is not shifts.device:
+#             self.G = self.G.to(shifts.device)
+#         shifts = shifts.type(self.G.dtype)
+#         G_shift = self.G + shifts.unsqueeze(1).unsqueeze(1)
+#         stamps_shifted = F.grid_sample(stamps.unsqueeze(1), G_shift, align_corners=False)
+#         return stamps_shifted.squeeze(1)
 
 
-class SdssPSF:
-    def __init__(self, psf_fit_file, bands):
-        self.psf_fit_file = psf_fit_file
-        self.bands = bands
-        self.cache = [None] * len(self.bands)
+# class SdssPSF:
+#     def __init__(self, psf_fit_file, bands):
+#         self.psf_fit_file = psf_fit_file
+#         self.bands = bands
+#         self.cache = [None] * len(self.bands)
 
-    def __getitem__(self, idx):
-        if self.cache[idx] is None:
-            x = self.read_psf(self.bands[idx])
-            self.cache[idx] = x
-        return self.cache[idx]
+#     def __getitem__(self, idx):
+#         if self.cache[idx] is None:
+#             x = self.read_psf(self.bands[idx])
+#             self.cache[idx] = x
+#         return self.cache[idx]
 
-    def read_psf(self, band):
-        psfield = fits.open(self.psf_fit_file)
-        hdu = psfield[band + 1]
-        return hdu.data
+#     def read_psf(self, band):
+#         psfield = fits.open(self.psf_fit_file)
+#         hdu = psfield[band + 1]
+#         return hdu.data
 
-    def psf_at_points(self, idx, x, y):
-        psf = self[idx]
-        rtnscalar = np.isscalar(x) and np.isscalar(y)
-        x = np.atleast_1d(x)
-        y = np.atleast_1d(y)
+#     def psf_at_points(self, idx, x, y):
+#         psf = self[idx]
+#         rtnscalar = np.isscalar(x) and np.isscalar(y)
+#         x = np.atleast_1d(x)
+#         y = np.atleast_1d(y)
 
-        psfimgs = None
-        (outh, outw) = (None, None)
+#         psfimgs = None
+#         (outh, outw) = (None, None)
 
-        # From the IDL docs:
-        # http://photo.astro.princeton.edu/photoop_doc.html#SDSS_PSF_RECON
-        #   acoeff_k = SUM_i{ SUM_j{ (0.001*ROWC)^i * (0.001*COLC)^j * C_k_ij } }
-        #   psfimage = SUM_k{ acoeff_k * RROWS_k }
-        for k, psf_k in enumerate(psf):
-            nrb = psf_k["nrow_b"]
-            ncb = psf_k["ncol_b"]
+#         # From the IDL docs:
+#         # http://photo.astro.princeton.edu/photoop_doc.html#SDSS_PSF_RECON
+#         #   acoeff_k = SUM_i{ SUM_j{ (0.001*ROWC)^i * (0.001*COLC)^j * C_k_ij } }
+#         #   psfimage = SUM_k{ acoeff_k * RROWS_k }
+#         for k, psf_k in enumerate(psf):
+#             nrb = psf_k["nrow_b"]
+#             ncb = psf_k["ncol_b"]
 
-            c = psf_k["c"].reshape(5, 5)
-            c = c[:nrb, :ncb]
+#             c = psf_k["c"].reshape(5, 5)
+#             c = c[:nrb, :ncb]
 
-            (gridi, gridj) = np.meshgrid(range(nrb), range(ncb))
+#             (gridi, gridj) = np.meshgrid(range(nrb), range(ncb))
 
-            if psfimgs is None:
-                psfimgs = [np.zeros_like(psf["rrows"][k]) for xy in np.broadcast(x, y)]
-                (outh, outw) = (psf["rnrow"][k], psf["rncol"][k])
+#             if psfimgs is None:
+#                 psfimgs = [np.zeros_like(psf["rrows"][k]) for xy in np.broadcast(x, y)]
+#                 (outh, outw) = (psf["rnrow"][k], psf["rncol"][k])
 
-            for i, (xi, yi) in enumerate(np.broadcast(x, y)):
-                acoeff_k = (((0.001 * xi) ** gridi * (0.001 * yi) ** gridj * c)).sum()
-                psfimgs[i] += acoeff_k * psf["rrows"][k]
+#             for i, (xi, yi) in enumerate(np.broadcast(x, y)):
+#                 acoeff_k = (((0.001 * xi) ** gridi * (0.001 * yi) ** gridj * c)).sum()
+#                 psfimgs[i] += acoeff_k * psf["rrows"][k]
 
-        psfimgs = [img.reshape((outh, outw)) for img in psfimgs]
+#         psfimgs = [img.reshape((outh, outw)) for img in psfimgs]
 
-        if rtnscalar:
-            return psfimgs[0]
-        return psfimgs
+#         if rtnscalar:
+#             return psfimgs[0]
+#         return psfimgs
 
 
 class SloanDigitalSkySurvey(Dataset):
@@ -166,20 +166,20 @@ class SloanDigitalSkySurvey(Dataset):
         camcol=6,
         fields=(269,),
         bands=(0, 1, 2, 3, 4),
-        stampsize=5,
-        overwrite_fits_cache=False,
-        overwrite_cache=False,
-        center_subpixel=True,
+        # stampsize=5,
+        # overwrite_fits_cache=False,
+        # overwrite_cache=False,
+        # center_subpixel=True,
     ):
         super().__init__()
 
         self.sdss_path = pathlib.Path(sdss_dir)
         self.rcfgcs = []
         self.bands = bands
-        self.stampsize = stampsize
-        self.overwrite_cache = overwrite_cache
-        self.center_subpixel = center_subpixel
-        self.stamper = StarStamper(stampsize, center_subpixel=center_subpixel)
+        # self.stampsize = stampsize
+        # self.overwrite_cache = overwrite_cache
+        # self.center_subpixel = center_subpixel
+        # self.stamper = StarStamper(stampsize, center_subpixel=center_subpixel)
         # meta data for the run + camcol
         pf_file = f"photoField-{run:06d}-{camcol:d}.fits"
         camcol_path = self.sdss_path.joinpath(str(run), str(camcol))
@@ -193,105 +193,104 @@ class SloanDigitalSkySurvey(Dataset):
         for i, field in enumerate(fieldnums):
             gain = fieldgains[i]
             if (not fields) or field in fields:
-                # load the catalog distributed with SDSS
-                po_file = f"photoObj-{run:06d}-{camcol:d}-{field:04d}.fits"
-                po_cache = f"photoObj-{run:06d}-{camcol:d}-{field:04d}.pkl"
-                po_path = camcol_path.joinpath(str(field), po_file)
-                po_cache_path = camcol_path.joinpath(str(field), po_cache)
-                if (not po_cache_path.exists()) or (overwrite_fits_cache):
-                    try:
-                        po_fits = fits.getdata(po_path)
-                    except IndexError as e:
-                        print(
-                            f"INFO: IndexError while accessing field: {field}. "
-                            "This field will not be included.\n"
-                        )
-                        print(e)
-                        po_fits = None
-                    pickle.dump(po_fits, po_cache_path.open("wb+"))
-                else:
-                    po_fits = pickle.load(po_cache_path.open("rb+"))
-                    if po_fits is None:
-                        print(
-                            f"INFO: cached data for field {field} is None. "
-                            "This field will not be included"
-                        )
-
-                # Load the PSF produced by SDSS
-                psf_file = f"psField-{run:06d}-{camcol:d}-{field:04d}.fits"
-                psf_cache = f"psField-{run:06d}-{camcol:d}-{field:04d}.pkl"
-
-                psf_path = camcol_path.joinpath(str(field), psf_file)
-                psf_cache_path = camcol_path.joinpath(str(field), psf_cache)
-
-                try:
-                    psf = SdssPSF(psf_path.as_posix(), bands)
-                except IndexError as e:
-                    print(
-                        f"INFO: IndexError while accessing PSF for field: {field}. "
-                        "This field will not be included."
-                    )
-                    print(e)
-                    psf = None
-
-                pickle.dump(psf, psf_cache_path.open("wb+"))
-                if po_fits is not None:
-                    self.rcfgcs.append((run, camcol, field, gain, po_fits, psf))
+                self.rcfgcs.append((run, camcol, field, gain))
         self.items = [None] * len(self.rcfgcs)
-        self.cache_paths = [None] * len(self.rcfgcs)
+        #     # load the catalog distributed with SDSS
+        #     po_file = f"photoObj-{run:06d}-{camcol:d}-{field:04d}.fits"
+        #     po_cache = f"photoObj-{run:06d}-{camcol:d}-{field:04d}.pkl"
+        #     po_path = camcol_path.joinpath(str(field), po_file)
+        #     po_cache_path = camcol_path.joinpath(str(field), po_cache)
+        #     if (not po_cache_path.exists()) or (overwrite_fits_cache):
+        #         try:
+        #             po_fits = fits.getdata(po_path)
+        #         except IndexError as e:
+        #             print(
+        #                 f"INFO: IndexError while accessing field: {field}. "
+        #                 "This field will not be included.\n"
+        #             )
+        #             print(e)
+        #             po_fits = None
+        #         pickle.dump(po_fits, po_cache_path.open("wb+"))
+        #     else:
+        #         po_fits = pickle.load(po_cache_path.open("rb+"))
+        #         if po_fits is None:
+        #             print(
+        #                 f"INFO: cached data for field {field} is None. "
+        #                 "This field will not be included"
+        #             )
+
+        #     # Load the PSF produced by SDSS
+        #     psf_file = f"psField-{run:06d}-{camcol:d}-{field:04d}.fits"
+        #     psf_cache = f"psField-{run:06d}-{camcol:d}-{field:04d}.pkl"
+
+        #     psf_path = camcol_path.joinpath(str(field), psf_file)
+        #     psf_cache_path = camcol_path.joinpath(str(field), psf_cache)
+
+        #     try:
+        #         psf = SdssPSF(psf_path.as_posix(), bands)
+        #     except IndexError as e:
+        #         print(
+        #             f"INFO: IndexError while accessing PSF for field: {field}. "
+        #             "This field will not be included."
+        #         )
+        #         print(e)
+        #         psf = None
+
+        #     pickle.dump(psf, psf_cache_path.open("wb+"))
+        # self.cache_paths = [None] * len(self.rcfgcs)
 
     def __len__(self):
         return len(self.rcfgcs)
 
     def __getitem__(self, idx):
         if not self.items[idx]:
-            self.items[idx], self.cache_paths[idx] = self.get_from_disk(idx)
+            self.items[idx] = self.get_from_disk(idx)
         return self.items[idx]
 
-    def clear_cache(self):
-        for p in self.cache_paths:
-            if p is not None:
-                if p.exists():
-                    p.unlink()
+    # def clear_cache(self):
+    #     for p in self.cache_paths:
+    #         if p is not None:
+    #             if p.exists():
+    #                 p.unlink()
 
-    def fetch_bright_stars(self, po_fits, img, wcs, bg):
-        is_star = po_fits["objc_type"] == 6
-        is_bright = po_fits["psfflux"].sum(axis=1) > 100
-        is_thing = po_fits["thing_id"] != -1
-        is_target = is_star & is_bright & is_thing
+    # def fetch_bright_stars(self, po_fits, img, wcs, bg):
+    #     is_star = po_fits["objc_type"] == 6
+    #     is_bright = po_fits["psfflux"].sum(axis=1) > 100
+    #     is_thing = po_fits["thing_id"] != -1
+    #     is_target = is_star & is_bright & is_thing
 
-        ras = po_fits["ra"][is_target]
-        decs = po_fits["dec"][is_target]
-        pts = []
-        prs = []
-        for ra, dec in zip(ras, decs):
-            pt, pr = wcs.wcs_world2pix(ra, dec, 0)
-            pts.append(pt)
-            prs.append(pr)
-        pts = np.asarray(pts)
-        prs = np.asarray(prs)
-        fluxes = po_fits["psfflux"][is_target].sum(axis=1)
+    #     ras = po_fits["ra"][is_target]
+    #     decs = po_fits["dec"][is_target]
+    #     pts = []
+    #     prs = []
+    #     for ra, dec in zip(ras, decs):
+    #         pt, pr = wcs.wcs_world2pix(ra, dec, 0)
+    #         pts.append(pt)
+    #         prs.append(pr)
+    #     pts = np.asarray(pts)
+    #     prs = np.asarray(prs)
+    #     fluxes = po_fits["psfflux"][is_target].sum(axis=1)
 
-        stamps, bgs, is_edge = self.stamper(
-            torch.from_numpy(img),
-            torch.from_numpy(pts),
-            torch.from_numpy(prs),
-            bg=torch.from_numpy(bg),
-        )
-        is_edge = is_edge.numpy()
-        return (
-            stamps.numpy(),
-            pts[~is_edge],
-            prs[~is_edge],
-            fluxes[~is_edge],
-            bgs.numpy(),
-        )
+    #     stamps, bgs, is_edge = self.stamper(
+    #         torch.from_numpy(img),
+    #         torch.from_numpy(pts),
+    #         torch.from_numpy(prs),
+    #         bg=torch.from_numpy(bg),
+    #     )
+    #     is_edge = is_edge.numpy()
+    #     return (
+    #         stamps.numpy(),
+    #         pts[~is_edge],
+    #         prs[~is_edge],
+    #         fluxes[~is_edge],
+    #         bgs.numpy(),
+    #     )
 
     def get_from_disk(self, idx, verbose=False):
         # pylint: disable=too-many-statements
         if self.rcfgcs[idx] is None:
             return None
-        run, camcol, field, gain, po_fits, psf = self.rcfgcs[idx]
+        run, camcol, field, gain = self.rcfgcs[idx]
 
         camcol_dir = self.sdss_path.joinpath(str(run), str(camcol))
         field_dir = camcol_dir.joinpath(str(field))
@@ -303,14 +302,14 @@ class SloanDigitalSkySurvey(Dataset):
         gain_list = []
         wcs_list = []
 
-        cache_path = field_dir.joinpath(
-            f"cache_stmpsz{self.stampsize}_ctr{self.center_subpixel}.pkl"
-        )
-        if cache_path.exists() and not self.overwrite_cache:
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=FITSFixedWarning)
-                ret = pickle.load(cache_path.open("rb+"))
-            return ret, cache_path
+        # cache_path = field_dir.joinpath(
+        #     f"cache_stmpsz{self.stampsize}_ctr{self.center_subpixel}.pkl"
+        # )
+        # if cache_path.exists() and not self.overwrite_cache:
+        #     with warnings.catch_warnings():
+        #         warnings.filterwarnings("ignore", category=FITSFixedWarning)
+        #         ret = pickle.load(cache_path.open("rb+"))
+        #     return ret, cache_path
 
         for b, bl in enumerate("ugriz"):
             if b not in self.bands:
@@ -358,20 +357,20 @@ class SloanDigitalSkySurvey(Dataset):
             frame.close()
 
         # use 'r' band when possible.
-        if len(self.bands) > 2:
-            band_idx = 2
-        else:
-            band_idx = 0
+        # if len(self.bands) > 2:
+        #     band_idx = 2
+        # else:
+        #     band_idx = 0
 
-        stamps, pts, prs, fluxes, stamp_bgs = self.fetch_bright_stars(
-            po_fits, image_list[band_idx], wcs_list[band_idx], background_list[band_idx]
-        )
-        stamp_psfs = np.asarray(psf.psf_at_points(band_idx, pts, prs))
-        if stamp_bgs.size > 0:
-            psf_center = stamp_psfs.shape[-1] // 2
-            psf_lower = psf_center - floor(self.stampsize / 2)
-            psf_upper = psf_center + ceil(self.stampsize / 2)
-            stamp_psfs = stamp_psfs[:, psf_lower:psf_upper, psf_lower:psf_upper]
+        # stamps, pts, prs, fluxes, stamp_bgs = self.fetch_bright_stars(
+        #     po_fits, image_list[band_idx], wcs_list[band_idx], background_list[band_idx]
+        # )
+        # stamp_psfs = np.asarray(psf.psf_at_points(band_idx, pts, prs))
+        # if stamp_bgs.size > 0:
+        #     psf_center = stamp_psfs.shape[-1] // 2
+        #     psf_lower = psf_center - floor(self.stampsize / 2)
+        #     psf_upper = psf_center + ceil(self.stampsize / 2)
+        #     stamp_psfs = stamp_psfs[:, psf_lower:psf_upper, psf_lower:psf_upper]
 
         ret = {
             "image": np.stack(image_list),
@@ -381,14 +380,14 @@ class SloanDigitalSkySurvey(Dataset):
             "gain": np.stack(gain_list),
             "calibration": np.stack(calibration_list),
             "wcs": wcs_list,
-            "bright_stars": stamps,
-            "pts": pts,
-            "prs": prs,
-            "fluxes": fluxes,
-            "bright_star_bgs": stamp_bgs,
-            "sdss_psfs": stamp_psfs,
-            "po_fits": po_fits,
+            # "bright_stars": stamps,
+            # "pts": pts,
+            # "prs": prs,
+            # "fluxes": fluxes,
+            # "bright_star_bgs": stamp_bgs,
+            # "sdss_psfs": stamp_psfs,
+            # "po_fits": po_fits,
         }
-        pickle.dump(ret, cache_path.open("wb+"))
+        # pickle.dump(ret, cache_path.open("wb+"))
 
-        return ret, cache_path
+        return ret

--- a/bliss/datasets/sdss.py
+++ b/bliss/datasets/sdss.py
@@ -1,7 +1,5 @@
 import pathlib
-import pickle
 import warnings
-from math import ceil, floor
 
 import numpy as np
 import torch
@@ -23,140 +21,6 @@ def convert_flux_to_mag(flux, nelec_per_nmgy=987.31):
     return 22.5 - 2.5 * np.log10(flux / nelec_per_nmgy)
 
 
-# class StarStamper:
-#     def __init__(self, stampsize, center_subpixel=True, grid_dtype=torch.float):
-#         self.stampsize = stampsize
-#         self.center_subpixel = center_subpixel
-#         self.grid_dtype = grid_dtype
-#         if self.center_subpixel:
-#             self.G = self._construct_subpixel_grid_base()
-#         else:
-#             self.G = None
-
-#     def __call__(self, img, pts, prs, bg=None):
-#         stamps = []
-#         is_edge = []
-#         bgs = []
-#         for (pt, pr) in zip(pts, prs):
-#             pti, pri = int(pt + 0.5), int(pr + 0.5)
-
-#             row_lower = pri - self.stampsize // 2
-#             row_upper = pri + self.stampsize // 2 + 1
-#             col_lower = pti - self.stampsize // 2
-#             col_upper = pti + self.stampsize // 2 + 1
-
-#             edge_stamp = (
-#                 (row_lower < 0)
-#                 or (row_upper > img.shape[0])
-#                 or (col_lower < 0)
-#                 or (col_upper > img.shape[1])
-#             )
-
-#             is_edge.append(edge_stamp)
-
-#             if not edge_stamp:
-#                 stamp = img[row_lower:row_upper, col_lower:col_upper]
-#                 stamps.append(stamp)
-#                 if bg is not None:
-#                     stamp_bg = bg[row_lower:row_upper, col_lower:col_upper]
-#                     bgs.append(stamp_bg)
-
-#         stamps = torch.stack(stamps)
-#         is_edge = torch.tensor(is_edge, device=img.device)
-#         if self.center_subpixel:
-#             stamps = self._center_stamps_subpixel(stamps, pts[~is_edge], prs[~is_edge])
-
-#         return (
-#             stamps,
-#             None if bg is None else torch.stack(bgs),
-#             is_edge,
-#         )
-
-#     def _construct_subpixel_grid_base(self):
-#         grid_x = np.linspace(-1.0, 1.0, num=self.stampsize)
-#         grid_y = np.linspace(-1.0, 1.0, num=self.stampsize)
-
-#         G_x = torch.stack([torch.from_numpy(grid_x)] * self.stampsize, dim=0)
-#         G_y = torch.stack([torch.from_numpy(grid_y)] * self.stampsize, dim=1)
-
-#         G = rearrange([G_x, G_y], "n x y -> 1 x y n")
-
-#         return G.type(self.grid_dtype)
-
-#     def _center_stamps_subpixel(
-#         self,
-#         stamps,
-#         pts,
-#         prs,
-#     ):
-#         locs = torch.stack([pts, prs], dim=1)
-#         shifts = (
-#             2
-#             * (locs - (locs + 0.5).trunc())
-#             / torch.tensor(stamps.shape[1:], device=stamps.device).unsqueeze(0)
-#         )
-#         if self.G.device is not shifts.device:
-#             self.G = self.G.to(shifts.device)
-#         shifts = shifts.type(self.G.dtype)
-#         G_shift = self.G + shifts.unsqueeze(1).unsqueeze(1)
-#         stamps_shifted = F.grid_sample(stamps.unsqueeze(1), G_shift, align_corners=False)
-#         return stamps_shifted.squeeze(1)
-
-
-# class SdssPSF:
-#     def __init__(self, psf_fit_file, bands):
-#         self.psf_fit_file = psf_fit_file
-#         self.bands = bands
-#         self.cache = [None] * len(self.bands)
-
-#     def __getitem__(self, idx):
-#         if self.cache[idx] is None:
-#             x = self.read_psf(self.bands[idx])
-#             self.cache[idx] = x
-#         return self.cache[idx]
-
-#     def read_psf(self, band):
-#         psfield = fits.open(self.psf_fit_file)
-#         hdu = psfield[band + 1]
-#         return hdu.data
-
-#     def psf_at_points(self, idx, x, y):
-#         psf = self[idx]
-#         rtnscalar = np.isscalar(x) and np.isscalar(y)
-#         x = np.atleast_1d(x)
-#         y = np.atleast_1d(y)
-
-#         psfimgs = None
-#         (outh, outw) = (None, None)
-
-#         # From the IDL docs:
-#         # http://photo.astro.princeton.edu/photoop_doc.html#SDSS_PSF_RECON
-#         #   acoeff_k = SUM_i{ SUM_j{ (0.001*ROWC)^i * (0.001*COLC)^j * C_k_ij } }
-#         #   psfimage = SUM_k{ acoeff_k * RROWS_k }
-#         for k, psf_k in enumerate(psf):
-#             nrb = psf_k["nrow_b"]
-#             ncb = psf_k["ncol_b"]
-
-#             c = psf_k["c"].reshape(5, 5)
-#             c = c[:nrb, :ncb]
-
-#             (gridi, gridj) = np.meshgrid(range(nrb), range(ncb))
-
-#             if psfimgs is None:
-#                 psfimgs = [np.zeros_like(psf["rrows"][k]) for xy in np.broadcast(x, y)]
-#                 (outh, outw) = (psf["rnrow"][k], psf["rncol"][k])
-
-#             for i, (xi, yi) in enumerate(np.broadcast(x, y)):
-#                 acoeff_k = (((0.001 * xi) ** gridi * (0.001 * yi) ** gridj * c)).sum()
-#                 psfimgs[i] += acoeff_k * psf["rrows"][k]
-
-#         psfimgs = [img.reshape((outh, outw)) for img in psfimgs]
-
-#         if rtnscalar:
-#             return psfimgs[0]
-#         return psfimgs
-
-
 class SloanDigitalSkySurvey(Dataset):
     # pylint: disable=dangerous-default-value
     def __init__(
@@ -166,21 +30,12 @@ class SloanDigitalSkySurvey(Dataset):
         camcol=6,
         fields=(269,),
         bands=(0, 1, 2, 3, 4),
-        # stampsize=5,
-        # overwrite_fits_cache=False,
-        # overwrite_cache=False,
-        # center_subpixel=True,
     ):
         super().__init__()
 
         self.sdss_path = pathlib.Path(sdss_dir)
         self.rcfgcs = []
         self.bands = bands
-        # self.stampsize = stampsize
-        # self.overwrite_cache = overwrite_cache
-        # self.center_subpixel = center_subpixel
-        # self.stamper = StarStamper(stampsize, center_subpixel=center_subpixel)
-        # meta data for the run + camcol
         pf_file = f"photoField-{run:06d}-{camcol:d}.fits"
         camcol_path = self.sdss_path.joinpath(str(run), str(camcol))
         pf_path = camcol_path.joinpath(pf_file)
@@ -195,49 +50,6 @@ class SloanDigitalSkySurvey(Dataset):
             if (not fields) or field in fields:
                 self.rcfgcs.append((run, camcol, field, gain))
         self.items = [None] * len(self.rcfgcs)
-        #     # load the catalog distributed with SDSS
-        #     po_file = f"photoObj-{run:06d}-{camcol:d}-{field:04d}.fits"
-        #     po_cache = f"photoObj-{run:06d}-{camcol:d}-{field:04d}.pkl"
-        #     po_path = camcol_path.joinpath(str(field), po_file)
-        #     po_cache_path = camcol_path.joinpath(str(field), po_cache)
-        #     if (not po_cache_path.exists()) or (overwrite_fits_cache):
-        #         try:
-        #             po_fits = fits.getdata(po_path)
-        #         except IndexError as e:
-        #             print(
-        #                 f"INFO: IndexError while accessing field: {field}. "
-        #                 "This field will not be included.\n"
-        #             )
-        #             print(e)
-        #             po_fits = None
-        #         pickle.dump(po_fits, po_cache_path.open("wb+"))
-        #     else:
-        #         po_fits = pickle.load(po_cache_path.open("rb+"))
-        #         if po_fits is None:
-        #             print(
-        #                 f"INFO: cached data for field {field} is None. "
-        #                 "This field will not be included"
-        #             )
-
-        #     # Load the PSF produced by SDSS
-        #     psf_file = f"psField-{run:06d}-{camcol:d}-{field:04d}.fits"
-        #     psf_cache = f"psField-{run:06d}-{camcol:d}-{field:04d}.pkl"
-
-        #     psf_path = camcol_path.joinpath(str(field), psf_file)
-        #     psf_cache_path = camcol_path.joinpath(str(field), psf_cache)
-
-        #     try:
-        #         psf = SdssPSF(psf_path.as_posix(), bands)
-        #     except IndexError as e:
-        #         print(
-        #             f"INFO: IndexError while accessing PSF for field: {field}. "
-        #             "This field will not be included."
-        #         )
-        #         print(e)
-        #         psf = None
-
-        #     pickle.dump(psf, psf_cache_path.open("wb+"))
-        # self.cache_paths = [None] * len(self.rcfgcs)
 
     def __len__(self):
         return len(self.rcfgcs)
@@ -246,45 +58,6 @@ class SloanDigitalSkySurvey(Dataset):
         if not self.items[idx]:
             self.items[idx] = self.get_from_disk(idx)
         return self.items[idx]
-
-    # def clear_cache(self):
-    #     for p in self.cache_paths:
-    #         if p is not None:
-    #             if p.exists():
-    #                 p.unlink()
-
-    # def fetch_bright_stars(self, po_fits, img, wcs, bg):
-    #     is_star = po_fits["objc_type"] == 6
-    #     is_bright = po_fits["psfflux"].sum(axis=1) > 100
-    #     is_thing = po_fits["thing_id"] != -1
-    #     is_target = is_star & is_bright & is_thing
-
-    #     ras = po_fits["ra"][is_target]
-    #     decs = po_fits["dec"][is_target]
-    #     pts = []
-    #     prs = []
-    #     for ra, dec in zip(ras, decs):
-    #         pt, pr = wcs.wcs_world2pix(ra, dec, 0)
-    #         pts.append(pt)
-    #         prs.append(pr)
-    #     pts = np.asarray(pts)
-    #     prs = np.asarray(prs)
-    #     fluxes = po_fits["psfflux"][is_target].sum(axis=1)
-
-    #     stamps, bgs, is_edge = self.stamper(
-    #         torch.from_numpy(img),
-    #         torch.from_numpy(pts),
-    #         torch.from_numpy(prs),
-    #         bg=torch.from_numpy(bg),
-    #     )
-    #     is_edge = is_edge.numpy()
-    #     return (
-    #         stamps.numpy(),
-    #         pts[~is_edge],
-    #         prs[~is_edge],
-    #         fluxes[~is_edge],
-    #         bgs.numpy(),
-    #     )
 
     def get_from_disk(self, idx, verbose=False):
         # pylint: disable=too-many-statements
@@ -301,15 +74,6 @@ class SloanDigitalSkySurvey(Dataset):
         calibration_list = []
         gain_list = []
         wcs_list = []
-
-        # cache_path = field_dir.joinpath(
-        #     f"cache_stmpsz{self.stampsize}_ctr{self.center_subpixel}.pkl"
-        # )
-        # if cache_path.exists() and not self.overwrite_cache:
-        #     with warnings.catch_warnings():
-        #         warnings.filterwarnings("ignore", category=FITSFixedWarning)
-        #         ret = pickle.load(cache_path.open("rb+"))
-        #     return ret, cache_path
 
         for b, bl in enumerate("ugriz"):
             if b not in self.bands:
@@ -356,23 +120,7 @@ class SloanDigitalSkySurvey(Dataset):
 
             frame.close()
 
-        # use 'r' band when possible.
-        # if len(self.bands) > 2:
-        #     band_idx = 2
-        # else:
-        #     band_idx = 0
-
-        # stamps, pts, prs, fluxes, stamp_bgs = self.fetch_bright_stars(
-        #     po_fits, image_list[band_idx], wcs_list[band_idx], background_list[band_idx]
-        # )
-        # stamp_psfs = np.asarray(psf.psf_at_points(band_idx, pts, prs))
-        # if stamp_bgs.size > 0:
-        #     psf_center = stamp_psfs.shape[-1] // 2
-        #     psf_lower = psf_center - floor(self.stampsize / 2)
-        #     psf_upper = psf_center + ceil(self.stampsize / 2)
-        #     stamp_psfs = stamp_psfs[:, psf_lower:psf_upper, psf_lower:psf_upper]
-
-        ret = {
+        return {
             "image": np.stack(image_list),
             "field": field,
             "background": np.stack(background_list),
@@ -380,14 +128,4 @@ class SloanDigitalSkySurvey(Dataset):
             "gain": np.stack(gain_list),
             "calibration": np.stack(calibration_list),
             "wcs": wcs_list,
-            # "bright_stars": stamps,
-            # "pts": pts,
-            # "prs": prs,
-            # "fluxes": fluxes,
-            # "bright_star_bgs": stamp_bgs,
-            # "sdss_psfs": stamp_psfs,
-            # "po_fits": po_fits,
         }
-        # pickle.dump(ret, cache_path.open("wb+"))
-
-        return ret

--- a/bliss/datasets/sdss.py
+++ b/bliss/datasets/sdss.py
@@ -20,7 +20,6 @@ def convert_flux_to_mag(flux, nelec_per_nmgy=987.31):
 
 
 class SloanDigitalSkySurvey(Dataset):
-    # pylint: disable=dangerous-default-value
     def __init__(
         self,
         sdss_dir="data/sdss",
@@ -57,7 +56,7 @@ class SloanDigitalSkySurvey(Dataset):
             self.items[idx] = self.get_from_disk(idx)
         return self.items[idx]
 
-    def get_from_disk(self, idx, verbose=False):
+    def get_from_disk(self, idx):
         if self.rcfgcs[idx] is None:
             return None
         run, camcol, field, gain = self.rcfgcs[idx]

--- a/bliss/datasets/sdss.py
+++ b/bliss/datasets/sdss.py
@@ -2,12 +2,10 @@ import pathlib
 import warnings
 
 import numpy as np
-import torch
 from astropy.io import fits
 from astropy.wcs import WCS, FITSFixedWarning
 from einops import rearrange
 from scipy.interpolate import RegularGridInterpolator
-from torch.nn import functional as F
 from torch.utils.data import Dataset
 
 

--- a/bliss/datasets/sdss_blended_galaxies.py
+++ b/bliss/datasets/sdss_blended_galaxies.py
@@ -72,8 +72,6 @@ class SdssBlendedGalaxies(pl.LightningDataModule):
             camcol=camcol,
             fields=(field,),
             bands=bands,
-            # overwrite_cache=True,
-            # overwrite_fits_cache=True,
         )
         image = torch.from_numpy(sdss_data[0]["image"][0])
         image = rearrange(image, "h w -> 1 1 h w")

--- a/bliss/datasets/sdss_blended_galaxies.py
+++ b/bliss/datasets/sdss_blended_galaxies.py
@@ -72,8 +72,8 @@ class SdssBlendedGalaxies(pl.LightningDataModule):
             camcol=camcol,
             fields=(field,),
             bands=bands,
-            overwrite_cache=True,
-            overwrite_fits_cache=True,
+            # overwrite_cache=True,
+            # overwrite_fits_cache=True,
         )
         image = torch.from_numpy(sdss_data[0]["image"][0])
         image = rearrange(image, "h w -> 1 1 h w")

--- a/case_studies/sdss_galaxies/config/config.yaml
+++ b/case_studies/sdss_galaxies/config/config.yaml
@@ -152,10 +152,6 @@ predict:
         camcol: 1
         fields:
             - 12
-        stampsize: 5
-        overwrite_fits_cache: False
-        overwrite_cache: False
-        center_subpixel: True
     bands:
         - 2
 

--- a/case_studies/sdss_galaxies/tests/test_sdss.py
+++ b/case_studies/sdss_galaxies/tests/test_sdss.py
@@ -14,42 +14,15 @@ class TestSDSS:
             camcol=6,
             fields=[269],
             bands=range(5),
-            stampsize=5,
-            overwrite_cache=True,
-            overwrite_fits_cache=True,
         )
         an_obj = sdss_obj[0]
         assert an_obj["gain"][3] == pytest.approx(4.76)
 
-        assert len(an_obj["bright_stars"]) == 43
-        assert an_obj["bright_stars"].shape[1] == 5
-        assert an_obj["bright_stars"].shape[2] == 5
-
-        assert len(an_obj["sdss_psfs"]) == 43
-        assert an_obj["sdss_psfs"].shape[1] == 5
-        assert an_obj["sdss_psfs"].shape[2] == 5
-        super_star = an_obj["bright_stars"].sum(axis=0)
-        assert np.all(super_star[2, 2] + 1e-4 >= super_star)
-
-        assert len(an_obj["sdss_psfs"]) == 43
-
         sdss_obj9 = SloanDigitalSkySurvey(
-            sdss_dir, run=3900, camcol=6, fields=[269, 745], bands=range(5), stampsize=9
+            sdss_dir,
+            run=3900,
+            camcol=6,
+            fields=[269, 745],
+            bands=range(5),
         )
-
-        another_obj = sdss_obj9[0]
-        assert another_obj["bright_stars"].shape[1] == 9
-        assert another_obj["bright_stars"].shape[2] == 9
-        assert another_obj["sdss_psfs"].shape[1] == 9
-        assert another_obj["sdss_psfs"].shape[2] == 9
-
-        sdss_obj9_cached = SloanDigitalSkySurvey(
-            sdss_dir, run=3900, camcol=6, fields=[269, 745], bands=range(5), stampsize=9
-        )
-
-        assert sdss_obj9_cached[0]["bright_stars"].shape[1] == 9
-        assert sdss_obj9_cached[0]["bright_stars"].shape[2] == 9
-
-        sdss_obj.clear_cache()
-        sdss_obj9.clear_cache()
-        sdss_obj9_cached.clear_cache()
+        sdss_obj9[0]

--- a/case_studies/sdss_galaxies/tests/test_sdss.py
+++ b/case_studies/sdss_galaxies/tests/test_sdss.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 
 from bliss.datasets.sdss import SloanDigitalSkySurvey
 
@@ -15,7 +16,12 @@ class TestSDSS:
             bands=range(5),
         )
         an_obj = sdss_obj[0]
+        for k in {"image", "background", "gain", "nelec_per_nmgy_list", "calibration"}:
+            assert isinstance(an_obj[k], np.ndarray)
+
+        assert an_obj["field"] == 269
         assert an_obj["gain"][3] == pytest.approx(4.76)
+        assert isinstance(an_obj["wcs"], list)
 
         sdss_obj9 = SloanDigitalSkySurvey(
             sdss_dir,
@@ -24,4 +30,4 @@ class TestSDSS:
             fields=[269, 745],
             bands=range(5),
         )
-        sdss_obj9[0]
+        assert (len(sdss_obj9)) == 2

--- a/case_studies/sdss_galaxies/tests/test_sdss.py
+++ b/case_studies/sdss_galaxies/tests/test_sdss.py
@@ -16,7 +16,7 @@ class TestSDSS:
             bands=range(5),
         )
         an_obj = sdss_obj[0]
-        for k in {"image", "background", "gain", "nelec_per_nmgy_list", "calibration"}:
+        for k in ("image", "background", "gain", "nelec_per_nmgy_list", "calibration"):
             assert isinstance(an_obj[k], np.ndarray)
 
         assert an_obj["field"] == 269

--- a/case_studies/sdss_galaxies/tests/test_sdss.py
+++ b/case_studies/sdss_galaxies/tests/test_sdss.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 from bliss.datasets.sdss import SloanDigitalSkySurvey

--- a/case_studies/sdss_galaxies_vae/config/config.yaml
+++ b/case_studies/sdss_galaxies_vae/config/config.yaml
@@ -156,10 +156,6 @@ predict:
         camcol: 1
         fields:
             - 12
-        stampsize: 5
-        overwrite_fits_cache: False
-        overwrite_cache: False
-        center_subpixel: True
     bands:
         - 2
 

--- a/case_studies/sdss_galaxies_vae/reconstruction.py
+++ b/case_studies/sdss_galaxies_vae/reconstruction.py
@@ -78,8 +78,6 @@ def get_sdss_data(sdss_dir, sdss_pixel_scale):
         camcol=camcol,
         fields=(field,),
         bands=bands,
-        overwrite_cache=True,
-        overwrite_fits_cache=True,
     )
 
     return {


### PR DESCRIPTION
We aren't currently using the fetch bright stars functionality in SloanDigitalSkySurvey, so we can remove a lot of code in sdss.py. When we need that functionality again, we should bring it back as a separate class to keep loading the actual data as simple as possible.

Closes #381.