### PR TITLE
Decouple generate config from training

### DIFF
--- a/bliss/generate.py
+++ b/bliss/generate.py
@@ -17,7 +17,7 @@ FileDatum = TypedDict(
 
 
 def generate(cfg: DictConfig):
-    file_data_capacity = cfg.cached_simulator.file_data_capacity
+    file_data_capacity = cfg.generate.file_data_capacity
     cached_data_path = cfg.cached_simulator.cached_data_path
 
     # largest `batch_size` multiple <= `file_data_capacity`

--- a/bliss/simulator/simulated_dataset.py
+++ b/bliss/simulator/simulated_dataset.py
@@ -119,6 +119,12 @@ class CachedSimulatedDataset(pl.LightningDataModule, IterableDataset):
             if filename.startswith("dataset") and filename.endswith(".pkl"):
                 self.data += self.read_file(f"{self.cached_data_path}/{filename}")
         assert self.data, "No cached data loaded; run `generate.py` first"
+        assert len(self.data) >= self.n_batches * self.batch_size, (
+            f"Insufficient cached data loaded; "
+            f"need at least {self.n_batches * self.batch_size} "
+            f"but only have {len(self.data)}. Re-run `generate.py` with "
+            f"different generation `n_batches` and/or `batch_size`."
+        )
 
         # fix validation set
         assert os.path.exists(
@@ -155,10 +161,10 @@ class CachedSimulatedDataset(pl.LightningDataModule, IterableDataset):
             yield self.get_batch(batch_idx)
 
     def train_dataloader(self):
-        return DataLoader(self, batch_size=None, num_workers=0)
+        return DataLoader(self, batch_size=None, num_workers=self.num_workers)
 
     def val_dataloader(self):
-        return DataLoader(self.valid, batch_size=None, num_workers=0)
+        return DataLoader(self.valid, batch_size=None, num_workers=self.num_workers)
 
     def test_dataloader(self):
-        return DataLoader(self.test, batch_size=None, num_workers=0)
+        return DataLoader(self.test, batch_size=None, num_workers=self.num_workers)

--- a/bliss/simulator/simulated_dataset.py
+++ b/bliss/simulator/simulated_dataset.py
@@ -97,9 +97,8 @@ class CachedSimulatedDataset(pl.LightningDataModule, IterableDataset):
     def __init__(
         self,
         n_batches: int,
-        num_workers: int,
         batch_size: int,
-        file_data_capacity: int,
+        num_workers: int,
         cached_data_path: str,
     ):
         super().__init__()
@@ -107,7 +106,6 @@ class CachedSimulatedDataset(pl.LightningDataModule, IterableDataset):
         self.n_batches = n_batches
         self.num_workers = num_workers
         self.batch_size = batch_size
-        self.file_data_capacity = file_data_capacity
         self.cached_data_path = cached_data_path
 
         self.data: List[FileDatum] = []

--- a/case_studies/diskrw_gsimages_721/config.yaml
+++ b/case_studies/diskrw_gsimages_721/config.yaml
@@ -19,7 +19,7 @@ simulator:
         field: 12
         bands: [2]
 
-cached_simulator:
+generate:
     file_data_capacity: 150
 
 training:

--- a/case_studies/diskrw_gsimages_721/config.yaml
+++ b/case_studies/diskrw_gsimages_721/config.yaml
@@ -10,7 +10,6 @@ paths:
     pretrained_models: ${paths.data}/pretrained_models
 
 simulator:
-    n_batches: 5
     background:
         _target_: bliss.simulator.background.SimulatedSDSSBackground
         sdss_dir: ${paths.sdss}
@@ -20,7 +19,8 @@ simulator:
         bands: [2]
 
 generate:
-    file_data_capacity: 150
+    n_batches: 5
+    max_images_per_file: 150
 
 training:
     name: "encoder"

--- a/conf/base_config.yaml
+++ b/conf/base_config.yaml
@@ -56,10 +56,10 @@ simulator:
 
 cached_simulator:
     _target_: bliss.simulator.simulated_dataset.CachedSimulatedDataset
-    n_batches: ${simulator.n_batches}
+    n_batches: ${generate.n_batches}
     batch_size: ${simulator.prior.batch_size}
-    num_workers: ${simulator.num_workers}
-    cached_data_path: ${paths.data}/cached_dataset
+    num_workers: 0
+    cached_data_path: ${generate.cached_data_path}
 
 encoder:
     _target_: bliss.encoder.Encoder
@@ -107,9 +107,11 @@ encoder:
 
 generate:
     splits: [train, valid, test]
+    n_batches: ${simulator.n_batches}
     valid_n_batches: ${simulator.valid_n_batches}
     test_n_batches: ${simulator.valid_n_batches}
-    file_data_capacity: 5000
+    max_images_per_file: 5000
+    cached_data_path: ${paths.data}/cached_dataset
 
 training:
     name: null

--- a/conf/base_config.yaml
+++ b/conf/base_config.yaml
@@ -57,9 +57,8 @@ simulator:
 cached_simulator:
     _target_: bliss.simulator.simulated_dataset.CachedSimulatedDataset
     n_batches: ${simulator.n_batches}
-    num_workers: ${simulator.num_workers}
     batch_size: ${simulator.prior.batch_size}
-    file_data_capacity: 5000
+    num_workers: ${simulator.num_workers}
     cached_data_path: ${paths.data}/cached_dataset
 
 encoder:
@@ -110,6 +109,7 @@ generate:
     splits: [train, valid, test]
     valid_n_batches: ${simulator.valid_n_batches}
     test_n_batches: ${simulator.valid_n_batches}
+    file_data_capacity: 5000
 
 training:
     name: null

--- a/tests/test_cached_dataset.py
+++ b/tests/test_cached_dataset.py
@@ -13,7 +13,7 @@ def cached_data(cfg):
     generate(cfg)
     # check that cached dataset exists
     cached_dataset_should_exist = cfg.simulator.n_batches > 0 and (
-        cfg.simulator.prior.batch_size < cfg.cached_simulator.file_data_capacity
+        cfg.simulator.prior.batch_size < cfg.generate.max_images_per_file
     )
     file_path = cfg.cached_simulator.cached_data_path + "/dataset_0.pkl"
     if cached_dataset_should_exist:

--- a/tests/testing_config.yaml
+++ b/tests/testing_config.yaml
@@ -5,7 +5,6 @@ defaults:
     - override hydra/job_logging: stdout
 
 simulator:
-    n_batches: 2
     valid_n_batches: 2
     num_workers: 0
     prior:
@@ -18,8 +17,9 @@ simulator:
         _target_: bliss.simulator.background.ConstantBackground
         background: [865.0]
 
-cached_simulator:
-    file_data_capacity: 50
+generate:
+    n_batches: 2
+    max_images_per_file: 50
     cached_data_path: null # use pytest tmpdir
 
 training:


### PR DESCRIPTION
So that `cfg.cached_simulator` is only needed/used for training, and `cfg.generate` (with `cfg.simulator`) defines how data is generated at generate step.