### PR TITLE
nbstripout notebooks in `case_studies/sdss_galaxies/notebooks`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-*.ipynb filter=nbstripout
-*.ipynb diff=ipynb
+case_studies/sdss_galaxies/notebooks/*.ipynb filter=nbstripout
+case_studies/sdss_galaxies/notebooks/*.ipynb diff=ipynb
 data/sdss/2583/* filter=lfs diff=lfs merge=lfs -text
 data/hubble/* filter=lfs diff=lfs merge=lfs -text
 data/cosmoDC2_wld_sdss_10_sq_deg.fits filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
I ran into some problems push my notebook so this fixes that. I only in nbstripout notebooks in my case_studies folder. @dereklhansen feel free to add your directly later too if that might be helpful for your own notebooks. 