### PR TITLE
Revert "Enable sampling from variational distribution (#556)"

### DIFF
--- a/bliss/encoder.py
+++ b/bliss/encoder.py
@@ -4,12 +4,7 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor, nn
 
-from bliss.catalog import (
-    TileCatalog,
-    TileCatalogSamples,
-    get_images_in_tiles,
-    get_is_on_from_n_sources,
-)
+from bliss.catalog import TileCatalog, get_images_in_tiles, get_is_on_from_n_sources
 from bliss.models.binary import BinaryEncoder
 from bliss.models.galaxy_encoder import GalaxyEncoder
 from bliss.models.location_encoder import LocationEncoder
@@ -79,38 +74,47 @@ class Encoder(nn.Module):
             ".forward() method for Encoder not available. Use .max_a_post() or .sample()."
         )
 
-    def sample(
-        self, image: Tensor, background: Tensor, n_samples: Optional[int] = None
-    ) -> TileCatalogSamples:
+    def sample(self, image_ptiles, n_samples):
+        raise NotImplementedError("Sampling from Encoder not yet available.")
+
+    def max_a_post(self, image: Tensor, background: Tensor) -> TileCatalog:
+        """Get maximum a posteriori of catalog from image padded tiles.
+
+        Note that, strictly speaking, this is not the true MAP of the variational
+        distribution of the catalog.
+        Rather, we use sequential estimation; the MAP of the locations is first estimated,
+        then plugged-in to the binary and galaxy encoders. Thus, the binary and galaxy
+        encoders are conditioned on the location MAP. The true MAP would require optimizing
+        over the entire catalog jointly, but this is not tractable.
+
+        Args:
+            image: An astronomical image,
+                with shape `n * n_bands * h * w`.
+            background: Background associated with image,
+                with shape `n * n_bands * h * w`.
+
+        Returns:
+            A dictionary of the maximum a posteriori
+            of the catalog in tiles. Specifically, this dictionary comprises:
+                - The output of LocationEncoder.max_a_post()
+                - 'galaxy_bools', 'star_bools', and 'galaxy_probs' from BinaryEncoder.
+                - 'galaxy_params' from GalaxyEncoder.
+        """
+        assert isinstance(self.map_n_source_weights, Tensor)
         var_params = self.location_encoder.encode(
             image, background, eval_mean_detections=self.eval_mean_detections
         )
-        if n_samples is None:
-            assert isinstance(self.map_n_source_weights, Tensor)
-            tile_map = self.location_encoder.max_a_post(
-                var_params, n_source_weights=self.map_n_source_weights
-            )
-            tile_catalog_samples = TileCatalogSamples.unflatten_sample_and_batch_dim(1, tile_map)
-        else:
-            tile_catalog_samples = self.location_encoder.sample(var_params, n_samples)
+        tile_map = self.location_encoder.max_a_post(
+            var_params, n_source_weights=self.map_n_source_weights
+        )
+
         if self.binary_encoder is not None:
             assert not self.binary_encoder.training
-            locs = tile_catalog_samples.locs.reshape(-1, *tile_catalog_samples.shape[2:], 2)
-            image = image.expand(locs.shape[0], -1, -1, -1)
-            background = image.expand(locs.shape[0], -1, -1, -1)
-            galaxy_probs = self.binary_encoder.forward(image, background, locs)
-            galaxy_probs = galaxy_probs.reshape(*tile_catalog_samples.shape, 1)
-            galaxy_probs *= tile_catalog_samples.is_on_array.unsqueeze(-1)
-            if n_samples is None:
-                galaxy_bools = (
-                    galaxy_probs > 0.5
-                ).float() * tile_catalog_samples.is_on_array.unsqueeze(-1)
-            else:
-                galaxy_bools = (
-                    torch.rand_like(galaxy_probs) <= galaxy_probs
-                ) * tile_catalog_samples.is_on_array.unsqueeze(-1)
-            star_bools = get_star_bools(tile_catalog_samples.n_sources, galaxy_bools)
-            tile_catalog_samples.update(
+            galaxy_probs = self.binary_encoder.forward(image, background, tile_map.locs)
+            galaxy_probs *= tile_map.is_on_array.unsqueeze(-1)
+            galaxy_bools = (galaxy_probs > 0.5).float() * tile_map.is_on_array.unsqueeze(-1)
+            star_bools = get_star_bools(tile_map.n_sources, galaxy_bools)
+            tile_map.update(
                 {
                     "galaxy_bools": galaxy_bools,
                     "star_bools": star_bools,
@@ -119,21 +123,10 @@ class Encoder(nn.Module):
             )
 
         if self.galaxy_encoder is not None:
-            if n_samples is None:
-                galaxy_params = self.galaxy_encoder.max_a_post(image, background, locs)
-            else:
-                galaxy_params = self.galaxy_encoder.sample(image, background, locs)
-            galaxy_params = galaxy_params.reshape(*tile_catalog_samples.shape, -1)
-            galaxy_params *= (
-                tile_catalog_samples.is_on_array.unsqueeze(-1)
-                * tile_catalog_samples["galaxy_bools"]
-            )
-            tile_catalog_samples.update({"galaxy_params": galaxy_params})
-        return tile_catalog_samples
-
-    def max_a_post(self, image: Tensor, background: Tensor) -> TileCatalog:
-        tile_samples = self.sample(image, background, n_samples=None)
-        return tile_samples.flatten_sample_and_batch_dim()
+            galaxy_params = self.galaxy_encoder.max_a_post(image, background, tile_map.locs)
+            galaxy_params *= tile_map.is_on_array.unsqueeze(-1) * tile_map["galaxy_bools"]
+            tile_map.update({"galaxy_params": galaxy_params})
+        return tile_map
 
     def get_images_in_ptiles(self, images):
         """Run get_images_in_ptiles with correct tile_slen and ptile_slen."""

--- a/bliss/inference.py
+++ b/bliss/inference.py
@@ -1,6 +1,6 @@
 import math
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Sequence, Tuple
 
 import numpy as np
 import torch
@@ -9,7 +9,7 @@ from torch import Tensor
 from torch.nn import functional as F
 from tqdm import tqdm
 
-from bliss.catalog import FullCatalog, TileCatalog, TileCatalogSamples
+from bliss.catalog import FullCatalog, TileCatalog
 from bliss.datasets.sdss import SloanDigitalSkySurvey, convert_flux_to_mag
 from bliss.datasets.simulated import SimulatedDataset
 from bliss.encoder import Encoder
@@ -18,33 +18,29 @@ from bliss.reporting import CoaddFullCatalog
 
 
 def reconstruct_scene_at_coordinates(
-    n_samples: Union[int, None],
     encoder: Encoder,
     decoder: ImageDecoder,
     img: Tensor,
     background: Tensor,
     h_range: Tuple[int, int],
     w_range: Tuple[int, int],
-    slen: int,
+    slen: int = 300,
     device=None,
-) -> Tuple[Tensor, Union[TileCatalog, TileCatalogSamples]]:
+) -> Tuple[Tensor, TileCatalog]:
     """Reconstruct all objects contained within a scene, padding as needed.
 
     This function will run the encoder and decoder on a padded image containing the image specified
     via h, w, and scene_length, to ensure that all objects can be detected and reconstructed.
 
     Args:
-        n_samples:
-            Number of samples to draw from variational posterior. If None, evaluate the
-            maximum a posteriori (MAP) of the variational posterior.
         encoder:
             Trained Encoder module.
         decoder:
             Trained ImageDecoder module.
         img:
-            A 1xCxHxW tensor representing an HxW image with C bands.
+            A NxCxHxW tensor of N HxW images (with C bands).
         background:
-            A 1xCxHxW tensor representing an HxW image of background values with C bands.
+            A NxCxHxW tensor of N HxW background values (with C bands).
         h_range:
             Range of height coordinates.
         w_range:
@@ -67,8 +63,6 @@ def reconstruct_scene_at_coordinates(
             they are to the left/above (h, w) or greater than scene_length.
 
     """
-    assert img.shape[0] == 1
-    assert background.shape[0] == 1
     bp = encoder.border_padding
     h_range_pad = (h_range[0] - bp, h_range[1] + bp)
     w_range_pad = (w_range[0] - bp, w_range[1] + bp)
@@ -79,11 +73,8 @@ def reconstruct_scene_at_coordinates(
     assert scene.shape[2] == h_range_pad[1] - h_range_pad[0]
     assert scene.shape[3] == w_range_pad[1] - w_range_pad[0]
     chunked_scene = ChunkedScene(scene, bg_scene, slen, bp)
-    with torch.no_grad():
-        recon, tile_cat = chunked_scene.reconstruct(encoder, decoder, device, n_samples)
-    assert recon.shape[1:] == scene.shape[1:]
-    output_batches = n_samples if n_samples is not None else 1
-    assert recon.shape[0] == output_batches
+    recon, tile_map_scene = chunked_scene.reconstruct(encoder, decoder, device)
+    assert recon.shape == scene.shape
     recon += bg_scene
     # Get reconstruction at coordinates
     recon_at_coords = recon[
@@ -92,10 +83,7 @@ def reconstruct_scene_at_coordinates(
         bp:-bp,
         bp:-bp,
     ]
-    if n_samples is not None:
-        tile_cat_samples = TileCatalogSamples.unflatten_sample_and_batch_dim(n_samples, tile_cat)
-        return recon_at_coords.unsqueeze(1), tile_cat_samples
-    return recon_at_coords, tile_cat
+    return recon_at_coords, tile_map_scene
 
 
 class ChunkedScene:
@@ -106,8 +94,8 @@ class ChunkedScene:
         kernel_size = slen + bp * 2
         self.kernel_size = kernel_size
         self.output_size = (scene.shape[2], scene.shape[3])
-        self.chunk_dict: Dict[str, Tensor] = {}
-        self.bg_dict: Dict[str, Tensor] = {}
+        self.chunk_dict = {}
+        self.bg_dict = {}
 
         n_chunks_h = (scene.shape[2] - (bp * 2)) // slen
         n_chunks_w = (scene.shape[3] - (bp * 2)) // slen
@@ -151,7 +139,7 @@ class ChunkedScene:
             self.chunk_dict["bottom_right"] = bottom_right_border
             self.bg_dict["bottom_right"] = bg_bottom_right_border
 
-    def _chunk_image(self, image: Tensor, kernel_size, stride) -> Tensor:
+    def _chunk_image(self, image, kernel_size, stride):
         chunks = F.unfold(image, kernel_size=kernel_size, stride=stride)
         return rearrange(
             chunks,
@@ -161,55 +149,48 @@ class ChunkedScene:
             w=kernel_size[1],
         )
 
-    def reconstruct(
-        self,
-        encoder: Encoder,
-        decoder: ImageDecoder,
-        device: torch.device,
-        n_samples: Optional[int],
-    ):
-        reconstructions: Dict[str, Tensor] = {}
-        tile_maps: Dict[str, List[TileCatalog]] = {}
+    def reconstruct(self, encoder, decoder, device):
+        chunk_est_dict = {}
         for chunk_type, chunks in self.chunk_dict.items():
             bgs = self.bg_dict[chunk_type]
-            recon_list: List[Tensor] = []
-            tile_map_list: List[TileCatalog] = []
-            for chunk, bg in tqdm(zip(chunks, bgs), desc="Reconstructing chunks"):
-                tile_samples = encoder.sample(
-                    chunk.unsqueeze(0).to(device), bg.unsqueeze(0).to(device), n_samples
-                )
-                if isinstance(tile_samples, TileCatalogSamples):
-                    tile_cat = tile_samples.flatten_sample_and_batch_dim()
-                else:
-                    tile_cat = tile_samples
-                recon = decoder.render_images(tile_cat)
-                tile_cat["galaxy_fluxes"] = decoder.get_galaxy_fluxes(
-                    tile_cat["galaxy_bools"], tile_cat["galaxy_params"]
-                )
-                recon_list.append(recon.cpu())
-                tile_map_list.append(tile_cat.cpu())
-            reconstructions[chunk_type] = torch.cat(recon_list, dim=0)
-            tile_maps[chunk_type] = tile_map_list
-        scene_recon = self._combine_reconstructions(reconstructions)
-        tile_map_recon = self._combine_tile_maps(tile_maps)
+            chunk_est_dict[chunk_type] = self._reconstruct_chunks(
+                chunks, bgs, encoder, decoder, device
+            )
+        reconstructions_dict = {k: v["reconstructions"] for k, v in chunk_est_dict.items()}
+        scene_recon = self._combine_into_scene(reconstructions_dict)
+        chunk_tile_maps_dict = {k: v["tile_maps"] for k, v in chunk_est_dict.items()}
+        tile_map_recon = self._combine_tile_maps(chunk_tile_maps_dict)
         return scene_recon, tile_map_recon
 
-    def _combine_reconstructions(self, reconstructions: Dict[str, Tensor]) -> Tensor:
+    def _reconstruct_chunks(self, chunks, bgs, encoder, decoder, device):
+        reconstructions = []
+        tile_maps = []
+        for chunk, bg in tqdm(zip(chunks, bgs), desc="Reconstructing chunks"):
+            recon, tile_map = reconstruct_img(
+                encoder, decoder, chunk.unsqueeze(0).to(device), bg.unsqueeze(0).to(device)
+            )
+            reconstructions.append(recon.cpu())
+            tile_maps.append(tile_map.cpu())
+        return {
+            "reconstructions": torch.cat(reconstructions, dim=0),
+            "tile_maps": tile_maps,
+        }
+
+    def _combine_into_scene(self, reconstructions: Dict[str, Tensor]) -> Tensor:
         main: Tensor = reconstructions["main"]
         main = rearrange(
             main,
-            "(b nch ncw) c h w -> b nch ncw c h w",
+            "(nch ncw) c h w -> nch ncw c h w",
             nch=self.n_chunks_h_main,
             ncw=self.n_chunks_w_main,
         )
-        batch_size = main.shape[0]
 
         right = reconstructions.get("right")
         if right is not None:
             right_padding = self.kernel_size - right.shape[-1]
             right_padded: Tensor = F.pad(right, (0, right_padding, 0, 0))
-            right_padded = rearrange(right_padded, "(b nch) c h w -> b nch 1 c h w", b=batch_size)
-            main = torch.cat((main, right_padded), dim=2)
+            right_padded = rearrange(right_padded, "nch c h w -> nch 1 c h w")
+            main = torch.cat((main, right_padded), dim=1)
         else:
             right_padding = 0
 
@@ -217,16 +198,16 @@ class ChunkedScene:
         if bottom is not None:
             bottom_padding = self.kernel_size - bottom.shape[-2]
             bottom_padded: Tensor = F.pad(bottom, (0, 0, 0, bottom_padding))
-            bottom_padded = rearrange(bottom_padded, "(b ncw) c h w -> b 1 ncw c h w", b=batch_size)
+
             bottom_right = reconstructions.get("bottom_right")
             if bottom_right is not None:
                 bottom_right_padded = F.pad(bottom_right, (0, right_padding, 0, bottom_padding))
-                bottom_right_padded = rearrange(bottom_right_padded, "b c h w -> b 1 1 c h w")
-                bottom_padded = torch.cat((bottom_padded, bottom_right_padded), dim=2)
-            main = torch.cat((main, bottom_padded), dim=1)
+                bottom_padded = torch.cat((bottom_padded, bottom_right_padded), dim=0)
+            bottom_padded = rearrange(bottom_padded, "ncw c h w -> 1 ncw c h w")
+            main = torch.cat((main, bottom_padded), dim=0)
         else:
             bottom_padding = 0
-        image_flat: Tensor = rearrange(main, "b nch ncw c h w -> b (c h w) (nch ncw)")
+        image_flat: Tensor = rearrange(main, "nch ncw c h w -> 1 (c h w) (nch ncw)")
         output_size = (self.output_size[0] + bottom_padding, self.output_size[1] + right_padding)
         image = F.fold(
             image_flat, output_size=output_size, kernel_size=self.kernel_size, stride=self.slen
@@ -260,10 +241,9 @@ class ChunkedScene:
 
         tile_map_list = []
         for tile_map_row in main:
-            tile_map_row_combined = TileCatalog.cat(tile_map_row, 1)
+            tile_map_row_combined = cat_tile_catalog(tile_map_row, 1)
             tile_map_list.append(tile_map_row_combined)
-
-        return TileCatalog.cat(tile_map_list, 0)
+        return cat_tile_catalog(tile_map_list, 0)
 
     @staticmethod
     def _tile_catalog_array(tile_catalogs: List[TileCatalog]):
@@ -271,6 +251,30 @@ class ChunkedScene:
         for i, tile_catalog in enumerate(tile_catalogs):
             out[i] = tile_catalog
         return out
+
+
+def reconstruct_img(
+    encoder: Encoder, decoder: ImageDecoder, img: Tensor, bg: Tensor
+) -> Tuple[Tensor, TileCatalog]:
+
+    with torch.no_grad():
+        tile_map = encoder.max_a_post(img, bg)
+        recon_image = decoder.render_images(tile_map)
+        tile_map["galaxy_fluxes"] = decoder.get_galaxy_fluxes(
+            tile_map["galaxy_bools"], tile_map["galaxy_params"]
+        )
+    return recon_image, tile_map
+
+
+def cat_tile_catalog(tile_catalogs: Sequence[TileCatalog], tile_dim: int = 0) -> TileCatalog:
+    assert tile_dim in {0, 1}
+    out = {}
+    tile_catalog_dicts = [tm.to_dict() for tm in tile_catalogs]
+    for k in tile_catalog_dicts[0].keys():
+        tensors = [tm[k] for tm in tile_catalog_dicts]
+        value = torch.cat(tensors, dim=(tile_dim + 1))
+        out[k] = value
+    return TileCatalog(tile_catalogs[0].tile_slen, out)
 
 
 class SDSSFrame:

--- a/bliss/models/galaxy_encoder.py
+++ b/bliss/models/galaxy_encoder.py
@@ -86,7 +86,7 @@ class GalaxyEncoder(pl.LightningModule):
             galaxy_params_flat,
             "(b nth ntw s) d -> b nth ntw s d",
             b=batch_size,
-            nth=nth,
+            nth=ntw,
             ntw=ntw,
             s=max_sources,
         )

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -12,12 +12,7 @@ from torch.distributions import Categorical, Normal, Poisson
 from torch.nn import functional as F
 from torch.optim import Adam
 
-from bliss.catalog import (
-    TileCatalog,
-    TileCatalogSamples,
-    get_images_in_tiles,
-    get_is_on_from_n_sources,
-)
+from bliss.catalog import TileCatalog, get_images_in_tiles, get_is_on_from_n_sources
 from bliss.reporting import DetectionMetrics
 
 
@@ -208,7 +203,7 @@ class LocationEncoder(pl.LightningModule):
             "n_source_log_probs": n_source_log_probs,
         }
 
-    def sample(self, var_params: Dict[str, Tensor], n_samples: int) -> TileCatalogSamples:
+    def sample(self, var_params: Dict[str, Tensor], n_samples: int) -> Dict[str, Tensor]:
         """Sample from encoded variational distribution.
 
         Args:
@@ -257,11 +252,11 @@ class LocationEncoder(pl.LightningModule):
         b, nth, ntw, _ = log_probs_n_sources_per_tile.shape
         sample = {}
         for k, v in sample_flat.items():
-            pattern = "n (b nth ntw) ns k -> n b nth ntw ns k"
+            pattern = "ns (b nth ntw) s k -> ns b nth ntw s k"
             sample[k] = rearrange(v, pattern, b=b, nth=nth, ntw=ntw)
         sample["n_sources"] = tile_n_sources
 
-        return TileCatalogSamples(self.tile_slen, sample)
+        return sample
 
     def max_a_post(
         self, var_params: Dict[str, Tensor], n_source_weights: Optional[Tensor] = None

--- a/case_studies/sdss_galaxies/plots.py
+++ b/case_studies/sdss_galaxies/plots.py
@@ -508,7 +508,6 @@ class DetectionClassificationFigures(BlissFigures):
 
         # obtain predictions from BLISS.
         _, tile_est_params = reconstruct_scene_at_coordinates(
-            None,
             encoder,
             decoder,
             frame.image,
@@ -724,7 +723,6 @@ class SDSSReconstructionFigures(BlissFigures):
             coadd_params = frame.get_catalog((h, h_end), (w, w_end))
 
             recon, tile_map_recon = reconstruct_scene_at_coordinates(
-                None,
                 encoder,
                 decoder,
                 frame.image,

--- a/case_studies/sdss_galaxies_vae/reconstruction.py
+++ b/case_studies/sdss_galaxies_vae/reconstruction.py
@@ -62,18 +62,6 @@ def reconstruct(cfg):
             w_end = w + scene_size
         true = frame.image[:, :, h:h_end, w:w_end]
         recon, tile_map_recon = reconstruct_scene_at_coordinates(
-            None,
-            encoder,
-            dec,
-            frame.image,
-            frame.background,
-            (h, h_end),
-            (w, w_end),
-            slen=cfg.reconstruct.slen,
-            device=device,
-        )
-        sampled_recons, tile_samples = reconstruct_scene_at_coordinates(
-            2,
             encoder,
             dec,
             frame.image,

--- a/tests/case_studies/m2/test_m2.py
+++ b/tests/case_studies/m2/test_m2.py
@@ -82,7 +82,7 @@ def get_map_estimate(
     )
     tile_map = image_encoder.max_a_post(var_params)
     full_map = tile_map.to_full_params()
-    tile_map_tilde = full_map.to_tile_params(image_encoder.tile_slen, tile_map.shape[-1])
+    tile_map_tilde = full_map.to_tile_params(image_encoder.tile_slen, tile_map.max_sources)
     assert tile_map.equals(tile_map_tilde, exclude=("n_source_log_probs",), atol=1e-5)
 
     return full_map

--- a/tests/case_studies/sdss_galaxies_vae/test_sdss_blended_galaxies.py
+++ b/tests/case_studies/sdss_galaxies_vae/test_sdss_blended_galaxies.py
@@ -11,8 +11,8 @@ class TestSdssBlendedGalaxies:
             if devices.use_cuda
             else "cpu",
             "+datasets.sdss_blended_galaxies.slen": 40,
-            "+datasets.sdss_blended_galaxies.h_start": 460,
-            "+datasets.sdss_blended_galaxies.w_start": 742,
+            "+datasets.sdss_blended_galaxies.h_start": 200,
+            "+datasets.sdss_blended_galaxies.w_start": 1800,
             "+datasets.sdss_blended_galaxies.scene_size": 100,
             "training.n_epochs": 1,
             "training.trainer.log_every_n_steps": 1,


### PR DESCRIPTION
This reverts commit 25f21f43f82185ca75463b3c457b7e368148e9fd.

There is a regression in the performance of the BinaryEncoder,
likely due to the way the images are pre-processed. We'll need
to debug this further.