### PR TITLE
Make variational mode a special case of LocationEncoder.sample()

### DIFF
--- a/bliss/encoder.py
+++ b/bliss/encoder.py
@@ -134,6 +134,8 @@ class Encoder(nn.Module):
         tile_map_dict = self.location_encoder.variational_mode(
             dist_params, n_source_weights=self.map_n_source_weights
         )
+        n_source_log_probs = dist_params["n_source_log_probs"][:, 1:]
+        tile_map_dict["n_source_log_probs"] = n_source_log_probs.unsqueeze(-1)
         locs = tile_map_dict["locs"]
         n_sources = tile_map_dict["n_sources"]
         is_on_array = get_is_on_from_n_sources(n_sources, self.location_encoder.max_detections)

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -224,21 +224,16 @@ class LocationEncoder(pl.LightningModule):
 
         if n_samples is not None:
             tile_locs = Normal(dist_params_n_src["loc_mean"], dist_params_n_src["loc_sd"]).rsample()
-        else:
-            tile_locs = dist_params_n_src["loc_mean"]
-        tile_locs *= tile_is_on_array  # Is masking here helpful/necessary?
-
-        if n_samples is not None:
             tile_log_fluxes = Normal(
                 dist_params_n_src["log_flux_mean"], dist_params_n_src["log_flux_sd"]
             ).rsample()
         else:
+            tile_locs = dist_params_n_src["loc_mean"]
             tile_log_fluxes = dist_params_n_src["log_flux_mean"]
+        tile_locs *= tile_is_on_array  # Is masking here helpful/necessary?
         tile_fluxes = tile_log_fluxes.exp()
         tile_fluxes *= tile_is_on_array
 
-        # Given all the rearranging/unflattening below, I suspect we never should have
-        # flattened in the first place
         return {
             "locs": tile_locs,
             "log_fluxes": tile_log_fluxes,

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -249,7 +249,7 @@ class LocationEncoder(pl.LightningModule):
     def variational_mode(
         self, dist_params: Dict[str, Tensor], n_source_weights: Optional[Tensor] = None
     ) -> Dict[str, Tensor]:
-        """Compute the mode of the variational distribution. Special case of sample()."""
+        """Compute the variational mode. Special case of sample() where first dim is squeezed."""
         detection_params = self.sample(dist_params, None, n_source_weights=n_source_weights)
         return {k: v.squeeze(0) for k, v in detection_params.items()}
 

--- a/bliss/models/location_encoder.py
+++ b/bliss/models/location_encoder.py
@@ -207,7 +207,7 @@ class LocationEncoder(pl.LightningModule):
             n_source_weights = torch.ones(self.max_detections + 1, device=self.device)
         n_source_weights = n_source_weights.reshape(1, -1)
         ns_log_probs_adj = dist_params["n_source_log_probs"] + n_source_weights.log()
-        ns_log_probs_adj -= ns_log_probs_adj.logsumexp(dim=-1)
+        ns_log_probs_adj -= ns_log_probs_adj.logsumexp(dim=-1, keepdim=True)
 
         if n_samples is not None:
             n_source_probs = ns_log_probs_adj.exp()


### PR DESCRIPTION
This refactors LocationEncoder to use the same logic for both sampling and variational mode (with the latter now a special case of the former).