### PR TITLE
U/im/coadd flux posterior calibration

### DIFF
--- a/bliss/encoder.py
+++ b/bliss/encoder.py
@@ -139,7 +139,7 @@ class Encoder(nn.Module):
                 tile_map_list.append(out_ptiles)
         return self.collate(tile_map_list)
 
-    def make_ptile_loader(self, image: Tensor, background: Tensor, n_tiles_h: int) -> Tensor:
+    def make_ptile_loader(self, image: Tensor, background: Tensor, n_tiles_h: int):
         img_bg = torch.cat((image, background), dim=1).to(self.device)
         n_images = image.shape[0]
         for start_b in range(0, n_images, self.n_images_per_batch):

--- a/bliss/models/detection_encoder.py
+++ b/bliss/models/detection_encoder.py
@@ -155,10 +155,7 @@ class DetectionEncoder(pl.LightningModule):
 
         n_source_log_probs = self.log_softmax(n_source_free_probs)
 
-        return {
-            "per_source_params": per_source_params,
-            "n_source_log_probs": n_source_log_probs,
-        }
+        return {"per_source_params": per_source_params, "n_source_log_probs": n_source_log_probs}
 
     def sample(
         self,

--- a/case_studies/coadds/README.md
+++ b/case_studies/coadds/README.md
@@ -35,4 +35,8 @@ python get_results.py # generate plots from cache
 The figures are saved as `.png` files in `./outputs/figs/{SEED}/` as default, where `SEED` is the value
 of the seed at the top of the config file.
 
-**NOTE:** Results for the ML4Science Neurips 2022 submission can be reproduced at commit [7b9f7aa](https://github.com/prob-ml/bliss/commit/7b9f7aaabd88b512e4d42432166a8ce319329bd9).
+## Updates
+
+- 11/20/22: Flux measurement comparison (and flux posterior calibration) now conditions on true detections allowing for star-by-star comparison between models. 
+
+- 11/16/22: Results for the ML4Science Neurips 2022 submission can be reproduced at commit [7b9f7aa](https://github.com/prob-ml/bliss/commit/7b9f7aaabd88b512e4d42432166a8ce319329bd9).

--- a/case_studies/coadds/README.md
+++ b/case_studies/coadds/README.md
@@ -34,3 +34,5 @@ python get_results.py # generate plots from cache
 
 The figures are saved as `.png` files in `./outputs/figs/{SEED}/` as default, where `SEED` is the value
 of the seed at the top of the config file.
+
+**NOTE:** Results for Neurips 2022 submission can be reproduced at commit [7b9f7aa](https://github.com/prob-ml/bliss/commit/7b9f7aaabd88b512e4d42432166a8ce319329bd9).

--- a/case_studies/coadds/README.md
+++ b/case_studies/coadds/README.md
@@ -35,4 +35,4 @@ python get_results.py # generate plots from cache
 The figures are saved as `.png` files in `./outputs/figs/{SEED}/` as default, where `SEED` is the value
 of the seed at the top of the config file.
 
-**NOTE:** Results for Neurips 2022 submission can be reproduced at commit [7b9f7aa](https://github.com/prob-ml/bliss/commit/7b9f7aaabd88b512e4d42432166a8ce319329bd9).
+**NOTE:** Results for the ML4Science Neurips 2022 submission can be reproduced at commit [7b9f7aa](https://github.com/prob-ml/bliss/commit/7b9f7aaabd88b512e4d42432166a8ce319329bd9).

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -14,7 +14,7 @@ def test_multiple_sources_one_tile():
 
     with pytest.raises(ValueError) as error_info:
         full_cat.to_tile_params(1, 1, ignore_extra_sources=False)
-    assert error_info.value.args[0] == "Number of sources per tile exceeds `max_sources_per_tile`."
+    assert error_info.value.args[0] == "# of sources per tile exceeds `max_sources_per_tile`."
 
     # should return only first source in first tile.
     tile_cat = full_cat.to_tile_params(1, 1, ignore_extra_sources=True)


### PR DESCRIPTION
Improvement over ml4science neurips results by conditioning (all) detection encoders on true counts per tiles of all stars for flux measurement. Thus allowing for comparison between encoders on flux measurement on source by source basis. 
Before, the sample was based on matched locations, so the sample that each encoder was tested on was different since the detections were different depending on number of coadds used (making comparison unfair). 

This is also in the spirit of evaluating the flux measurement independently of detections.

It makes sense to condition on star locations that might below detection threshold for some encoders because (1) The flux residual plot is per bin, so some bins can be ignored if desired (2) We want to actually compare each star between encoders, we want to test if the coadd encoders can extract more information from the coadd and give a better estimate of the flux. The only way to do this is if we test all the encoders on the same stars. 

This PR also demonstrates that is not completely straightforward to condition detection encoder on true locations. This suggest some refactoring is necessary or perhaps working on #697. 

I made it clear in the README how results from neurips submission can be reproduced (pointed to a commit). The main conclusions stayed the same (see figures below).

- [x] extend `to_tile_params` to allow for multiple batches
- [x] use detection encoder conditioned on true detections (counts per tile) to allow 1-1 comparison of fluxes for posterior calibration results and residual flux metric plot. 