### PR TITLE
more location encoder refactoring

### DIFF
--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -566,13 +566,13 @@ def make_enc_final(in_size, hidden, out_size, dropout):
 class EncoderCNN(nn.Module):
     def __init__(self, n_bands, channel, dropout):
         super().__init__()
-        self.layers = self._make_layers(n_bands, channel, dropout)
+        self.layer = self._make_layer(n_bands, channel, dropout)
 
     def forward(self, x: Tensor) -> Tensor:
         """Runs encoder CNN on inputs."""
-        return self.layers(x)
+        return self.layer(x)
 
-    def _make_layers(self, n_bands, channel, dropout):
+    def _make_layer(self, n_bands, channel, dropout):
         layers = [
             nn.Conv2d(n_bands, channel, 3, padding=1),
             nn.BatchNorm2d(channel),

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -265,10 +265,10 @@ class LocationEncoder(pl.LightningModule):
             `"locs", "log_fluxes", "fluxes", and "n_sources".`.
         """
         if n_source_weights is None:
-            n_source_weights = torch.ones(self.max_detections + 1)
-        n_source_weights = n_source_weights.to(self.device).reshape(1, 1, 1, -1)
-        n_source_log_weights = n_source_weights.log()
-        log_joint = dist_params["n_source_log_probs"] + n_source_log_weights
+            n_source_weights = torch.ones(self.max_detections + 1, device=self.device)
+
+        n_source_weights = n_source_weights.reshape(1, 1, 1, -1)
+        log_joint = dist_params["n_source_log_probs"] + n_source_weights.log()
         map_n_sources: Tensor = torch.argmax(log_joint, dim=-1)
 
         # the first dimension is the number of samples (just one in this case)

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -280,6 +280,8 @@ class LocationEncoder(pl.LightningModule):
         tile_locs = pred["loc_mean"] * is_on_array
         tile_locs = tile_locs.clamp(0, 1)
 
+        # In the catalog, do we need to store both fluxes and log fluxes?
+        # Also, can we avoid gating log_flux_mean here is_on_array? Because log(0) != 0.
         tile_log_fluxes = pred["log_flux_mean"] * is_on_array
         tile_fluxes = tile_log_fluxes.exp() * is_on_array
 

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -249,7 +249,7 @@ class LocationEncoder(pl.LightningModule):
         """Compute the mode of the variational distribution.
 
         Args:
-            dist_params: The output of `self.encode(ptiles)` which is the distribuitonal parameters
+            dist_params: The output of `self.encode(ptiles)` which is the distributional parameters
                 in matrix form. Has size `n_ptiles * n_bands`.
             n_source_weights:
                 If specified, adds adjustment to number of sources when taking the argmax. Useful


### PR DESCRIPTION
This PR pretty much closes #540.

I didn't remove some of the masking that should be unnecessary because I was concerned about introducing bugs, and I wasn't sure if I could rely on our tests to catch any new bugs while #563 remains an issue.

There's still quite a bit more we could do to improve the readability of the location encoder. For instance, many of the calls to `rearrange` and `squeeze` could likely be avoided by not flattening structures in the first place. But this PR may be enough for now.