### PR TITLE
Fix bug with cached_data_path in generate

### DIFF
--- a/bliss/generate.py
+++ b/bliss/generate.py
@@ -42,6 +42,7 @@ def generate(cfg: DictConfig):
     # create cached_data_path if it doesn't exist
     if not os.path.exists(cached_data_path):
         os.makedirs(cached_data_path)
+    print("Data will be saved to {}".format(cached_data_path))
 
     if "train" in cfg.generate.splits:
         # assume overwriting any existing cached image files

--- a/bliss/generate.py
+++ b/bliss/generate.py
@@ -17,7 +17,7 @@ FileDatum = TypedDict(
 
 def generate(cfg: DictConfig):
     max_images_per_file = cfg.generate.max_images_per_file
-    cached_data_path = cfg.cached_simulator.cached_data_path
+    cached_data_path = cfg.generate.cached_data_path
 
     # largest `batch_size` multiple <= `max_images_per_file`
     bs = cfg.generate.batch_size

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def cfg(pytestconfig, cached_data_path):
         "predict.device": "cuda:0" if use_gpu else "cpu",
         "paths.root": Path(__file__).parents[1].as_posix(),
         "cached_simulator.cached_data_path": str(cached_data_path),
+        "generate.cached_data_path": str(cached_data_path),
     }
     overrides = [f"{k}={v}" if v is not None else f"{k}=null" for k, v in overrides.items()]
     with initialize(config_path=".", version_base=None):


### PR DESCRIPTION
Get `cached_data_path` from `cfg.generate` instead of `cfg.cached_simulator` in generate.
https://github.com/prob-ml/bliss/blob/756092a0b1f14fe43890bf8f09eab238147d9ef6/bliss/generate.py#L19-L21