### PR TITLE
Split n_ptiles_per_image into n_tiles_h, n_tiles_w

### DIFF
--- a/bliss/encoder.py
+++ b/bliss/encoder.py
@@ -91,10 +91,18 @@ class Encoder(nn.Module):
         var_params = self.location_encoder.encode(image_ptiles)
         tile_map = self.location_encoder.max_a_post(var_params)
 
+        image_ptiles_flat = rearrange(image_ptiles, "b nth ntw c h w -> (b nth ntw) c h w")
+        locs_flat = rearrange(tile_map["locs"], "b nth ntw s xy -> (b nth ntw) s xy")
         if self.binary_encoder is not None:
             assert not self.binary_encoder.training
-            galaxy_probs = self.binary_encoder(image_ptiles, tile_map["locs"])
-            galaxy_probs = galaxy_probs.view(-1, 1, 1)
+            galaxy_probs = self.binary_encoder(image_ptiles_flat, locs_flat)
+            galaxy_probs = rearrange(
+                galaxy_probs,
+                "(b nth ntw) 1 -> b nth ntw 1 1",
+                b=image_ptiles.shape[0],
+                nth=image_ptiles.shape[1],
+                ntw=image_ptiles.shape[2],
+            )
             galaxy_probs *= tile_map["is_on_array"]
             galaxy_bools = (galaxy_probs > 0.5).float() * tile_map["is_on_array"]
             star_bools = get_star_bools(tile_map["n_sources"], galaxy_bools)
@@ -107,9 +115,14 @@ class Encoder(nn.Module):
             )
 
         if self.galaxy_encoder is not None:
-            galaxy_params = self.galaxy_encoder.sample(image_ptiles, tile_map["locs"])
+            galaxy_params = self.galaxy_encoder.sample(image_ptiles_flat, locs_flat)
             galaxy_params = rearrange(
-                galaxy_params, "(n_ptiles n_sources) d -> n_ptiles n_sources d", n_sources=1
+                galaxy_params,
+                "(b nth ntw n_sources) d -> b nth ntw n_sources d",
+                b=image_ptiles.shape[0],
+                nth=image_ptiles.shape[1],
+                ntw=image_ptiles.shape[2],
+                n_sources=1,
             )
             galaxy_params *= tile_map["is_on_array"] * tile_map["galaxy_bools"]
             tile_map.update({"galaxy_params": galaxy_params})

--- a/bliss/inference.py
+++ b/bliss/inference.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 from bliss.datasets.sdss_blended_galaxies import cpu
 from bliss.encoder import Encoder
 from bliss.models.decoder import ImageDecoder
-from bliss.models.location_encoder import get_full_params_from_tiles, get_params_in_batches
+from bliss.models.location_encoder import get_full_params_from_tiles
 
 
 def reconstruct_scene_at_coordinates(
@@ -148,7 +148,6 @@ def reconstruct_img(
 
     with torch.no_grad():
         tile_map = encoder.max_a_post(img_ptiles)
-        tile_map = get_params_in_batches(tile_map, img.shape[0])
         recon_image, _ = decoder.render_images(
             tile_map["n_sources"],
             tile_map["locs"],

--- a/bliss/models/binary.py
+++ b/bliss/models/binary.py
@@ -1,5 +1,6 @@
 import pytorch_lightning as pl
 import torch
+from einops import rearrange
 from matplotlib import pyplot as plt
 from torch import nn
 from torch.nn import BCELoss
@@ -101,6 +102,7 @@ class BinaryEncoder(pl.LightningModule):
         """Splits `images` into padded tiles and runs `self.forward()` on them."""
         batch_size = images.shape[0]
         ptiles = self.get_images_in_tiles(images)
+        ptiles = rearrange(ptiles, "b nth ntw c h w -> (b nth ntw) c h w")
         galaxy_probs = self(ptiles, tile_locs)
         return galaxy_probs.view(batch_size, -1, 1, 1)
 

--- a/bliss/models/binary.py
+++ b/bliss/models/binary.py
@@ -98,11 +98,6 @@ class BinaryEncoder(pl.LightningModule):
             self.cached_grid,
         )
 
-    def forward_image(self, images, tile_locs):
-        """Splits `images` into padded tiles and runs `self.forward()` on them."""
-        ptiles = self.get_images_in_tiles(images)
-        return self(ptiles, tile_locs)
-
     def forward(self, image_ptiles, tile_locs):
         """Centers padded tiles using `tile_locs` and runs the binary encoder on them."""
         assert image_ptiles.shape[-1] == image_ptiles.shape[-2] == self.ptile_slen
@@ -135,7 +130,8 @@ class BinaryEncoder(pl.LightningModule):
         galaxy_bools = batch["galaxy_bools"].reshape(-1)
         locs = batch["locs"]
         batch_size, n_tiles_h, n_tiles_w, max_sources, _ = locs.shape
-        galaxy_probs = self.forward_image(images, locs).reshape(-1)
+        ptiles = self.get_images_in_tiles(images)
+        galaxy_probs = self.forward(ptiles, locs).reshape(-1)
         tile_is_on_array = get_is_on_from_n_sources(batch["n_sources"], self.max_sources)
         tile_is_on_array = tile_is_on_array.reshape(-1)
 

--- a/bliss/models/binary.py
+++ b/bliss/models/binary.py
@@ -100,34 +100,42 @@ class BinaryEncoder(pl.LightningModule):
 
     def forward_image(self, images, tile_locs):
         """Splits `images` into padded tiles and runs `self.forward()` on them."""
-        batch_size = images.shape[0]
         ptiles = self.get_images_in_tiles(images)
-        ptiles = rearrange(ptiles, "b nth ntw c h w -> (b nth ntw) c h w")
-        galaxy_probs = self(ptiles, tile_locs)
-        return galaxy_probs.view(batch_size, -1, 1, 1)
+        return self(ptiles, tile_locs)
 
     def forward(self, image_ptiles, tile_locs):
         """Centers padded tiles using `tile_locs` and runs the binary encoder on them."""
         assert image_ptiles.shape[-1] == image_ptiles.shape[-2] == self.ptile_slen
-        n_ptiles = image_ptiles.shape[0]
+        batch_size, n_tiles_h, n_tiles_w = tile_locs.shape[:3]
 
         # in each padded tile we need to center the corresponding galaxy/star
-        tile_locs = tile_locs.reshape(n_ptiles, self.max_sources, 2)
-        centered_ptiles = self.center_ptiles(image_ptiles, tile_locs)
+        image_ptiles_flat = rearrange(image_ptiles, "b nth ntw c h w -> (b nth ntw) c h w")
+        tile_locs_flat = rearrange(tile_locs, "b nth ntw s xy -> (b nth ntw) s xy")
+        centered_ptiles = self.center_ptiles(image_ptiles_flat, tile_locs_flat)
         assert centered_ptiles.shape[-1] == centered_ptiles.shape[-2] == self.slen
 
         # forward to layer shared by all n_sources
         log_img = torch.log(centered_ptiles - centered_ptiles.min() + 1.0)
         h = self.enc_conv(log_img)
-        z = self.enc_final(h).reshape(n_ptiles, 1)
-        return torch.sigmoid(z).clamp(1e-4, 1 - 1e-4)
+        h2 = self.enc_final(h)
+        z = torch.sigmoid(h2).clamp(1e-4, 1 - 1e-4)
+        return rearrange(
+            z,
+            "(b nth ntw s) 1 -> b nth ntw s 1",
+            b=batch_size,
+            nth=n_tiles_h,
+            ntw=n_tiles_w,
+            s=self.max_sources,
+        )
 
     def get_prediction(self, batch):
         """Return loss, accuracy, binary probabilities, and MAP classifications for given batch."""
 
         images = batch["images"]
         galaxy_bools = batch["galaxy_bools"].reshape(-1)
-        galaxy_probs = self.forward_image(images, batch["locs"]).reshape(-1)
+        locs = batch["locs"]
+        batch_size, n_tiles_h, n_tiles_w, max_sources, _ = locs.shape
+        galaxy_probs = self.forward_image(images, locs).reshape(-1)
         tile_is_on_array = get_is_on_from_n_sources(batch["n_sources"], self.max_sources)
         tile_is_on_array = tile_is_on_array.reshape(-1)
 
@@ -144,13 +152,25 @@ class BinaryEncoder(pl.LightningModule):
         # finally organize quantities and return as a dictionary
         pred_star_bools = (1 - pred_galaxy_bools) * tile_is_on_array
 
-        return {
+        ret = {
             "loss": loss,
             "acc": acc,
-            "galaxy_bools": pred_galaxy_bools.reshape(images.shape[0], -1, 1, 1),
-            "star_bools": pred_star_bools.reshape(images.shape[0], -1, 1, 1),
-            "galaxy_probs": galaxy_probs.reshape(images.shape[0], -1, 1, 1),
+            "galaxy_bools": pred_galaxy_bools,
+            "star_bools": pred_star_bools,
+            "galaxy_probs": galaxy_probs,
         }
+
+        for k in ("galaxy_bools", "star_bools", "galaxy_probs"):
+            ret[k] = rearrange(
+                ret[k],
+                "(b nth ntw s) -> b nth ntw s 1",
+                b=batch_size,
+                nth=n_tiles_h,
+                ntw=n_tiles_w,
+                s=max_sources,
+            )
+
+        return ret
 
     def configure_optimizers(self):
         """Pytorch lightning method."""

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -377,9 +377,13 @@ class LocationEncoder(nn.Module):
         }
         sample = {}
         for k, v in sample_flat.items():
+            if k == "n_sources":
+                pattern = "ns (b nth ntw) -> ns b nth ntw"
+            else:
+                pattern = "ns (b nth ntw) s k -> ns b nth ntw s k"
             sample[k] = rearrange(
                 v,
-                "ns (b nth ntw) k -> ns b nth ntw k",
+                pattern,
                 b=var_params.shape[0],
                 nth=var_params.shape[1],
                 ntw=var_params.shape[2],

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -1,6 +1,5 @@
 from typing import Dict, Optional, Tuple
 
-import numpy as np
 import torch
 from einops import rearrange, reduce, repeat
 from torch import Tensor, nn
@@ -19,27 +18,29 @@ def get_images_in_tiles(images, tile_slen, ptile_slen):
         ptile_slen: Side length of padded tile
 
     Returns:
-        A (batchsize x tiles_per_batch) x n_bands x tile_weight x tile_width image
+        A batchsize x n_tiles_h x n_tiles_w x n_bands x tile_weight x tile_width image
     """
     assert len(images.shape) == 4
     n_bands = images.shape[1]
     window = ptile_slen
+    n_tiles_h, n_tiles_w = get_n_tiles_hw(images.shape[2], images.shape[3], window, tile_slen)
     tiles = F.unfold(images, kernel_size=window, stride=tile_slen)
     # b: batch, c: channel, h: tile height, w: tile width, n: num of total tiles for each batch
-    return rearrange(tiles, "b (c h w) n -> (b n) c h w", c=n_bands, h=window, w=window)
+    return rearrange(
+        tiles,
+        "b (c h w) (nth ntw) -> b nth ntw c h w",
+        nth=n_tiles_h,
+        ntw=n_tiles_w,
+        c=n_bands,
+        h=window,
+        w=window,
+    )
 
 
 def get_n_tiles_hw(h, w, window, tile_slen):
     nh = ((h - window) // tile_slen) + 1
     nw = ((w - window) // tile_slen) + 1
     return nh, nw
-
-
-def get_params_in_batches(params: Dict["str", torch.Tensor], batch_size):
-    out = {}
-    for k, v in params.items():
-        out[k] = v.view(batch_size, -1, *v.shape[1:])
-    return out
 
 
 def get_is_on_from_n_sources(n_sources, max_sources):
@@ -85,7 +86,7 @@ def get_full_params_from_tiles(
             samples from the variational distribution or the maximum a posteriori (such as from
             LocationEncoder.max_a_post or SleepPhase.tile_map_estimate).
             The first three dimensions of each tensor in this dictionary
-            should be of shape `n_samples x n_tiles_per_image x max_detections`.ge.
+            should be of shape `batch_size x n_tiles_h x n_tiles_w x max_detections`.ge.
         tile_slen:
             Side-length of each tile.
         n_tiles_w:
@@ -95,7 +96,7 @@ def get_full_params_from_tiles(
 
     Returns:
         A dictionary of tensors with the same members as those in `tile_params`.
-        The first two dimensions of each tensor is `n_samples x max(n_sources)`,
+        The first two dimensions of each tensor is `batch_size x max(n_sources)`,
         where `max(n_sources)` is the maximum number of sources detected across samples.
         In samples where the number of sources detected is less than max(n_sources),
         these values will be zeroed out. Thus, it is imperative to use the "n_sources"
@@ -130,7 +131,7 @@ def get_full_params_from_tiles(
                 "ones (check spelling?)"
             )
 
-    plocs, locs = get_full_locs_from_tiles(tile_locs, tile_slen, n_tiles_w=n_tiles_w)
+    plocs, locs = get_full_locs_from_tiles(tile_locs, tile_slen)
     tile_params_to_gather = {
         "locs": locs,
         "plocs": plocs,
@@ -140,50 +141,38 @@ def get_full_params_from_tiles(
     )
 
     params = {}
-    max_detections = tile_locs.shape[2]
+    max_detections = tile_locs.shape[3]
     indices_to_retrieve, is_on_array = get_indices_of_on_sources(tile_n_sources, max_detections)
     for param_name, tile_param in tile_params_to_gather.items():
         k = tile_param.shape[-1]
-        param = rearrange(tile_param, "b t d k -> b (t d) k", k=k)
-        indices_for_param = repeat(indices_to_retrieve, "b n -> b n k", k=k)
+        param = rearrange(tile_param, "b nth ntw s k -> b (nth ntw s) k", k=k)
+        indices_for_param = repeat(indices_to_retrieve, "b nth_ntw_s -> b nth_ntw_s k", k=k)
         param = torch.gather(param, dim=1, index=indices_for_param)
         if param_name in param_names_to_mask:
             param *= is_on_array.unsqueeze(-1)
         params[param_name] = param
 
-    params["n_sources"] = reduce(tile_params["n_sources"], "b n -> b", "sum")
+    params["n_sources"] = reduce(tile_params["n_sources"], "b nth ntw -> b", "sum")
     assert params["locs"].shape[1] == params["n_sources"].max().int().item()
     return params
 
 
-def get_full_locs_from_tiles(
-    tile_locs: Tensor, tile_slen: int, n_tiles_w: Optional[int] = None
-) -> Tuple[Tensor, Tensor]:
+def get_full_locs_from_tiles(tile_locs: Tensor, tile_slen: int) -> Tuple[Tensor, Tensor]:
     """Get the full image locations from tile locations.
 
     Args:
         tile_locs:
-            A tensor of shape `n_samples x n_tiles_per_image x max_detections x 2`,
+            A tensor of shape `batch_size x n_tiles_h x n_tiles_w x max_detections x 2`,
             representing the locations in each tile.
         tile_slen:
             The side-length of each tile.
-        n_tiles_w:
-            Defaults to None. Can directly specify the number of tiles in width.
-            This is necessary when the original image was not square.
 
     Returns:
         A tuple of two elements, "plocs" and "locs".
         "plocs" are the pixel coordinates of each source (between 0 and slen).
         "locs" are the scaled locations of each source (between 0 and 1).
     """
-    n_samples, n_tiles_per_image, _, _ = tile_locs.shape
-    if n_tiles_w is None:
-        n_tiles_h = int(np.sqrt(n_tiles_per_image))
-        n_tiles_w = n_tiles_h
-    else:
-        n_tiles_h = n_tiles_per_image // n_tiles_w
-    assert n_tiles_h * n_tiles_w == n_tiles_per_image
-
+    batch_size, n_tiles_h, n_tiles_w, _, _ = tile_locs.shape
     slen = n_tiles_h * tile_slen
     wlen = n_tiles_w * tile_slen
     # coordinates on tiles.
@@ -192,11 +181,13 @@ def get_full_locs_from_tiles(
     tile_coords = torch.cartesian_prod(x_coords, y_coords)
 
     # recenter and renormalize locations.
-    tile_locs = rearrange(tile_locs, "b n d xy -> (b n) d xy", xy=2)
-    bias = repeat(tile_coords, "n xy -> (r n) 1 xy", r=n_samples).float()
+    tile_locs = rearrange(tile_locs, "b nth ntw d xy -> (b nth ntw) d xy", xy=2)
+    bias = repeat(tile_coords, "n xy -> (r n) 1 xy", r=batch_size).float()
 
     plocs = tile_locs * tile_slen + bias
-    plocs = rearrange(plocs, "(b n) d xy -> b n d xy", b=n_samples)
+    plocs = rearrange(
+        plocs, "(b nth ntw) d xy -> b nth ntw d xy", b=batch_size, nth=n_tiles_h, ntw=n_tiles_w
+    )
     locs = plocs.clone()
     locs[..., 0] /= slen
     locs[..., 1] /= wlen
@@ -209,7 +200,7 @@ def get_indices_of_on_sources(tile_n_sources: Tensor, max_detections: int) -> Te
 
     Args:
         tile_n_sources:
-            A Tensor of shape `n_samples x n_tiles_per_image`, containing the
+            A Tensor of shape `batch_size x n_tiles_h x n_tiles_w`, containing the
             number of detected sources in a given tile.
         max_detections:
             The maximum number of detections allowed in a given tile.
@@ -226,9 +217,9 @@ def get_indices_of_on_sources(tile_n_sources: Tensor, max_detections: int) -> Te
         the elements of this tensor would take values from 0 up to and including 5.
     """
     tile_is_on_array_sampled = get_is_on_from_n_sources(tile_n_sources, max_detections)
-    n_sources = tile_is_on_array_sampled.sum(dim=(1, 2))  # per sample.
+    n_sources = reduce(tile_is_on_array_sampled, "b nth ntw d -> b", "sum")
     max_sources = n_sources.max().int().item()
-    tile_is_on_array = rearrange(tile_is_on_array_sampled, "b n d -> b (n d)")
+    tile_is_on_array = rearrange(tile_is_on_array_sampled, "b nth ntw d -> b (nth ntw d)")
     indices_sorted = tile_is_on_array.long().argsort(dim=1, descending=True)
     indices_sorted = indices_sorted[:, :max_sources]
 
@@ -321,7 +312,7 @@ class LocationEncoder(nn.Module):
 
         Args:
             image_ptiles: A tensor of padded image tiles,
-                with shape `n_ptiles * n_bands * h * w`.
+                with shape `b * n_tiles_h * n_tiles_w * n_bands * h * w`.
 
         Returns:
             A tensor of variational parameters in matrix form per-tile
@@ -331,11 +322,17 @@ class LocationEncoder(nn.Module):
         """
         # get h matrix.
         # Forward to the layer that is shared by all n_sources.
-        log_img = torch.log(image_ptiles - image_ptiles.min() + 1.0)
-        var_params = self.enc_conv(log_img)
-
-        # Concatenate all output parameters for all possible n_sources
-        return self.enc_final(var_params)
+        image_ptiles_flat = rearrange(image_ptiles, "b nth ntw c h w -> (b nth ntw) c h w")
+        log_img = torch.log(image_ptiles_flat - image_ptiles_flat.min() + 1.0)
+        var_params_conv = self.enc_conv(log_img)
+        var_params_flat = self.enc_final(var_params_conv)
+        return rearrange(
+            var_params_flat,
+            "(b nth ntw) d -> b nth ntw d",
+            b=image_ptiles.shape[0],
+            nth=image_ptiles.shape[1],
+            ntw=image_ptiles.shape[2],
+        )
 
     def sample(self, var_params: Tensor, n_samples: int) -> Dict[str, Tensor]:
         """Sample from encoded variational distribution.
@@ -350,7 +347,8 @@ class LocationEncoder(nn.Module):
             A dictionary of tensors with shape `n_samples * n_ptiles * max_sources* ...`.
             Consists of `"n_sources", "locs", "log_fluxes", and "fluxes"`.
         """
-        log_probs_n_sources_per_tile = self._get_logprob_n_from_var_params(var_params)
+        var_params_flat = rearrange(var_params, "b nth ntw d -> (b nth ntw) d")
+        log_probs_n_sources_per_tile = self._get_logprob_n_from_var_params(var_params_flat)
 
         # sample number of sources.
         # tile_n_sources shape = (n_samples x n_ptiles)
@@ -362,7 +360,7 @@ class LocationEncoder(nn.Module):
         tile_is_on_array = tile_is_on_array.unsqueeze(-1).float()
 
         # get var_params conditioned on n_sources
-        pred = self.encode_for_n_sources(var_params, tile_n_sources)
+        pred = self.encode_for_n_sources(var_params_flat, tile_n_sources)
 
         pred["loc_sd"] = torch.exp(0.5 * pred["loc_logvar"])
         pred["log_flux_sd"] = torch.exp(0.5 * pred["log_flux_logvar"])
@@ -371,12 +369,23 @@ class LocationEncoder(nn.Module):
             pred["log_flux_mean"], pred["log_flux_sd"], tile_is_on_array
         )
         tile_fluxes = tile_log_fluxes.exp() * tile_is_on_array
-        return {
+        sample_flat = {
             "n_sources": tile_n_sources,
             "locs": tile_locs,
             "log_fluxes": tile_log_fluxes,
             "fluxes": tile_fluxes,
         }
+        sample = {}
+        for k, v in sample_flat.items():
+            sample[k] = rearrange(
+                v,
+                "ns (b nth ntw) k -> ns b nth ntw k",
+                b=var_params.shape[0],
+                nth=var_params.shape[1],
+                ntw=var_params.shape[2],
+            )
+
+        return sample
 
     def max_a_post(self, var_params: Tensor) -> Dict[str, Tensor]:
         """Derive maximum a posteriori from variational parameters.
@@ -391,8 +400,9 @@ class LocationEncoder(nn.Module):
             The dictionary contains
             `"locs", "log_fluxes", "fluxes", and "n_sources".`.
         """
-        tile_n_sources = self.tile_map_n_sources(var_params)
-        pred = self.encode_for_n_sources(var_params, tile_n_sources)
+        var_params_flat = rearrange(var_params, "b nth ntw d -> (b nth ntw) d")
+        tile_n_sources = self.tile_map_n_sources(var_params_flat)
+        pred = self.encode_for_n_sources(var_params_flat, tile_n_sources)
 
         tile_n_sources = torch.argmax(pred["n_source_log_probs"], dim=1)
         tile_is_on_array = get_is_on_from_n_sources(tile_n_sources, self.max_detections)
@@ -410,20 +420,32 @@ class LocationEncoder(nn.Module):
         tile_log_fluxes = self._get_normal_samples(log_flux_mean, log_flux_sd, tile_is_on_array)
         tile_fluxes = tile_log_fluxes.exp() * tile_is_on_array
 
-        return {
+        max_a_post_flat = {
             "locs": tile_locs,
             "log_fluxes": tile_log_fluxes,
             "fluxes": tile_fluxes,
             "n_sources": tile_n_sources,
             "is_on_array": tile_is_on_array,
         }
+        max_a_post = {}
+        for k, v in max_a_post_flat.items():
+            if k == "n_sources":
+                pattern = "(b nth ntw) -> b nth ntw"
+            else:
+                pattern = "(b nth ntw) s k -> b nth ntw s k"
+            max_a_post[k] = rearrange(
+                v, pattern, b=var_params.shape[0], nth=var_params.shape[1], ntw=var_params.shape[2]
+            )
+        return max_a_post
 
-    def encode_for_n_sources(self, var_params, tile_n_sources):
+    def encode_for_n_sources(self, var_params_flat, tile_n_sources):
         """Get variational parameters conditioned on number of sources in tile.
 
         Args:
-            var_params: The output of `self.encode(ptiles)` which is the variational parameters
-                in matrix form. Has size `n_ptiles * n_bands`.
+            var_params_flat: The output of `self.encode(ptiles)`,
+                where the first three dimensions have been flattened.
+                These are the variational parameters in matrix form.
+                Has size `(batch_size x n_tiles_h x n_tiles_w) * d`.
             tile_n_sources:
                 A tensor of the number of sources in each tile.
 
@@ -445,14 +467,16 @@ class LocationEncoder(nn.Module):
         else:
             raise ValueError("tile_n_sources must have shape size 1 or 2")
 
-        assert var_params.shape[0] == tile_n_sources.shape[1]
+        assert var_params_flat.shape[0] == tile_n_sources.shape[1]
         # get probability of params except n_sources
         # e.g. loc_mean: shape = (n_samples x n_ptiles x max_detections x len(x,y))
-        var_params_for_n_sources = self._get_var_params_for_n_sources(var_params, tile_n_sources)
+        var_params_for_n_sources = self._get_var_params_for_n_sources(
+            var_params_flat, tile_n_sources
+        )
 
         # get probability of n_sources
         # n_source_log_probs: shape = (n_ptiles x (max_detections+1))
-        n_source_log_probs = self._get_logprob_n_from_var_params(var_params)
+        n_source_log_probs = self._get_logprob_n_from_var_params(var_params_flat)
         var_params_for_n_sources["n_source_log_probs"] = n_source_log_probs
         if squeeze:
             var_params_for_n_sources = {

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -15,7 +15,6 @@ from bliss.models.location_encoder import (
     get_images_in_tiles,
     get_is_on_from_n_sources,
     get_n_tiles_hw,
-    get_params_in_batches,
 )
 
 
@@ -56,13 +55,13 @@ def predict_on_image(
 
     # get MAP estimates and variational parameters from image_encoder
     var_params = image_encoder.encode(ptiles)
-    tile_n_sources = image_encoder.tile_map_n_sources(var_params)
+    var_params_flat = rearrange(var_params, "b nth ntw d -> (b nth ntw) d")
+    tile_n_sources = image_encoder.tile_map_n_sources(var_params_flat)
     tile_is_on_array = get_is_on_from_n_sources(tile_n_sources, 1).reshape(1, -1, 1, 1)
 
     tile_map = image_encoder.max_a_post(var_params)
-    tile_map = get_params_in_batches(tile_map, image.shape[0])
 
-    var_params_n_sources = image_encoder.encode_for_n_sources(var_params, tile_n_sources)
+    var_params_n_sources = image_encoder.encode_for_n_sources(var_params_flat, tile_n_sources)
 
     # binary prediction
     assert not binary_encoder.training

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -69,6 +69,9 @@ def predict_on_image(
 
     galaxy_probs = binary_encoder(ptiles, tile_map["locs"]).reshape(1, -1, 1, 1) * tile_is_on_array
     galaxy_bools = (galaxy_probs > 0.5).float() * tile_is_on_array
+
+    galaxy_probs = rearrange(galaxy_probs, "b (nth ntw) s 1 -> b nth ntw s 1", nth=ptiles.shape[1])
+    galaxy_bools = rearrange(galaxy_bools, "b (nth ntw) s 1 -> b nth ntw s 1", nth=ptiles.shape[1])
     star_bools = get_star_bools(tile_map["n_sources"], galaxy_bools)
     var_params_n_sources["galaxy_bools"] = galaxy_bools
     var_params_n_sources["star_bools"] = star_bools
@@ -86,7 +89,10 @@ def predict_on_image(
     galaxy_param_mean, _ = galaxy_encoder.encode(ptiles, tile_map["locs"])
     latent_dim = galaxy_param_mean.shape[-1]
     galaxy_param_mean = galaxy_param_mean.reshape(1, -1, 1, latent_dim)
-    galaxy_param_mean *= tile_is_on_array * galaxy_bools
+    galaxy_param_mean *= tile_is_on_array * galaxy_bools.reshape(1, -1, 1, 1)
+    galaxy_param_mean = rearrange(
+        galaxy_param_mean, "b (nth ntw) s d -> b nth ntw s d", nth=ptiles.shape[1]
+    )
     var_params_n_sources["galaxy_param_mean"] = galaxy_param_mean
     tile_map["galaxy_params"] = galaxy_param_mean
 

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -230,17 +230,19 @@ class SleepPhase(pl.LightningModule):
         max_sources = self.image_encoder.max_detections
 
         # clip decoder output since constraint is: max_detections <= max_sources (per tile)
-        true_tile_locs = true_tile_locs[:, :, 0:max_sources]
-        true_tile_log_fluxes = true_tile_log_fluxes[:, :, 0:max_sources]
-        true_tile_galaxy_bools = true_tile_galaxy_bools[:, :, 0:max_sources]
+        true_tile_locs = true_tile_locs[:, :, :, 0:max_sources]
+        true_tile_log_fluxes = true_tile_log_fluxes[:, :, :, 0:max_sources]
+        true_tile_galaxy_bools = true_tile_galaxy_bools[:, :, :, 0:max_sources]
         true_tile_n_sources = true_tile_n_sources.clamp(max=max_sources)
 
         # flatten so first dimension is ptile
         # b: batch, s: n_tiles_per_image
-        true_tile_locs = rearrange(true_tile_locs, "b n s xy -> (b n) s xy", xy=2)
-        true_tile_log_fluxes = rearrange(true_tile_log_fluxes, "b n s bands -> (b n) s bands")
-        true_tile_galaxy_bools = rearrange(true_tile_galaxy_bools, "b n s 1 -> (b n) s")
-        true_tile_n_sources = rearrange(true_tile_n_sources, "b n -> (b n)")
+        true_tile_locs = rearrange(true_tile_locs, "b nth ntw s xy -> (b nth ntw) s xy", xy=2)
+        true_tile_log_fluxes = rearrange(
+            true_tile_log_fluxes, "b nth ntw s bands -> (b nth ntw) s bands"
+        )
+        true_tile_galaxy_bools = rearrange(true_tile_galaxy_bools, "b nth ntw s 1 -> (b nth ntw) s")
+        true_tile_n_sources = rearrange(true_tile_n_sources, "b nth ntw -> (b nth ntw)")
         true_tile_is_on_array = get_is_on_from_n_sources(true_tile_n_sources, max_sources)
 
         # extract image tiles

--- a/tests/m2/test_m2.py
+++ b/tests/m2/test_m2.py
@@ -7,7 +7,6 @@ import torch
 from bliss.models.location_encoder import (
     get_full_params_from_tiles,
     get_images_in_tiles,
-    get_params_in_batches,
 )
 
 
@@ -73,7 +72,6 @@ def get_map_estimate(image_encoder, images, slen: int, wlen: int = None):
     ptiles = get_images_in_tiles(images, image_encoder.tile_slen, image_encoder.ptile_slen)
     var_params = image_encoder.encode(ptiles)
     tile_map = image_encoder.max_a_post(var_params)
-    tile_map = get_params_in_batches(tile_map, images.shape[0])
 
     return get_full_params_from_tiles(tile_map, image_encoder.tile_slen)
 


### PR DESCRIPTION
Fixes #390. We now keep track of the padded tiles in their 2-D positions, which makes it easier to reconstruct non-square images.