### PR TITLE
Encoder/decoder integration

### DIFF
--- a/bliss/catalog.py
+++ b/bliss/catalog.py
@@ -38,6 +38,9 @@ class TileCatalog(UserDict):
         "matched",
         "mismatched",
         "detection_thresholds",
+        "lensed_galaxy_bools",
+        "lensed_galaxy_probs",
+        "lens_params",
     }
 
     def __init__(self, tile_slen: int, d: Dict[str, Tensor]):

--- a/bliss/models/decoder.py
+++ b/bliss/models/decoder.py
@@ -12,6 +12,7 @@ from torch.nn import functional as F
 from bliss.catalog import TileCatalog, get_is_on_from_n_sources
 from bliss.datasets.galsim_galaxies import SingleGalsimGalaxyDecoder
 from bliss.models.galaxy_net import OneCenteredGalaxyAE
+from bliss.models.psf_decoder import get_mgrid, PSFDecoder
 from bliss.reporting import get_single_galaxy_ellipticities
 
 GalaxyModel = Union[OneCenteredGalaxyAE, SingleGalsimGalaxyDecoder]
@@ -395,53 +396,13 @@ class Tiler(nn.Module):
         return source[:, l_indx:u_indx, l_indx:u_indx]
 
 
-def get_mgrid(slen: int):
-    offset = (slen - 1) / 2
-    # Currently type-checking with mypy doesn't work with np.mgrid
-    # See https://github.com/python/mypy/issues/11185.
-    x, y = np.mgrid[-offset : (offset + 1), -offset : (offset + 1)]  # type: ignore
-    mgrid = torch.tensor(np.dstack((y, x))) / offset
-    # mgrid is between -1 and 1
-    # then scale slightly because of the way f.grid_sample
-    # parameterizes the edges: (0, 0) is center of edge pixel
-    return mgrid.float() * (slen - 1) / slen
-
-
-class StarTileDecoder(nn.Module):
+class StarTileDecoder(PSFDecoder):
     def __init__(
         self, tile_slen, ptile_slen, n_bands, psf_slen, sdss_bands=(2,), psf_params_file=None
     ):
-        super().__init__()
+        super().__init__(n_bands, psf_slen, sdss_bands, psf_params_file)
         self.tiler = Tiler(tile_slen, ptile_slen)
-        self.n_bands = n_bands
-        self.psf_slen = psf_slen
-
-        ext = Path(psf_params_file).suffix
-        if ext == ".npy":
-            psf_params = torch.from_numpy(np.load(psf_params_file))
-            psf_params = psf_params[list(range(n_bands))]
-        elif ext == ".fits":
-            assert len(sdss_bands) == n_bands
-            psf_params = self._get_fit_file_psf_params(psf_params_file, sdss_bands)
-        else:
-            raise NotImplementedError(
-                "Only .npy and .fits extensions are supported for PSF params files."
-            )
-        self.params = nn.Parameter(psf_params.clone(), requires_grad=True)
-        self.psf_image = None
-        grid = get_mgrid(self.psf_slen) * (self.psf_slen - 1) / 2
-        # extra factor to be consistent with old repo
-        # but probably doesn't matter ...
-        grid *= self.psf_slen / (self.psf_slen - 1)
-        self.register_buffer("cached_radii_grid", (grid**2).sum(2).sqrt())
-
-        # get psf normalization_constant
-        self.normalization_constant = torch.zeros(self.n_bands)
-        for i in range(self.n_bands):
-            psf_i = self._get_psf_single_band(i)
-            self.normalization_constant[i] = 1 / psf_i.sum()
-        self.normalization_constant = self.normalization_constant.detach()
-
+        
     def forward(self, locs, fluxes, star_bools):
         """Renders star tile from locations and fluxes."""
         # locs: is (n_ptiles x max_num_stars x 2)
@@ -466,72 +427,6 @@ class StarTileDecoder(nn.Module):
         sources *= rearrange(star_bools, "np ms 1 -> np ms 1 1 1")
 
         return self.tiler(locs, sources)
-
-    def psf_forward(self):
-        psf = self._get_psf()
-        init_psf_sum = reduce(psf, "n m k -> n", "sum").detach()
-        norm = reduce(psf, "n m k -> n", "sum")
-        psf *= rearrange(init_psf_sum / norm, "n -> n 1 1")
-        return psf
-
-    @staticmethod
-    def _get_fit_file_psf_params(psf_fit_file, bands=(2, 3)):
-        data = fits.open(psf_fit_file, ignore_missing_end=True).pop(6).data
-        psf_params = torch.zeros(len(bands), 6)
-        for i, band in enumerate(bands):
-            sigma1 = data["psf_sigma1"][0][band] ** 2
-            sigma2 = data["psf_sigma2"][0][band] ** 2
-            sigmap = data["psf_sigmap"][0][band] ** 2
-            beta = data["psf_beta"][0][band]
-            b = data["psf_b"][0][band]
-            p0 = data["psf_p0"][0][band]
-
-            psf_params[i] = torch.log(torch.tensor([sigma1, sigma2, sigmap, beta, b, p0]))
-
-        return psf_params
-
-    def _get_psf(self):
-        psf_list = []
-        for i in range(self.n_bands):
-            band_psf = self._get_psf_single_band(i)
-            band_psf *= self.normalization_constant[i]
-            psf_list.append(band_psf.unsqueeze(0))
-        psf = torch.cat(psf_list)
-
-        assert (psf > 0).all()
-        return psf
-
-    @staticmethod
-    def _psf_fun(r, sigma1, sigma2, sigmap, beta, b, p0):
-        term1 = torch.exp(-(r**2) / (2 * sigma1))
-        term2 = b * torch.exp(-(r**2) / (2 * sigma2))
-        term3 = p0 * (1 + r**2 / (beta * sigmap)) ** (-beta / 2)
-        return (term1 + term2 + term3) / (1 + b + p0)
-
-    def _get_psf_single_band(self, band_idx):
-        psf_params = torch.exp(self.params[band_idx])
-        return self._psf_fun(
-            self.cached_radii_grid,
-            psf_params[0],
-            psf_params[1],
-            psf_params[2],
-            psf_params[3],
-            psf_params[4],
-            psf_params[5],
-        )
-
-    def forward_adjusted_psf(self):
-        # use power_law_psf and current psf parameters to forward and obtain fresh psf model.
-        # first dimension of psf is number of bands
-        # dimension of the psf/slen should be odd
-        psf = self.psf_forward()
-        psf_slen = psf.shape[2]
-        assert len(psf.shape) == 3
-        assert psf.shape[0] == self.n_bands
-        assert psf.shape[1] == psf_slen
-        assert (psf_slen % 2) == 1
-
-        return self.tiler.fit_source_to_ptile(psf)
 
 
 class GalaxyTileDecoder(nn.Module):

--- a/bliss/models/psf_decoder.py
+++ b/bliss/models/psf_decoder.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+
+import numpy as np
+import torch
+from astropy.io import fits
+from einops import rearrange, reduce
+from torch import nn
+
+
+def get_mgrid(slen: int):
+    offset = (slen - 1) / 2
+    # Currently type-checking with mypy doesn't work with np.mgrid
+    # See https://github.com/python/mypy/issues/11185.
+    x, y = np.mgrid[-offset : (offset + 1), -offset : (offset + 1)]  # type: ignore
+    mgrid = torch.tensor(np.dstack((y, x))) / offset
+    # mgrid is between -1 and 1
+    # then scale slightly because of the way f.grid_sample
+    # parameterizes the edges: (0, 0) is center of edge pixel
+    return mgrid.float() * (slen - 1) / slen
+
+
+class PSFDecoder(nn.Module):
+    """Abstract decoder class to subclass whenever the decoded result will go through a PSF.
+
+    PSF (point-spread function) use is common for decoding the final realistic astronomical
+    image to account for sensor lens effects. PSF loading is suppported as a direct image (npy)
+    or through attributes (npy or fits) file.
+
+    Attributes:
+        n_bands: Number of bands (colors) in the image
+        tile_slen: Side-length of each tile.
+        ptile_slen: Padded side-length of each tile (for reconstructing image).
+        border_padding: Size of border around the final image where sources will not be present.
+        star_tile_decoder: Module which renders stars on individual tiles.
+        galaxy_tile_decoder: Module which renders galaxies on individual tiles.
+    """
+
+    def __init__(self, n_bands, psf_slen, sdss_bands=(2,), psf_params_file=None):
+        super().__init__()
+        self.n_bands = n_bands
+        self.psf_slen = psf_slen
+
+        ext = Path(psf_params_file).suffix
+        if ext == ".npy":
+            psf_params = torch.from_numpy(np.load(psf_params_file))
+            psf_params = psf_params[list(range(n_bands))]
+        elif ext == ".fits":
+            assert len(sdss_bands) == n_bands
+            psf_params = self._get_fit_file_psf_params(psf_params_file, sdss_bands)
+        else:
+            raise NotImplementedError(
+                "Only .npy and .fits extensions are supported for PSF params files."
+            )
+        self.params = nn.Parameter(psf_params.clone(), requires_grad=True)
+        self.psf_image = None
+        grid = get_mgrid(self.psf_slen) * (self.psf_slen - 1) / 2
+        # extra factor to be consistent with old repo
+        # but probably doesn't matter ...
+        grid *= self.psf_slen / (self.psf_slen - 1)
+        self.register_buffer("cached_radii_grid", (grid**2).sum(2).sqrt())
+
+        # get psf normalization_constant
+        self.normalization_constant = torch.zeros(self.n_bands)
+        for i in range(self.n_bands):
+            psf_i = self._get_psf_single_band(i)
+            self.normalization_constant[i] = 1 / psf_i.sum()
+        self.normalization_constant = self.normalization_constant.detach()
+
+    def forward(self, x):
+        raise NotImplementedError("Please extend this class and implement forward()")
+
+    def psf_forward(self):
+        psf = self._get_psf()
+        init_psf_sum = reduce(psf, "n m k -> n", "sum").detach()
+        norm = reduce(psf, "n m k -> n", "sum")
+        psf *= rearrange(init_psf_sum / norm, "n -> n 1 1")
+        return psf
+
+    @staticmethod
+    def _get_fit_file_psf_params(psf_fit_file, bands=(2, 3)):
+        data = fits.open(psf_fit_file, ignore_missing_end=True).pop(6).data
+        psf_params = torch.zeros(len(bands), 6)
+        for i, band in enumerate(bands):
+            sigma1 = data["psf_sigma1"][0][band] ** 2
+            sigma2 = data["psf_sigma2"][0][band] ** 2
+            sigmap = data["psf_sigmap"][0][band] ** 2
+            beta = data["psf_beta"][0][band]
+            b = data["psf_b"][0][band]
+            p0 = data["psf_p0"][0][band]
+
+            psf_params[i] = torch.log(torch.tensor([sigma1, sigma2, sigmap, beta, b, p0]))
+
+        return psf_params
+
+    def _get_psf(self):
+        psf_list = []
+        for i in range(self.n_bands):
+            band_psf = self._get_psf_single_band(i)
+            band_psf *= self.normalization_constant[i]
+            psf_list.append(band_psf.unsqueeze(0))
+        psf = torch.cat(psf_list)
+
+        assert (psf > 0).all()
+        return psf
+
+    @staticmethod
+    def _psf_fun(r, sigma1, sigma2, sigmap, beta, b, p0):
+        term1 = torch.exp(-(r**2) / (2 * sigma1))
+        term2 = b * torch.exp(-(r**2) / (2 * sigma2))
+        term3 = p0 * (1 + r**2 / (beta * sigmap)) ** (-beta / 2)
+        return (term1 + term2 + term3) / (1 + b + p0)
+
+    def _get_psf_single_band(self, band_idx):
+        psf_params = torch.exp(self.params[band_idx])
+        return self._psf_fun(
+            self.cached_radii_grid,
+            psf_params[0],
+            psf_params[1],
+            psf_params[2],
+            psf_params[3],
+            psf_params[4],
+            psf_params[5],
+        )
+
+    def forward_adjusted_psf(self):
+        # use power_law_psf and current psf parameters to forward and obtain fresh psf model.
+        # first dimension of psf is number of bands
+        # dimension of the psf/slen should be odd
+        psf = self.psf_forward()
+        psf_slen = psf.shape[2]
+        assert len(psf.shape) == 3
+        assert psf.shape[0] == self.n_bands
+        assert psf.shape[1] == psf_slen
+        assert (psf_slen % 2) == 1
+        return psf

--- a/case_studies/strong_lensing/eval.py
+++ b/case_studies/strong_lensing/eval.py
@@ -1,0 +1,78 @@
+import sys
+sys.path.append("../../")
+
+from einops import rearrange
+from bliss.catalog import TileCatalog, get_images_in_tiles, get_is_on_from_n_sources
+from bliss import reporting
+from bliss.encoder import Encoder
+from bliss.inference import SDSSFrame
+from bliss.datasets import sdss
+from bliss.inference import reconstruct_scene_at_coordinates
+from case_studies.strong_lensing.plots.main import load_models
+
+import matplotlib.pyplot as plt
+plt.style.use('ggplot')
+import torch
+
+from astropy.table import Table
+import plotly.express as px
+import plotly.graph_objects as go
+from hydra import compose, initialize
+from hydra.utils import instantiate
+import numpy as np
+
+with initialize(config_path="config"):
+    cfg = compose("config", overrides=[])
+
+device = torch.device('cuda:0')
+enc, dec = load_models(cfg, device)
+bp = enc.border_padding
+torch.cuda.empty_cache()
+
+enc.n_rows_per_batch = 10
+enc.n_images_per_batch = 15
+
+dataset = instantiate(
+    cfg.datasets.simulated,
+    generate_device="cuda:0",
+)
+
+delta = 0.025
+increments = np.arange(0, 1.0, delta)
+galaxies = np.zeros(increments.shape)
+counts = np.zeros(increments.shape)
+
+batch_size = 8
+trials = 1000
+for _ in range(trials):
+    tile_catalog = dataset.sample_prior(batch_size, cfg.datasets.simulated.n_tiles_h, cfg.datasets.simulated.n_tiles_w)
+    tile_catalog.set_all_fluxes_and_mags(dataset.image_decoder)
+    images, backgrounds = dataset.simulate_image_from_catalog(tile_catalog)
+
+    tile_map = enc.variational_mode(images, backgrounds, tile_catalog)
+    full_map = tile_map.cpu().to_full_params()
+    full_true = tile_catalog.cpu().to_full_params()
+
+    for i in range(batch_size):
+        true_gal_bool = full_true["lensed_galaxy_bools"].cpu().numpy()[i,:,0].astype("bool")
+        pred_gal_probs = full_map["lensed_galaxy_probs"].cpu().numpy()[i,...]
+
+        gal_probs = pred_gal_probs[true_gal_bool]
+        gal_buckets = (gal_probs // delta).astype("int")
+        for bucket in gal_buckets:
+            galaxies[bucket] += 1
+        
+        count_buckets = (pred_gal_probs // delta).astype("int")
+        for bucket in count_buckets:
+            counts[bucket] += 1
+
+x = []
+y = []
+for i, (galaxy, count) in enumerate(zip(galaxies, counts)):
+    if count > 0:
+        x.append(increments[i])
+        y.append(galaxy / count)
+
+plt.plot(increments, increments, color="b")
+plt.scatter(x, y)
+plt.savefig("lensing_posterior.png")

--- a/case_studies/strong_lensing/eval_ci.py
+++ b/case_studies/strong_lensing/eval_ci.py
@@ -1,0 +1,81 @@
+import sys
+sys.path.append("../../")
+
+from einops import rearrange
+from bliss.catalog import TileCatalog, get_images_in_tiles, get_is_on_from_n_sources
+from bliss import reporting
+from bliss.encoder import Encoder
+from bliss.inference import SDSSFrame
+from bliss.datasets import sdss
+from bliss.inference import reconstruct_scene_at_coordinates
+from case_studies.strong_lensing.plots.main import load_models
+
+import matplotlib.pyplot as plt
+plt.style.use('ggplot')
+import torch
+
+from astropy.table import Table
+import plotly.express as px
+import plotly.graph_objects as go
+from hydra import compose, initialize
+from hydra.utils import instantiate
+import numpy as np
+
+with initialize(config_path="config"):
+    cfg = compose("config", overrides=[])
+
+device = torch.device('cuda:0')
+enc, dec = load_models(cfg, device)
+bp = enc.border_padding
+torch.cuda.empty_cache()
+
+enc.n_rows_per_batch = 10
+enc.n_images_per_batch = 15
+
+dataset = instantiate(
+    cfg.datasets.simulated,
+    generate_device="cuda:0",
+)
+
+total_contained = np.zeros(7)
+
+total_lenses = 0
+batch_size = 1
+trials = 1000
+num_samples = 100
+
+for _ in range(trials):
+    tile_catalog = dataset.sample_prior(batch_size, cfg.datasets.simulated.n_tiles_h, cfg.datasets.simulated.n_tiles_w)
+    tile_catalog.set_all_fluxes_and_mags(dataset.image_decoder)
+    images, backgrounds = dataset.simulate_image_from_catalog(tile_catalog)
+
+    full_true = tile_catalog.cpu().to_full_params()
+
+    true_gal_bool = full_true["galaxy_bools"].cpu().numpy()[0,:,0].astype("bool")
+    true_lens = full_true["galaxy_params"].cpu().numpy()[0,...][true_gal_bool]
+
+    samples = []
+    for _ in range(num_samples):
+        tile_sample_dict = enc.sample(images, backgrounds, 1, tile_catalog)
+        tile_sample = TileCatalog.from_flat_dict(
+            enc.detection_encoder.tile_slen,
+            cfg.datasets.simulated.n_tiles_h,
+            cfg.datasets.simulated.n_tiles_w,
+            {k: v.squeeze(0) for k, v in tile_sample_dict.items()},
+        )
+        full_sample = tile_sample.cpu().to_full_params()
+        lens_sample = full_sample["galaxy_params"].cpu().numpy()[0,...][true_gal_bool]
+        samples.append(lens_sample)
+    
+    samples = np.array(samples)
+    
+    confidence_percent = .90
+    alpha = ((1 - confidence_percent) / 2) * 100
+    lower_ci = np.percentile(samples, alpha, axis=0)
+    upper_ci = np.percentile(samples, 100 - alpha, axis=0)
+    
+    contained = np.logical_and(lower_ci <= true_lens, true_lens <= upper_ci).astype("int")
+    total_contained += np.sum(contained, axis=0).squeeze()
+    total_lenses += true_lens.shape[0]
+
+print(total_contained / total_lenses)

--- a/tests/case_studies/strong_lensing/conftest.py
+++ b/tests/case_studies/strong_lensing/conftest.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import pytest
+from hydra import compose, initialize
+
+from tests.conftest import ModelSetup
+
+
+def get_strong_lensing_cfg(overrides, devices):
+    overrides.update({"gpus": devices.gpus, "paths.root": Path(__file__).parents[3].as_posix()})
+    overrides = [f"{k}={v}" if v is not None else f"{k}=null" for k, v in overrides.items()]
+    with initialize(config_path="../../../case_studies/strong_lensing/config"):
+        cfg = compose("config", overrides=overrides)
+    return cfg
+
+
+class SingleGalsimGalaxiesSetup(ModelSetup):
+    def get_cfg(self, overrides):
+        return get_strong_lensing_cfg(overrides, self.devices)
+
+
+@pytest.fixture(scope="session")
+def strong_lensing_setup(devices):
+    return SingleGalsimGalaxiesSetup(devices)
+
+
+@pytest.fixture(scope="session")
+def get_strong_lensing_config():
+    return get_strong_lensing_cfg

--- a/tests/case_studies/strong_lensing/test_lens_encoder.py
+++ b/tests/case_studies/strong_lensing/test_lens_encoder.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def overrides(devices):
+    overrides = {
+        "mode": "train",
+        "training": "sdss_lens_encoder",
+    }
+    if devices.use_cuda:
+        overrides.update({"training.n_epochs": 50})
+    else:
+        overrides.update(
+            {
+                "datasets.simulated.n_batches": 1,
+                "datasets.simulated.batch_size": 2,
+                "datasets.simulated.generate_device": "cpu",
+                "training.n_epochs": 2,
+            }
+        )
+    return overrides
+
+
+def test_lens_encoder(strong_lensing_setup, devices, overrides):
+    trained_lens_encoder = strong_lensing_setup.get_trained_model(overrides)
+    results = strong_lensing_setup.test_model(overrides, trained_lens_encoder)

--- a/tests/case_studies/strong_lensing/test_lensing_binary_encoder.py
+++ b/tests/case_studies/strong_lensing/test_lensing_binary_encoder.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def overrides(devices):
+    overrides = {
+        "mode": "train",
+        "training": "sdss_lensing_binary_encoder",
+    }
+    if devices.use_cuda:
+        overrides.update({"training.n_epochs": 51})
+    else:
+        overrides.update(
+            {
+                "datasets.simulated.n_batches": 1,
+                "datasets.simulated.batch_size": 2,
+                "datasets.simulated.generate_device": "cpu",
+                "training.n_epochs": 2,
+            }
+        )
+    return overrides
+
+
+def test_sdss_lensing_detection_encoder(strong_lensing_setup, overrides, devices):
+    trained_location = strong_lensing_setup.get_trained_model(overrides)
+    results = strong_lensing_setup.test_model(overrides, trained_location)
+
+    assert "acc" in results
+
+    # only check testing results if GPU available
+    if devices.use_cuda:
+        assert results["acc"] > 0.75


### PR DESCRIPTION
This is the PR where all the other lensing encoders and decoders are integrated, so this partially touches the core pipeline. To address some questions about the choice for the lensing decoder, here's some context about rendering lensed galaxies as we currently support it: lensed galaxies are assumed to be lensed by some other galaxy (i.e. we don't support lensing due to unseen dark matter or anything of that sort). This means, whenever we're rendering a lensed galaxy, we are rendering *both* the lensed galaxy *and* the lensing galaxy. So, in reality, when we have a "lensed galaxy" in the code, it's actually 2 galaxies. This is why, when we have a lensing event, we have 7 parameters for the *lensing* galaxy and 12 for the *lensed* galaxy (7 to describe the galaxy itself and 5 for how it is to be distorted).

As for why to integrate it into the GalsimDecoder directly, it felt natural to say, if we have a galaxy that is involved with lensing, we can first rendering the galaxy and then render the galaxy it's lensing at the same time instead of doing a "second pass" to just render the lensed galaxies. So, I kept that the same as before.

Otherwise, I think I addressed most of the issues from the first PR! I didn't change some of the formatting stuff, cause I just ran black and kept the result of that. But I guess we can override that if we wanna 