### PR TITLE
Fix dependency on batch size by making image_min a parameter

### DIFF
--- a/bliss/datasets/sdss_blended_galaxies.py
+++ b/bliss/datasets/sdss_blended_galaxies.py
@@ -136,7 +136,8 @@ class SdssBlendedGalaxies(pl.LightningDataModule):
             out[k] = torch.cat([x[k] for x in tile_catalogs], dim=0)
         return out
 
-    def _prerender_chunks(self, image):
+    def _prerender_chunks(self, image: Tensor):
+        image_min = image.min()
         chunks = F.unfold(image, kernel_size=self.kernel_size, stride=self.stride)
         chunks = rearrange(
             chunks,
@@ -152,7 +153,7 @@ class SdssBlendedGalaxies(pl.LightningDataModule):
             for chunk in tqdm(chunks):
                 chunk_device = chunk.to(self.prerender_device)
                 image_ptiles = encoder.get_images_in_ptiles(chunk_device.unsqueeze(0))
-                tile_map = encoder.max_a_post(image_ptiles)
+                tile_map = encoder.max_a_post(image_ptiles, image_min)
                 if tile_map["galaxy_bools"].sum() > 0:
                     catalogs.append(cpu(tile_map))
                     chunks_with_galaxies.append(chunk.cpu())

--- a/bliss/encoder.py
+++ b/bliss/encoder.py
@@ -66,7 +66,7 @@ class Encoder(nn.Module):
     def sample(self, image_ptiles, n_samples):
         raise NotImplementedError("Sampling from Encoder not yet available.")
 
-    def max_a_post(self, image_ptiles: Tensor) -> Dict[str, Tensor]:
+    def max_a_post(self, image_ptiles: Tensor, image_min: float) -> Dict[str, Tensor]:
         """Get maximum a posteriori of catalog from image padded tiles.
 
         Note that, strictly speaking, this is not the true MAP of the variational
@@ -87,12 +87,12 @@ class Encoder(nn.Module):
             - 'galaxy_bools', 'star_bools', and 'galaxy_probs' from BinaryEncoder.
             - 'galaxy_params' from GalaxyEncoder.
         """
-        var_params = self.location_encoder.encode(image_ptiles)
+        var_params = self.location_encoder.encode(image_ptiles, image_min)
         tile_map = self.location_encoder.max_a_post(var_params)
 
         if self.binary_encoder is not None:
             assert not self.binary_encoder.training
-            galaxy_probs = self.binary_encoder(image_ptiles, tile_map["locs"])
+            galaxy_probs = self.binary_encoder(image_ptiles, tile_map["locs"], image_min)
             galaxy_probs *= tile_map["is_on_array"]
             galaxy_bools = (galaxy_probs > 0.5).float() * tile_map["is_on_array"]
             star_bools = get_star_bools(tile_map["n_sources"], galaxy_bools)

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -307,7 +307,7 @@ class LocationEncoder(nn.Module):
     def forward(self, image_ptiles, tile_n_sources):
         raise NotImplementedError("The forward method has changed to encode_for_n_sources()")
 
-    def encode(self, image_ptiles: Tensor) -> Tensor:
+    def encode(self, image_ptiles: Tensor, image_min: float = None) -> Tensor:
         """Encodes variational parameters from image padded tiles.
 
         Args:
@@ -323,7 +323,10 @@ class LocationEncoder(nn.Module):
         # get h matrix.
         # Forward to the layer that is shared by all n_sources.
         image_ptiles_flat = rearrange(image_ptiles, "b nth ntw c h w -> (b nth ntw) c h w")
-        log_img = torch.log(image_ptiles_flat - image_ptiles_flat.min() + 1.0)
+        if image_min is None:
+            assert self.training
+            image_min = image_ptiles_flat.min()
+        log_img = torch.log(image_ptiles_flat - image_min + 1.0)
         var_params_conv = self.enc_conv(log_img)
         var_params_flat = self.enc_final(var_params_conv)
         return rearrange(

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -160,7 +160,8 @@ class SleepPhase(pl.LightningModule):
         image_ptiles = get_images_in_tiles(
             images, self.image_encoder.tile_slen, self.image_encoder.ptile_slen
         )
-        var_params = self.image_encoder.encode(image_ptiles)
+        assert not self.image_encoder.training
+        var_params = self.image_encoder.encode(image_ptiles, image_ptiles.min())
         tile_map = self.image_encoder.max_a_post(var_params)
         tile_map["galaxy_params"] = batch["galaxy_params"]
 
@@ -249,7 +250,10 @@ class SleepPhase(pl.LightningModule):
         image_ptiles = get_images_in_tiles(
             images, self.image_encoder.tile_slen, self.image_encoder.ptile_slen
         )
-        var_params = self.image_encoder.encode(image_ptiles)
+        if self.image_encoder.training:
+            var_params = self.image_encoder.encode(image_ptiles)
+        else:
+            var_params = self.image_encoder.encode(image_ptiles, image_ptiles.min())
         var_params_flat = rearrange(var_params, "b nth ntw d -> (b nth ntw) d")
         pred = self.image_encoder.encode_for_n_sources(var_params_flat, true_tile_n_sources)
 

--- a/case_studies/sdss_galaxies_vae/config/config.yaml
+++ b/case_studies/sdss_galaxies_vae/config/config.yaml
@@ -204,7 +204,6 @@ reconstruct:
     coadd_cat: ${paths.data}/coadd_catalog_94_1_12.fits
     psf_file: ${paths.data}/psField-000094-1-0012-PSF-image.npy
     real: False
-    slen: 300
     outdir:
     scenes:
         # sdss_recon0:

--- a/case_studies/sdss_galaxies_vae/config/reconstruct/sdss_figures_real.yaml
+++ b/case_studies/sdss_galaxies_vae/config/reconstruct/sdss_figures_real.yaml
@@ -5,15 +5,24 @@ scenes:
         h: 200
         w: 1700
         size: 300
+        slen: 300
     sdss_recon1:
         h: 1150
         w: 1000
         size: 300
+        slen: 300
+    sdss_recon1_80:
+        h: 1150
+        w: 1000
+        size: 300
+        slen: 80
     sdss_recon2:
         h: 200
         w: 200
         size: 1200
+        slen: 300
     sdss_recon3:
         h: 24
         w: 24
         size: "all"
+        slen: 300

--- a/case_studies/sdss_galaxies_vae/reconstruction.py
+++ b/case_studies/sdss_galaxies_vae/reconstruction.py
@@ -50,7 +50,12 @@ def reconstruct(cfg):
 
     for scene_name, scene_coords in cfg.reconstruct.scenes.items():
         bp = encoder.border_padding
-        h, w, scene_size = scene_coords["h"], scene_coords["w"], scene_coords["size"]
+        h, w, scene_size, slen = (
+            scene_coords["h"],
+            scene_coords["w"],
+            scene_coords["size"],
+            scene_coords["slen"],
+        )
         if scene_size == "all":
             h = bp
             w = bp
@@ -62,7 +67,7 @@ def reconstruct(cfg):
         true = my_image[:, :, h:h_end, w:w_end]
         coadd_objects = get_objects_from_coadd(coadd_cat, h, w, h_end, w_end)
         recon, map_recon = reconstruct_scene_at_coordinates(
-            encoder, dec, my_image, (h, h_end), (w, w_end), slen=cfg.reconstruct.slen, device=device
+            encoder, dec, my_image, (h, h_end), (w, w_end), slen=slen, device=device
         )
         resid = (true - recon) / recon.sqrt()
         if outdir is not None:

--- a/case_studies/sdss_galaxies_vae/tests/test_reconstruction.py
+++ b/case_studies/sdss_galaxies_vae/tests/test_reconstruction.py
@@ -7,10 +7,10 @@ def test_reconstruct(model_setup, devices):
         "reconstruct.outdir": None,
         "reconstruct.real": False,
         "reconstruct.device": "cpu",
-        "reconstruct.slen": 80,
         "+reconstruct.scenes.sdss_recon1_test.h": 200 + 50,
         "+reconstruct.scenes.sdss_recon1_test.w": 1700 + 150,
         "+reconstruct.scenes.sdss_recon1_test.size": 100,
+        "+reconstruct.scenes.sdss_recon1_test.slen": 80,
     }
 
     cfg = model_setup.get_cfg(overrides)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ class ModelSetup:
                 "+training.seed": 42,
                 "training.trainer.logger": False,
                 "training.trainer.check_val_every_n_epoch": 1001,
-                "training.trainer.deterministic": True,
+                "training.trainer.deterministic": not self.devices.use_cuda,
             }
         )
         cfg = self.get_cfg(overrides)

--- a/tests/m2/test_m2.py
+++ b/tests/m2/test_m2.py
@@ -72,7 +72,7 @@ def get_map_estimate(image_encoder, images, slen: int, wlen: int = None):
     ptiles = get_images_in_tiles(images, image_encoder.tile_slen, image_encoder.ptile_slen)
     var_params = image_encoder.encode(ptiles)
     var_params2 = image_encoder.encode(ptiles[:, :25, :25])
-    assert torch.allclose(var_params[0,:25,:25], var_params2)
+    assert torch.allclose(var_params[0, :25, :25], var_params2, atol=1e-5)
     tile_map = image_encoder.max_a_post(var_params)
 
     return get_full_params_from_tiles(tile_map, image_encoder.tile_slen)

--- a/tests/m2/test_m2.py
+++ b/tests/m2/test_m2.py
@@ -70,8 +70,9 @@ def get_map_estimate(image_encoder, images, slen: int, wlen: int = None):
 
     # obtained estimates per tile, then on full image.
     ptiles = get_images_in_tiles(images, image_encoder.tile_slen, image_encoder.ptile_slen)
-    var_params = image_encoder.encode(ptiles)
-    var_params2 = image_encoder.encode(ptiles[:, :25, :25])
+    image_min = ptiles.min()
+    var_params = image_encoder.encode(ptiles, image_min)
+    var_params2 = image_encoder.encode(ptiles[:, :25, :25], image_min)
     assert torch.allclose(var_params[0, :25, :25], var_params2, atol=1e-5)
     tile_map = image_encoder.max_a_post(var_params)
 

--- a/tests/m2/test_m2.py
+++ b/tests/m2/test_m2.py
@@ -71,6 +71,8 @@ def get_map_estimate(image_encoder, images, slen: int, wlen: int = None):
     # obtained estimates per tile, then on full image.
     ptiles = get_images_in_tiles(images, image_encoder.tile_slen, image_encoder.ptile_slen)
     var_params = image_encoder.encode(ptiles)
+    var_params2 = image_encoder.encode(ptiles[:, :25, :25])
+    assert torch.allclose(var_params[0,:25,:25], var_params2)
     tile_map = image_encoder.max_a_post(var_params)
 
     return get_full_params_from_tiles(tile_map, image_encoder.tile_slen)

--- a/tests/test_encoder_forward.py
+++ b/tests/test_encoder_forward.py
@@ -59,7 +59,7 @@ class TestSourceEncoder:
 
             var_params = star_encoder.encode(image_ptiles)
             var_params2 = star_encoder.encode(image_ptiles[:, :-2, :-3])
-            assert torch.allclose(var_params[:, :-2, :-3], var_params2)
+            assert torch.allclose(var_params[:, :-2, :-3], var_params2, atol=1e-5)
             var_params_flat = var_params.reshape(-1, var_params.shape[-1])
             pred = star_encoder.encode_for_n_sources(var_params_flat, n_star_per_tile)
 

--- a/tests/test_encoder_forward.py
+++ b/tests/test_encoder_forward.py
@@ -58,6 +58,8 @@ class TestSourceEncoder:
             )
 
             var_params = star_encoder.encode(image_ptiles)
+            var_params2 = star_encoder.encode(image_ptiles[:, :-2, :-3])
+            assert torch.allclose(var_params[:, :-2, :-3], var_params2)
             var_params_flat = var_params.reshape(-1, var_params.shape[-1])
             pred = star_encoder.encode_for_n_sources(var_params_flat, n_star_per_tile)
 


### PR DESCRIPTION
Using background values in #435 leads to performance degradation on the m2 cluster. Effectively, using the minimum value of the image is like a batch normalization. This is an alternative change that forces the user to pass the image min to the "forward()" method when in eval mode.