### PR TITLE
Fix incorrect expected recall and precision on detections

### DIFF
--- a/case_studies/sdss_galaxies_vae/reconstruction.py
+++ b/case_studies/sdss_galaxies_vae/reconstruction.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Tuple
 
 import torch
+import numpy as np
 import pandas as pd
 from astropy.table import Table
 from einops import rearrange, repeat
@@ -405,9 +406,6 @@ def create_scene_accuracy_table(scene_metrics_by_mag):
         line = f"{k} & {v['class_acc'].item():.2f} ({v['expected_accuracy'].item():.2f}) & {v['galaxy_accuracy']:.2f} ({v['expected_galaxy_accuracy']:.2f}) & {v['star_accuracy']:.2f} ({v['expected_star_accuracy']:.2f})\\\\\n"
         tex_lines.append(line)
     return tex_lines
-
-
-import numpy as np
 
 
 def create_scene_metrics_table(scene_metrics_by_mag):


### PR DESCRIPTION
- Don't calculate metrics on just galaxies, but overall
- We can't actually calculate recall with a magnitude cut, since
we don't estimate galaxy fluxes for objects where P < 0.5. This
could be changed.