### PR TITLE
Fix documentation errors by pinning git push action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
         git config --local user.name "github-actions[bot]"
         git commit -m "Generate docs" -a
     - name: Push changes
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@887c31bd838a40c4da09953b6df364b5439bd7c3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: refs/heads/master-sphinx

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,7 @@ name: docs
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,8 @@ name: docs
 on:
   push:
     branches: [master]
-
+  pull_request:
+    branches: [master]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It looks like the recent crashes in our documentation were due to an update from the Github Action I was using to force-push to master-sphinx. I pinned this action at the last good commit.