### PR TITLE
enable ellipticities in tile catalog and decoder

### DIFF
--- a/bliss/catalog.py
+++ b/bliss/catalog.py
@@ -20,6 +20,7 @@ class TileCatalog(UserDict):
         "fluxes",
         "log_fluxes",
         "mags",
+        "ellips",
         "galaxy_bools",
         "galaxy_params",
         "galaxy_fluxes",
@@ -224,7 +225,7 @@ class TileCatalog(UserDict):
         return {k: v[:, x_indx, y_indx, :, :].reshape(n_total, -1) for k, v in self.items()}
 
     def set_all_fluxes_and_mags(self, decoder):
-        """Set all fluxes (galaxy and star) for tile_cat given an ImageDecoder instance."""
+        """Set all fluxes (galaxy and star) of tile catalog given an ImageDecoder instance."""
         # first get galaxy fluxes
         assert "galaxy_bools" in self and "galaxy_params" in self and "fluxes" in self
         galaxy_bools, galaxy_params = self["galaxy_bools"], self["galaxy_params"]
@@ -242,6 +243,12 @@ class TileCatalog(UserDict):
         is_on_array = self.is_on_array > 0
         self["mags"] = torch.zeros_like(self["fluxes"])
         self["mags"][is_on_array] = convert_flux_to_mag(self["fluxes"][is_on_array])
+
+    def set_galaxy_ellips(self, decoder, scale: float = 0.393):
+        """Sets galaxy ellipticities of tile catalog given an ImageDecoder instance."""
+        galaxy_bools, galaxy_params = self["galaxy_bools"], self["galaxy_params"]
+        ellips = decoder.get_galaxy_ellips(galaxy_bools, galaxy_params, scale=scale)
+        self["ellips"] = ellips
 
 
 class FullCatalog(UserDict):

--- a/bliss/datasets/galsim_galaxies.py
+++ b/bliss/datasets/galsim_galaxies.py
@@ -364,6 +364,12 @@ class GalsimBlends(SingleGalsimGalaxies):
 
         # sample galaxy params and ensure tensor returned is of theh same size always.
         params = self.prior.sample(n_sources, "cpu")
+
+        # order galaxy params based on flux so centered (first one) is the brightest
+        indx_order = np.argsort(-params[:, 0])
+        params = params[indx_order, :]
+
+        # account for max sources
         galaxy_params = torch.zeros(self.max_n_sources, params.shape[-1])
         galaxy_params[:n_sources, :] = params
 

--- a/bliss/datasets/galsim_galaxies.py
+++ b/bliss/datasets/galsim_galaxies.py
@@ -407,7 +407,8 @@ class GalsimBlends(SingleGalsimGalaxies):
             n_sources, 1, slen, slen
         )
         mags = torch.zeros(self.max_n_sources)
-        mags[:n_sources] = convert_flux_to_mag(galaxy_params[:n_sources, 0])
+        for ii in range(n_sources):
+            mags[ii] = convert_flux_to_mag(galaxy_params[ii, 0])
         ellips = torch.zeros(self.max_n_sources, 2)
         meas = get_single_galaxy_measurements(single_galaxy_tensor, psf_tensor, scale)
         ellips[:n_sources, :] = meas["ellips"]

--- a/bliss/datasets/galsim_galaxies.py
+++ b/bliss/datasets/galsim_galaxies.py
@@ -406,7 +406,8 @@ class GalsimBlends(SingleGalsimGalaxies):
         single_galaxy_tensor = individual_noiseless_centered[:n_sources].reshape(
             n_sources, 1, slen, slen
         )
-        mags = convert_flux_to_mag(galaxy_params[:, 0])
+        mags = torch.zeros(self.max_n_sources)
+        mags[:n_sources] = convert_flux_to_mag(galaxy_params[:n_sources, 0])
         ellips = torch.zeros(self.max_n_sources, 2)
         meas = get_single_galaxy_measurements(single_galaxy_tensor, psf_tensor, scale)
         ellips[:n_sources, :] = meas["ellips"]

--- a/bliss/models/decoder.py
+++ b/bliss/models/decoder.py
@@ -409,7 +409,7 @@ class StarTileDecoder(nn.Module):
             psf_params = psf_params[list(range(n_bands))]
         elif ext == ".fits":
             assert len(sdss_bands) == n_bands
-            psf_params = self.get_fit_file_psf_params(psf_params_file, sdss_bands)
+            psf_params = self._get_fit_file_psf_params(psf_params_file, sdss_bands)
         else:
             raise NotImplementedError(
                 "Only .npy and .fits extensions are supported for PSF params files."
@@ -462,7 +462,7 @@ class StarTileDecoder(nn.Module):
         return psf
 
     @staticmethod
-    def get_fit_file_psf_params(psf_fit_file, bands=(2, 3)):
+    def _get_fit_file_psf_params(psf_fit_file, bands=(2, 3)):
         data = fits.open(psf_fit_file, ignore_missing_end=True).pop(6).data
         psf_params = torch.zeros(len(bands), 6)
         for i, band in enumerate(bands):

--- a/bliss/reporting.py
+++ b/bliss/reporting.py
@@ -386,7 +386,7 @@ def get_single_galaxy_ellipticities(
         Tensor containing ellipticity measurements for each galaxy in `images`.
     """
     n_samples, _, _ = images.shape
-    ellip = torch.zeros((n_samples, 2))  # 2nd shape: e1, e2
+    ellips = torch.zeros((n_samples, 2))  # 2nd shape: e1, e2
     images_np = images.numpy()
     psf_np = psf_image.numpy()
     galsim_psf_image = galsim.Image(psf_np, scale=pixel_scale)
@@ -399,9 +399,9 @@ def get_single_galaxy_ellipticities(
             galsim_image, galsim_psf_image, shear_est="KSB", strict=False
         )
         g1, g2 = float(res_true.corrected_g1), float(res_true.corrected_g2)
-        ellip[i, :] = torch.tensor([g1, g2])
+        ellips[i, :] = torch.tensor([g1, g2])
 
-    return ellip
+    return ellips
 
 
 def get_single_galaxy_measurements(
@@ -424,11 +424,11 @@ def get_single_galaxy_measurements(
     images = rearrange(images, "n c h w -> (n c) h w")
     psf_image = rearrange(psf_image, "c h w -> (c h) w")
     fluxes = torch.sum(images, (1, 2))
-    ellip = get_single_galaxy_ellipticities(images, psf_image, pixel_scale)
+    ellips = get_single_galaxy_ellipticities(images, psf_image, pixel_scale)
 
     return {
         "fluxes": fluxes,
-        "ellip": ellip,
+        "ellips": ellips,
         "mags": convert_flux_to_mag(fluxes),
     }
 

--- a/bliss/reporting.py
+++ b/bliss/reporting.py
@@ -370,29 +370,23 @@ class CoaddFullCatalog(FullCatalog):
         return cls(height, width, data)
 
 
-def get_single_galaxy_measurements(
+def get_single_galaxy_ellipticities(
     images: Tensor, psf_image: Tensor, pixel_scale: float = 0.396
-) -> Dict[str, Tensor]:
-    """Compute individual galaxy measurements comparing true images with reconstructed images.
+) -> Tensor:
+    """Returns ellipticities of (noiseless, single-band) individual galaxy images.
 
     Args:
         pixel_scale: Conversion from arcseconds to pixel.
-        images: Array of shape (n_samples, n_bands, slen, slen) containing images of
+        images: Array of shape (n_samples, slen, slen) containing images of
             single-centered galaxies without noise or background.
-        psf_image: Array of shape (n_bands, slen, slen) containing PSF image used for
+        psf_image: Array of shape (slen, slen) containing PSF image used for
             convolving the galaxies in `true_images`.
 
     Returns:
-        Dictionary containing second-moment measurements for `true_images` and `recon_images`.
+        Tensor containing ellipticity measurements for each galaxy in `images`.
     """
-    n_samples, c, slen, w = images.shape
-    assert slen == w and c == 1 and psf_image.shape == (c, slen, w)
-    images = rearrange(images, "n c h w -> (n c) h w")
-    psf_image = rearrange(psf_image, "c h w -> (c h) w")
-    fluxes = torch.sum(images, (1, 2))
+    n_samples, _, _ = images.shape
     ellip = torch.zeros((n_samples, 2))  # 2nd shape: e1, e2
-
-    # get galsim PSF
     images_np = images.numpy()
     psf_np = psf_image.numpy()
     galsim_psf_image = galsim.Image(psf_np, scale=pixel_scale)
@@ -406,6 +400,31 @@ def get_single_galaxy_measurements(
         )
         g1, g2 = float(res_true.corrected_g1), float(res_true.corrected_g2)
         ellip[i, :] = torch.tensor([g1, g2])
+
+    return ellip
+
+
+def get_single_galaxy_measurements(
+    images: Tensor, psf_image: Tensor, pixel_scale: float = 0.396
+) -> Dict[str, Tensor]:
+    """Compute individual galaxy measurements comparing true images with reconstructed images.
+
+    Args:
+        pixel_scale: Conversion from arcseconds to pixel.
+        images: Array of shape (n_samples, n_bands, slen, slen) containing images of
+            single-centered galaxies without noise or background.
+        psf_image: Array of shape (n_bands, slen, slen) containing PSF image used for
+            convolving the galaxies in `true_images`.
+
+    Returns:
+        Dictionary containing fluxes, magnitudes, and ellipticities of `images`.
+    """
+    _, c, slen, w = images.shape
+    assert slen == w and c == 1 and psf_image.shape == (c, slen, w)
+    images = rearrange(images, "n c h w -> (n c) h w")
+    psf_image = rearrange(psf_image, "c h w -> (c h) w")
+    fluxes = torch.sum(images, (1, 2))
+    ellip = get_single_galaxy_ellipticities(images, psf_image, pixel_scale)
 
     return {
         "fluxes": fluxes,

--- a/case_studies/sdss_galaxies/plots/autoencoder.py
+++ b/case_studies/sdss_galaxies/plots/autoencoder.py
@@ -230,7 +230,7 @@ class AEReconstructionFigures(BlissFigures):
         )
 
         # ellipticities
-        true_ellip1, recon_ellip1 = meas["true_ellip"][:, 0], meas["recon_ellip"][:, 0]
+        true_ellip1, recon_ellip1 = meas["true_ellips"][:, 0], meas["recon_ellips"][:, 0]
         x, y = np.log10(snr), recon_ellip1 - true_ellip1
         scatter_bin_plot(
             ax3,
@@ -243,7 +243,7 @@ class AEReconstructionFigures(BlissFigures):
             ylabel=r"$g_{1}^{\rm recon} - g_{1}^{\rm true}$",
         )
 
-        true_ellip2, recon_ellip2 = meas["true_ellip"][:, 1], meas["recon_ellip"][:, 1]
+        true_ellip2, recon_ellip2 = meas["true_ellips"][:, 1], meas["recon_ellips"][:, 1]
         x, y = np.log10(snr), recon_ellip2 - true_ellip2
         scatter_bin_plot(
             ax4,

--- a/case_studies/sdss_galaxies/plots/sim_blend_metrics.py
+++ b/case_studies/sdss_galaxies/plots/sim_blend_metrics.py
@@ -45,7 +45,6 @@ class BlendSimFigures(BlissFigures):
         full_truth = FullCatalog(slen, slen, full_catalog_dict)
 
         print("INFO: BLISS posterior inference on images.")
-
         tile_est = encoder.variational_mode(images, background).cpu()
         tile_est.set_all_fluxes_and_mags(decoder)
         full_est = tile_est.to_full_params()

--- a/tests/case_studies/sdss_galaxies/test_decoder_ellipticity.py
+++ b/tests/case_studies/sdss_galaxies/test_decoder_ellipticity.py
@@ -1,0 +1,12 @@
+from hydra.utils import instantiate
+
+from bliss.models.decoder import ImageDecoder
+from bliss.models.prior import ImagePrior
+
+
+def test_get_ellips(devices, get_sdss_galaxies_config):
+    cfg = get_sdss_galaxies_config({}, devices)
+    image_prior: ImagePrior = instantiate(cfg.models.prior, prob_galaxy=1.0, mean_sources=0.33)
+    decoder: ImageDecoder = instantiate(cfg.models.decoder)
+    tile_cat = image_prior.sample_prior(decoder.tile_slen, 1, 3, 3)
+    tile_cat.set_galaxy_ellips(decoder, scale=0.393)

--- a/tests/case_studies/sdss_galaxies/test_galaxy_blend.py
+++ b/tests/case_studies/sdss_galaxies/test_galaxy_blend.py
@@ -23,6 +23,8 @@ def test_galaxy_blend(get_sdss_galaxies_config, devices):
         snr = b["snr"]
         blendedness = b["blendedness"]
         ellips = b["ellips"]
+        mags = b["mags"]
+        fluxes = b["fluxes"]
         assert images.shape == (4, 1, 81, 81)
         assert noiseless.shape == (4, 1, 81, 81)
         assert single_images_center.shape == (4, 3, 1, 81, 81)
@@ -33,6 +35,8 @@ def test_galaxy_blend(get_sdss_galaxies_config, devices):
         assert blendedness.shape == (4, 3)
         assert n_sources.shape == (4, 1)
         assert ellips.shape == (4, 3, 2)
+        assert mags.shape == (4, 3)
+        assert fluxes.shape == (4, 3)
 
         # check empty if no sources
         for ii, n in enumerate(n_sources):

--- a/tests/case_studies/sdss_galaxies/test_galaxy_blend.py
+++ b/tests/case_studies/sdss_galaxies/test_galaxy_blend.py
@@ -22,6 +22,7 @@ def test_galaxy_blend(get_sdss_galaxies_config, devices):
         plocs = b["plocs"]
         snr = b["snr"]
         blendedness = b["blendedness"]
+        ellips = b["ellips"]
         assert images.shape == (4, 1, 81, 81)
         assert noiseless.shape == (4, 1, 81, 81)
         assert single_images_center.shape == (4, 3, 1, 81, 81)
@@ -31,6 +32,7 @@ def test_galaxy_blend(get_sdss_galaxies_config, devices):
         assert snr.shape == (4, 3)
         assert blendedness.shape == (4, 3)
         assert n_sources.shape == (4, 1)
+        assert ellips.shape == (4, 3, 2)
 
         # check empty if no sources
         for ii, n in enumerate(n_sources):


### PR DESCRIPTION
- [x] Decoder outputs ellipticities per tile
- [x] simulated galsim blends always has brightest galaxy in the center 
- [x] simulated galsim blends output ellipticity, flux, mag
- [x] update test