### PR TITLE
refactor location encoder

### DIFF
--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -117,8 +117,6 @@ class LocationEncoder(nn.Module):
         for k, v in indx_mats.items():
             self.register_buffer(k + "_indx", v, persistent=False)
 
-        assert self.prob_n_source_indx.shape[0] == self.max_detections + 1
-
     def encode(self, image: Tensor, background: Tensor) -> Tensor:
         """Encodes variational parameters from image padded tiles.
 

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -239,7 +239,7 @@ class SleepPhase(pl.LightningModule):
         var_params = self.image_encoder.encode(images, background)
         var_params_flat = rearrange(var_params, "b nth ntw d -> (b nth ntw) d")
         n_source_log_probs = self.image_encoder.get_n_source_log_prob(var_params_flat)
-        pred = self.image_encoder.encode_for_n_sources(var_params_flat, true_tile_n_sources)
+        pred = self.image_encoder.encode_for_n_sources_flat(var_params_flat, true_tile_n_sources)
 
         # the loss for estimating the true number of sources
         nllloss = torch.nn.NLLLoss(reduction="none").requires_grad_(False)

--- a/bliss/sleep.py
+++ b/bliss/sleep.py
@@ -232,27 +232,28 @@ class SleepPhase(pl.LightningModule):
             true_tile_log_fluxes, "b nth ntw s bands -> (b nth ntw) s bands"
         )
         true_tile_galaxy_bools = rearrange(true_tile_galaxy_bools, "b nth ntw s 1 -> (b nth ntw) s")
-        true_tile_n_sources = rearrange(true_tile_n_sources, "b nth ntw -> (b nth ntw)")
-        true_tile_is_on_array = get_is_on_from_n_sources(true_tile_n_sources, max_sources)
+        true_tile_n_sources = rearrange(true_tile_n_sources, "b nth ntw -> 1 (b nth ntw)")
 
         # extract image tiles
         var_params = self.image_encoder.encode(images, background)
         var_params_flat = rearrange(var_params, "b nth ntw d -> (b nth ntw) d")
         n_source_log_probs = self.image_encoder.get_n_source_log_prob(var_params_flat)
-        pred = self.image_encoder.encode_for_n_sources_flat(var_params_flat, true_tile_n_sources)
-
+        pred = self.image_encoder.encode_for_n_sources(var_params_flat, true_tile_n_sources)
         # the loss for estimating the true number of sources
         nllloss = torch.nn.NLLLoss(reduction="none").requires_grad_(False)
-        counter_loss = nllloss(n_source_log_probs, true_tile_n_sources)
+        counter_loss = nllloss(n_source_log_probs, true_tile_n_sources.squeeze(0))
 
         # the following two functions computes the log-probability of parameters when
         # each estimated source i is matched with true source j.
         # enforce large error if source is off
-        loc_mean, loc_logvar = pred["loc_mean"], pred["loc_logvar"]
+        true_tile_is_on_array = get_is_on_from_n_sources(true_tile_n_sources, max_sources).squeeze(
+            0
+        )
+        loc_mean, loc_logvar = pred["loc_mean"][0], pred["loc_logvar"][0]
         loc_mean = loc_mean + (true_tile_is_on_array == 0).float().unsqueeze(-1) * 1e16
         locs_log_probs_all = get_params_logprob_all_combs(true_tile_locs, loc_mean, loc_logvar)
         star_params_log_probs_all = get_params_logprob_all_combs(
-            true_tile_log_fluxes, pred["log_flux_mean"], pred["log_flux_logvar"]
+            true_tile_log_fluxes, pred["log_flux_mean"][0], pred["log_flux_logvar"][0]
         )
 
         # inside _get_min_perm_loss is where the matching happens:

--- a/tests/test_encoder_forward.py
+++ b/tests/test_encoder_forward.py
@@ -77,7 +77,7 @@ class TestSourceEncoder:
                 var_params[:, :-h_tile_cutoff, :-w_tile_cutoff], var_params2, atol=1e-5
             )
             var_params_flat = var_params.reshape(-1, var_params.shape[-1])
-            pred = star_encoder.encode_for_n_sources(var_params_flat, n_star_per_tile)
+            pred = star_encoder.encode_for_n_sources_flat(var_params_flat, n_star_per_tile)
 
             assert torch.all(pred["loc_mean"] >= 0.0)
             assert torch.all(pred["loc_mean"] <= 1.0)

--- a/tests/test_encoder_forward.py
+++ b/tests/test_encoder_forward.py
@@ -77,30 +77,30 @@ class TestSourceEncoder:
                 var_params[:, :-h_tile_cutoff, :-w_tile_cutoff], var_params2, atol=1e-5
             )
             var_params_flat = var_params.reshape(-1, var_params.shape[-1])
-            pred = star_encoder.encode_for_n_sources_flat(var_params_flat, n_star_per_tile)
+            pred = star_encoder.encode_for_n_sources(var_params_flat, n_star_per_tile.unsqueeze(0))
 
             assert torch.all(pred["loc_mean"] >= 0.0)
             assert torch.all(pred["loc_mean"] <= 1.0)
 
             # test we have the correct pattern of zeros
-            assert ((pred["loc_mean"] != 0).sum(1)[:, 0] == n_star_per_tile).all()
-            assert ((pred["loc_mean"] != 0).sum(1)[:, 1] == n_star_per_tile).all()
+            assert ((pred["loc_mean"] != 0)[0].sum(1)[:, 0] == n_star_per_tile).all()
+            assert ((pred["loc_mean"] != 0)[0].sum(1)[:, 1] == n_star_per_tile).all()
 
-            assert ((pred["loc_logvar"] != 0).sum(1)[:, 0] == n_star_per_tile).all()
-            assert ((pred["loc_logvar"] != 0).sum(1)[:, 1] == n_star_per_tile).all()
+            assert ((pred["loc_logvar"] != 0)[0].sum(1)[:, 0] == n_star_per_tile).all()
+            assert ((pred["loc_logvar"] != 0)[0].sum(1)[:, 1] == n_star_per_tile).all()
 
             for i in range(2):
-                assert ((pred["loc_mean"][:, :, i] != 0).sum(1) == n_star_per_tile).all()
+                assert ((pred["loc_mean"][0, :, :, i] != 0).sum(1) == n_star_per_tile).all()
 
             for b in range(n_bands):
-                assert ((pred["log_flux_mean"][:, :, b] != 0).sum(1) == n_star_per_tile).all()
+                assert ((pred["log_flux_mean"][0, :, :, b] != 0).sum(1) == n_star_per_tile).all()
 
             # check pattern of zeros
             is_on_array = get_is_on_from_n_sources(n_star_per_tile, star_encoder.max_detections)
-            loc_mean = pred["loc_mean"] * is_on_array.unsqueeze(2).float()
-            log_flux_mean = pred["log_flux_mean"] * is_on_array.unsqueeze(2).float()
-            assert torch.all(loc_mean == pred["loc_mean"])
-            assert torch.all(log_flux_mean == pred["log_flux_mean"])
+            loc_mean = pred["loc_mean"][0] * is_on_array.unsqueeze(2).float()
+            log_flux_mean = pred["log_flux_mean"][0] * is_on_array.unsqueeze(2).float()
+            assert torch.all(loc_mean == pred["loc_mean"][0])
+            assert torch.all(log_flux_mean == pred["log_flux_mean"][0])
 
             # we check the variational parameters against the hidden parameters
             # one by one
@@ -115,15 +115,15 @@ class TestSourceEncoder:
 
             for i in range(batch_size * n_tiles_h * n_tiles_w):
                 if n_star_per_tile[i] == 0:
-                    assert torch.all(pred["loc_mean"][i] == 0)
-                    assert torch.all(pred["loc_logvar"][i] == 0)
-                    assert torch.all(pred["log_flux_mean"][i] == 0)
-                    assert torch.all(pred["log_flux_logvar"][i] == 0)
+                    assert torch.all(pred["loc_mean"][0, i] == 0)
+                    assert torch.all(pred["loc_logvar"][0, i] == 0)
+                    assert torch.all(pred["log_flux_mean"][0, i] == 0)
+                    assert torch.all(pred["log_flux_logvar"][0, i] == 0)
                 else:
                     n_stars_i = int(n_star_per_tile[i])
 
                     assert torch.all(
-                        pred["loc_mean"][i, :n_stars_i].flatten()
+                        pred["loc_mean"][0, i, :n_stars_i].flatten()
                         == torch.sigmoid(h_out)[
                             i,
                             locs_mean_indx_mat[n_stars_i][: (2 * n_stars_i)],
@@ -131,7 +131,7 @@ class TestSourceEncoder:
                     )
 
                     assert torch.all(
-                        pred["loc_logvar"][i, :n_stars_i].flatten()
+                        pred["loc_logvar"][0, i, :n_stars_i].flatten()
                         == h_out[
                             i,
                             locs_var_indx_mat[n_stars_i][: (2 * n_stars_i)],
@@ -139,7 +139,7 @@ class TestSourceEncoder:
                     )
 
                     assert torch.all(
-                        pred["log_flux_mean"][i, :n_stars_i].flatten()
+                        pred["log_flux_mean"][0, i, :n_stars_i].flatten()
                         == h_out[
                             i,
                             log_flux_mean_indx_mat[n_stars_i][: (n_bands * n_stars_i)],
@@ -147,7 +147,7 @@ class TestSourceEncoder:
                     )
 
                     assert torch.all(
-                        pred["log_flux_logvar"][i, :n_stars_i].flatten()
+                        pred["log_flux_logvar"][0, i, :n_stars_i].flatten()
                         == h_out[
                             i,
                             log_flux_var_indx_mat[n_stars_i][: (n_bands * n_stars_i)],


### PR DESCRIPTION
I have in mind overhauling the location encoder more thoroughly (begun on branch `jr/deeper_refactoring`), but I'm not sure when I'll get to it, so we may as merge this now. It's already a significant simplification. Closes #388 more or less. In a deeper refactoring, I'd aim to get rid of `encode_for_n_sources` (and `encode_for_n_sources_flat`, and `_get_hidden_indices`) entirely.