### PR TITLE
Save/load data with torch to reduce size

### DIFF
--- a/bliss/simulator/simulated_dataset.py
+++ b/bliss/simulator/simulated_dataset.py
@@ -1,5 +1,4 @@
 import os
-import pickle
 import random
 import warnings
 from typing import Dict, List, Optional, Tuple, Union
@@ -116,7 +115,7 @@ class CachedSimulatedDataset(pl.LightningDataModule, IterableDataset):
         for filename in os.listdir(self.cached_data_path):
             if "valid" in filename or "test" in filename:
                 continue
-            if filename.startswith("dataset") and filename.endswith(".pkl"):
+            if filename.startswith("dataset") and filename.endswith(".pt"):
                 self.data += self.read_file(f"{self.cached_data_path}/{filename}")
         assert self.data, "No cached data loaded; run `generate.py` first"
         assert len(self.data) >= self.n_batches * self.batch_size, (
@@ -128,18 +127,18 @@ class CachedSimulatedDataset(pl.LightningDataModule, IterableDataset):
 
         # fix validation set
         assert os.path.exists(
-            f"{self.cached_data_path}/dataset_valid.pkl"
+            f"{self.cached_data_path}/dataset_valid.pt"
         ), "No cached validation data found; run `generate.py` first"
-        self.valid = self.read_file(f"{self.cached_data_path}/dataset_valid.pkl")
+        self.valid = self.read_file(f"{self.cached_data_path}/dataset_valid.pt")
 
         assert os.path.exists(
-            f"{self.cached_data_path}/dataset_test.pkl"
+            f"{self.cached_data_path}/dataset_test.pt"
         ), "No cached test data found; run `generate.py` first"
-        self.test = self.read_file(f"{self.cached_data_path}/dataset_test.pkl")
+        self.test = self.read_file(f"{self.cached_data_path}/dataset_test.pt")
 
     def read_file(self, filename: str) -> List[FileDatum]:
         with open(filename, "rb") as f:
-            return pickle.load(f)
+            return torch.load(f)
 
     def get_batch(self, batch_idx) -> Dict:
         batch_data = self.data[batch_idx * self.batch_size : (batch_idx + 1) * self.batch_size]

--- a/conf/base_config.yaml
+++ b/conf/base_config.yaml
@@ -57,7 +57,7 @@ simulator:
 cached_simulator:
     _target_: bliss.simulator.simulated_dataset.CachedSimulatedDataset
     n_batches: ${generate.n_batches}
-    batch_size: ${simulator.prior.batch_size}
+    batch_size: ${generate.batch_size}
     num_workers: 0
     cached_data_path: ${generate.cached_data_path}
 
@@ -108,6 +108,7 @@ encoder:
 generate:
     splits: [train, valid, test]
     n_batches: ${simulator.n_batches}
+    batch_size: ${simulator.prior.batch_size}
     valid_n_batches: ${simulator.valid_n_batches}
     test_n_batches: ${simulator.valid_n_batches}
     max_images_per_file: 5000

--- a/tests/test_cached_dataset.py
+++ b/tests/test_cached_dataset.py
@@ -1,5 +1,4 @@
 import os
-import pickle
 
 import pytest
 import torch
@@ -15,12 +14,12 @@ def cached_data(cfg):
     cached_dataset_should_exist = cfg.simulator.n_batches > 0 and (
         cfg.simulator.prior.batch_size < cfg.generate.max_images_per_file
     )
-    file_path = cfg.cached_simulator.cached_data_path + "/dataset_0.pkl"
+    file_path = cfg.cached_simulator.cached_data_path + "/dataset_0.pt"
     if cached_dataset_should_exist:
         assert os.path.exists(file_path), f"{file_path} not found"
     # cursory check of contents of cached dataset
     with open(file_path, "rb") as f:
-        cached_dataset = pickle.load(f)
+        cached_dataset = torch.load(f)
         assert isinstance(cached_dataset, list), "cached_dataset must be a list"
         assert isinstance(cached_dataset[0], dict), "cached_dataset must be a list of dictionaries"
         assert isinstance(

--- a/tests/testing_config.yaml
+++ b/tests/testing_config.yaml
@@ -19,6 +19,7 @@ simulator:
 
 generate:
     n_batches: 2
+    batch_size: 32
     max_images_per_file: 50
     cached_data_path: null # use pytest tmpdir
 


### PR DESCRIPTION
@aakashdp6548 found that using pickle takes up so much more space than necessary, and also the amount of space increases exponentially with the number of images stored per file.

`torch.save` seems to drastically reduce the amount of space used:

Given the following `cfg.generate` config:
```
generate:
    n_batches: 37
    batch_size: 4
    max_images_per_file: 150
```

observe the space used by `.pt` vs `.pkl`
```
❯ du -sh data/cached_dataset_37_4_150_pt/dataset_0.pt
11M     data/cached_dataset_37_4_150_pt/dataset_0.pt

❯ du -sh data/cached_dataset_37_4_150_pkl/dataset_0.pkl
1.5G    data/cached_dataset_37_4_150_pkl/dataset_0.pkl
```