### PR TITLE
Utilize square-root of background when log-transforming images

### DIFF
--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -7,8 +7,22 @@ from torch.distributions import categorical
 from torch.nn import functional as F
 
 
-def subtract_bg_and_log_transform(image, background, slack=100.0):
-    return torch.log1p(F.relu(image - background + slack, inplace=True))
+def subtract_bg_and_log_transform(image: Tensor, background: Tensor, z_threshold: float = 3.4):
+    """Transforms image before encoder network.
+
+    This subtracts background plus a few standard deviations from the image,
+    then a log1p.
+
+    Arguments:
+        images: Tensor of images (n x c x h x w).
+        background: Tensor of background (n x c x h x w).
+        z_threshold: Number of standard deviations to further subtract from
+        background. Default is 3.4 because 100 / sqrt(865) is approximately 3.4.
+
+    Returns:
+        A Tensor of the transformed images (n x c x h x w).
+    """
+    return torch.log1p(F.relu(image - background + z_threshold * background.sqrt(), inplace=True))
 
 
 def get_images_in_tiles(images, tile_slen, ptile_slen):

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -7,7 +7,7 @@ from torch.distributions import categorical
 from torch.nn import functional as F
 
 
-def subtract_bg_and_log_transform(image: Tensor, background: Tensor, z_threshold: float = 3.4):
+def subtract_bg_and_log_transform(image: Tensor, background: Tensor, z_threshold: float = 5.0):
     """Transforms image before encoder network.
 
     This subtracts background plus a few standard deviations from the image,
@@ -17,7 +17,7 @@ def subtract_bg_and_log_transform(image: Tensor, background: Tensor, z_threshold
         images: Tensor of images (n x c x h x w).
         background: Tensor of background (n x c x h x w).
         z_threshold: Number of standard deviations to further subtract from
-        background. Default is 3.4 because 100 / sqrt(865) is approximately 3.4.
+        background. Default is 5.0.
 
     Returns:
         A Tensor of the transformed images (n x c x h x w).

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -7,7 +7,7 @@ from torch.distributions import categorical
 from torch.nn import functional as F
 
 
-def subtract_bg_and_log_transform(image: Tensor, background: Tensor, z_threshold: float = 5.0):
+def subtract_bg_and_log_transform(image: Tensor, background: Tensor, z_threshold: float = 4.0):
     """Transforms image before encoder network.
 
     This subtracts background plus a few standard deviations from the image,
@@ -16,8 +16,7 @@ def subtract_bg_and_log_transform(image: Tensor, background: Tensor, z_threshold
     Arguments:
         images: Tensor of images (n x c x h x w).
         background: Tensor of background (n x c x h x w).
-        z_threshold: Number of standard deviations to further subtract from
-        background. Default is 5.0.
+        z_threshold: Number of standard deviations to further subtract.
 
     Returns:
         A Tensor of the transformed images (n x c x h x w).

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -14,7 +14,7 @@ def subtract_bg_and_log_transform(image: Tensor, background: Tensor, z_threshold
     then a log1p.
 
     Arguments:
-        images: Tensor of images (n x c x h x w).
+        image: Tensor of images (n x c x h x w).
         background: Tensor of background (n x c x h x w).
         z_threshold: Number of standard deviations to further subtract.
 


### PR DESCRIPTION
Closes #450.