### PR TITLE
Multi-process single-threaded data gen

### DIFF
--- a/bliss/generate.py
+++ b/bliss/generate.py
@@ -52,26 +52,10 @@ def generate(cfg: DictConfig):
                 images_per_file // bs, simulated_dataset, "Simulating images in batches for file"
             )
             file_data = itemize_data(batch_data)
-            with open(f"{cached_data_path}/dataset_{file_idx}.pt", "wb") as f:
+            with open(
+                f"{cached_data_path}/{cfg.generate.train_file_prefix}_{file_idx}.pt", "wb"
+            ) as f:
                 torch.save(file_data, f)
-
-    if "valid" in cfg.generate.splits:
-        valid = generate_data(
-            cfg.generate.valid_n_batches,
-            simulated_dataset,
-            "Generating fixed validation set in batches",
-        )
-        with open(f"{cached_data_path}/dataset_valid.pt", "wb") as f:
-            torch.save(valid, f)
-
-    if "test" in cfg.generate.splits:
-        test = generate_data(
-            cfg.generate.test_n_batches,
-            simulated_dataset,
-            "Generating fixed test set in batches",
-        )
-        with open(f"{cached_data_path}/dataset_test.pt", "wb") as f:
-            torch.save(test, f)
 
 
 def generate_data(n_batches: int, simulated_dataset, desc="Generating data"):

--- a/bliss/generate.py
+++ b/bliss/generate.py
@@ -18,6 +18,8 @@ FileDatum = TypedDict(
 def generate(cfg: DictConfig):
     max_images_per_file = cfg.generate.max_images_per_file
     cached_data_path = cfg.generate.cached_data_path
+    files_start_idx = cfg.generate.files_start_idx
+    n_workers_per_process = cfg.generate.n_workers_per_process
 
     # largest `batch_size` multiple <= `max_images_per_file`
     bs = cfg.generate.batch_size
@@ -30,7 +32,9 @@ def generate(cfg: DictConfig):
 
     # use SimulatedDataset to generate data in minibatches iteratively,
     # then concatenate before caching to disk via pickle
-    simulator = instantiate(cfg.simulator, prior={"batch_size": bs})
+    simulator = instantiate(
+        cfg.simulator, num_workers=n_workers_per_process, prior={"batch_size": bs}
+    )
     simulated_dataset = simulator.train_dataloader().dataset
     assert isinstance(
         simulated_dataset, IterableDataset
@@ -45,17 +49,15 @@ def generate(cfg: DictConfig):
     with open(f"{cfg.generate.cached_data_path}/hparams.yaml", "w", encoding="utf-8") as f:
         OmegaConf.save(cfg, f)
 
-    if "train" in cfg.generate.splits:
-        # assume overwriting any existing cached image files
-        for file_idx in tqdm(range(n_files), desc="Generating and writing cached dataset files"):
-            batch_data = generate_data(
-                images_per_file // bs, simulated_dataset, "Simulating images in batches for file"
-            )
-            file_data = itemize_data(batch_data)
-            with open(
-                f"{cached_data_path}/{cfg.generate.train_file_prefix}_{file_idx}.pt", "wb"
-            ) as f:
-                torch.save(file_data, f)
+    # assume overwriting any existing cached image files
+    file_idxs = range(files_start_idx, files_start_idx + n_files)
+    for file_idx in tqdm(file_idxs, desc="Generating and writing cached dataset files"):
+        batch_data = generate_data(
+            images_per_file // bs, simulated_dataset, "Simulating images in batches for file"
+        )
+        file_data = itemize_data(batch_data)
+        with open(f"{cached_data_path}/{cfg.generate.file_prefix}_{file_idx}.pt", "wb") as f:
+            torch.save(file_data, f)
 
 
 def generate_data(n_batches: int, simulated_dataset, desc="Generating data"):

--- a/bliss/simulator/simulated_dataset.py
+++ b/bliss/simulator/simulated_dataset.py
@@ -98,6 +98,7 @@ class CachedSimulatedDataset(pl.LightningDataModule, Dataset):
         batch_size: int,
         num_workers: int,
         cached_data_path: str,
+        train_file_prefix: str = "dataset",
     ):
         super().__init__()
 
@@ -105,6 +106,7 @@ class CachedSimulatedDataset(pl.LightningDataModule, Dataset):
         self.num_workers = num_workers
         self.batch_size = batch_size
         self.cached_data_path = cached_data_path
+        self.train_file_prefix = train_file_prefix
 
         self.data: List[FileDatum] = []
         self.valid: List[FileDatum] = []
@@ -114,7 +116,7 @@ class CachedSimulatedDataset(pl.LightningDataModule, Dataset):
         for filename in os.listdir(self.cached_data_path):
             if "valid" in filename or "test" in filename:
                 continue
-            if filename.startswith("dataset") and filename.endswith(".pt"):
+            if filename.startswith(self.train_file_prefix) and filename.endswith(".pt"):
                 self.data += self.read_file(f"{self.cached_data_path}/{filename}")
 
         # fix validation set

--- a/case_studies/diskrw_gsimages_721/config.yaml
+++ b/case_studies/diskrw_gsimages_721/config.yaml
@@ -18,8 +18,13 @@ simulator:
         field: 12
         bands: [2]
 
+cached_simulator:
+    n_train_batches: 192
+    val_split_file_idxs: [96, 97, 98]
+    test_split_file_idxs: [99, 100, 101]
+
 generate:
-    n_batches: 5
+    n_batches: 6
     max_images_per_file: 150
 
 training:

--- a/conf/base_config.yaml
+++ b/conf/base_config.yaml
@@ -56,13 +56,13 @@ simulator:
 
 cached_simulator:
     _target_: bliss.simulator.simulated_dataset.CachedSimulatedDataset
-    n_batches: ${generate.n_batches}
+    train_n_batches: ${generate.n_batches}
     batch_size: ${generate.batch_size}
     num_workers: 0
     cached_data_path: ${generate.cached_data_path}
-    train_file_prefix: ${generate.train_file_prefix}
-    val_split_file_idxs: null
-    test_split_file_idxs: null
+    file_prefix: ${generate.file_prefix}
+    val_split_file_idxs: null # inclusive range
+    test_split_file_idxs: null # inclusive range
 
 encoder:
     _target_: bliss.encoder.Encoder
@@ -109,14 +109,13 @@ encoder:
         ]
 
 generate:
-    splits: [train, valid, test]
+    n_workers_per_process: 0
     n_batches: ${simulator.n_batches}
     batch_size: ${simulator.prior.batch_size}
-    valid_n_batches: ${simulator.valid_n_batches}
-    test_n_batches: ${simulator.valid_n_batches}
     max_images_per_file: 5000
     cached_data_path: ${paths.data}/cached_dataset
-    train_file_prefix: dataset
+    file_prefix: dataset
+    files_start_idx: 0
 
 training:
     name: null

--- a/conf/base_config.yaml
+++ b/conf/base_config.yaml
@@ -60,6 +60,9 @@ cached_simulator:
     batch_size: ${generate.batch_size}
     num_workers: 0
     cached_data_path: ${generate.cached_data_path}
+    train_file_prefix: ${generate.train_file_prefix}
+    val_split_file_idxs: null
+    test_split_file_idxs: null
 
 encoder:
     _target_: bliss.encoder.Encoder
@@ -113,6 +116,7 @@ generate:
     test_n_batches: ${simulator.valid_n_batches}
     max_images_per_file: 5000
     cached_data_path: ${paths.data}/cached_dataset
+    train_file_prefix: dataset
 
 training:
     name: null

--- a/scripts/generate_data_in_parallel.sh
+++ b/scripts/generate_data_in_parallel.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 
-NUM_PROCESSES=${1:-32}
-NUM_WORKERS_PER_PROCESS=${2:-0}
-CONFIG_PATH=${3:-"case_studies/summer_template"}
+# Usage: generate_data_in_parallel.sh <relative config_path> <num_files_per_process> <num_processes> <num_workers_per_process>
+CONFIG_PATH=$1
+N_FILES_PER_PROCESS=$2
+NUM_PROCESSES=${3:-32}
+N_WORKERS_PER_PROCESS=${4:-0}
+
+# Error if CONFIG_PATH, N_FILES_PER_PROCESS not specified
+if [ -z "$CONFIG_PATH" ] || [ -z "$N_FILES_PER_PROCESS" ]; then
+    echo "Usage: generate_data_in_parallel.sh <relative config_path> <num_files_per_process> <num_processes (default: 32)> <num_workers_per_process (default: 0)>"
+    exit 1
+fi
 
 for ((i=0; i<$NUM_PROCESSES; i++));
 do
-    bliss -cp $CONFIG_PATH 'mode=generate' 'generate.splits=[train]' "simulator.num_workers=$NUM_WORKERS_PER_PROCESS" "generate.train_file_prefix=dataset_p$i" &
+    files_start_idx=$((i * N_FILES_PER_PROCESS))
+    bliss -cp $CONFIG_PATH 'mode=generate' "simulator.num_workers=$N_WORKERS_PER_PROCESS" "generate.files_start_idx=$files_start_idx" &
 done
 wait

--- a/scripts/generate_data_in_parallel.sh
+++ b/scripts/generate_data_in_parallel.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+NUM_PROCESSES=${1:-32}
+NUM_WORKERS_PER_PROCESS=${2:-0}
+CONFIG_PATH=${3:-"case_studies/summer_template"}
+
+for ((i=0; i<$NUM_PROCESSES; i++));
+do
+    bliss -cp $CONFIG_PATH 'mode=generate' 'generate.splits=[train]' "simulator.num_workers=$NUM_WORKERS_PER_PROCESS" "generate.train_file_prefix=dataset_p$i" &
+done
+wait

--- a/tests/testing_config.yaml
+++ b/tests/testing_config.yaml
@@ -6,7 +6,6 @@ defaults:
 
 simulator:
     valid_n_batches: 2
-    num_workers: 0
     prior:
         n_tiles_h: 8
         n_tiles_w: 8
@@ -17,8 +16,13 @@ simulator:
         _target_: bliss.simulator.background.ConstantBackground
         background: [865.0]
 
+cached_simulator:
+    train_n_batches: 2
+    val_split_file_idxs: [2, 3]
+    test_split_file_idxs: [4, 5]
+
 generate:
-    n_batches: 2
+    n_batches: 6
     batch_size: 32
     max_images_per_file: 50
     cached_data_path: null # use pytest tmpdir


### PR DESCRIPTION
Either 
```
{BLISS_HOME}/generate_data_in_parallel.sh 32 0 {CONFIG_PATH}
```
or 

```
bliss -cp {CONFIG_PATH} 'mode=generate' 'generate.n_processes=32' 'generate.n_workers_per_process=0'
```

Some stats:
32 processes * 6 batches * 64 images/batch = **12,288 images** | **32 processes** | **0 workers/process**
- bash: 12454.65s user 113.11s system 2074% cpu 10:05.89 total
- python multiprocessing: 10617.55s user 74.27s system 934% cpu 19:03.68 total

1 process * 192 batches * 64 images/batch = **12,288 images** | **1 process** | **32 workers/process**
- bash: 7936.11s user 33.56s system 114% cpu 1:55:54.86  total

Fixes #761.