### PR TITLE
Log generation parameters and allow loading cached dataset without all splits

### DIFF
--- a/bliss/generate.py
+++ b/bliss/generate.py
@@ -3,7 +3,7 @@ from typing import Dict, List, TypedDict
 
 import torch
 from hydra.utils import instantiate
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 from torch.utils.data import IterableDataset
 from tqdm import tqdm
 
@@ -40,6 +40,10 @@ def generate(cfg: DictConfig):
     if not os.path.exists(cached_data_path):
         os.makedirs(cached_data_path)
     print("Data will be saved to {}".format(cached_data_path))
+
+    # Save Hydra config (used to generate data) to cached_data_path
+    with open(f"{cfg.generate.cached_data_path}/hparams.yaml", "w", encoding="utf-8") as f:
+        OmegaConf.save(cfg, f)
 
     if "train" in cfg.generate.splits:
         # assume overwriting any existing cached image files

--- a/bliss/simulator/simulated_dataset.py
+++ b/bliss/simulator/simulated_dataset.py
@@ -148,7 +148,7 @@ class CachedSimulatedDataset(pl.LightningDataModule, Dataset):
             f"different generation `n_batches` and/or `batch_size`."
         )
         return DataLoader(
-            self.data, shuffle=True, batch_size=self.batch_size, num_workers=self.num_workers
+            self, shuffle=True, batch_size=self.batch_size, num_workers=self.num_workers
         )
 
     def val_dataloader(self):

--- a/bliss/simulator/simulated_dataset.py
+++ b/bliss/simulator/simulated_dataset.py
@@ -116,26 +116,18 @@ class CachedSimulatedDataset(pl.LightningDataModule, Dataset):
                 continue
             if filename.startswith("dataset") and filename.endswith(".pt"):
                 self.data += self.read_file(f"{self.cached_data_path}/{filename}")
-        assert self.data, "No cached data loaded; run `generate.py` first"
-        assert len(self.data) >= self.n_batches * self.batch_size, (
-            f"Insufficient cached data loaded; "
-            f"need at least {self.n_batches * self.batch_size} "
-            f"but only have {len(self.data)}. Re-run `generate.py` with "
-            f"different generation `n_batches` and/or `batch_size`."
-        )
 
         # fix validation set
-        assert os.path.exists(
-            f"{self.cached_data_path}/dataset_valid.pt"
-        ), "No cached validation data found; run `generate.py` first"
-        valid_batched_data = self.read_file(f"{self.cached_data_path}/dataset_valid.pt")
-        self.valid = itemize_data(valid_batched_data)
+        val_file = f"{self.cached_data_path}/dataset_valid.pt"
+        if os.path.exists(val_file):
+            valid_batched_data = self.read_file(val_file)
+            self.valid = itemize_data(valid_batched_data)
 
-        assert os.path.exists(
-            f"{self.cached_data_path}/dataset_test.pt"
-        ), "No cached test data found; run `generate.py` first"
-        test_batched_data = self.read_file(f"{self.cached_data_path}/dataset_test.pt")
-        self.test = itemize_data(test_batched_data)
+        # fix test set
+        test_file = f"{self.cached_data_path}/dataset_test.pt"
+        if os.path.exists(test_file):
+            test_batched_data = self.read_file(test_file)
+            self.test = itemize_data(test_batched_data)
 
     def read_file(self, filename: str) -> List[FileDatum]:
         with open(filename, "rb") as f:
@@ -148,12 +140,21 @@ class CachedSimulatedDataset(pl.LightningDataModule, Dataset):
         return self.data[idx]
 
     def train_dataloader(self):
+        assert self.data, "No cached data loaded; run `generate.py` first"
+        assert len(self.data) >= self.n_batches * self.batch_size, (
+            f"Insufficient cached data loaded; "
+            f"need at least {self.n_batches * self.batch_size} "
+            f"but only have {len(self.data)}. Re-run `generate.py` with "
+            f"different generation `n_batches` and/or `batch_size`."
+        )
         return DataLoader(
-            self, shuffle=True, batch_size=self.batch_size, num_workers=self.num_workers
+            self.data, shuffle=True, batch_size=self.batch_size, num_workers=self.num_workers
         )
 
     def val_dataloader(self):
+        assert self.valid, "No cached validation data found; run `generate.py` first"
         return DataLoader(self.valid, batch_size=self.batch_size, num_workers=self.num_workers)
 
     def test_dataloader(self):
+        assert self.test, "No cached test data found; run `generate.py` first"
         return DataLoader(self.test, batch_size=self.batch_size, num_workers=self.num_workers)

--- a/bliss/simulator/simulated_dataset.py
+++ b/bliss/simulator/simulated_dataset.py
@@ -140,7 +140,7 @@ class CachedSimulatedDataset(pl.LightningDataModule, Dataset):
         return self.data[idx]
 
     def train_dataloader(self):
-        assert self.data, "No cached data loaded; run `generate.py` first"
+        assert self.data, "No cached train data loaded; run `generate.py` first"
         assert len(self.data) >= self.n_batches * self.batch_size, (
             f"Insufficient cached data loaded; "
             f"need at least {self.n_batches * self.batch_size} "


### PR DESCRIPTION
1) Logs config used at generation time to generated data folder for reference
2) Move asserts checking that all splits are present out of CachedSimulatedDataset constructor and into individual dataloader functions. This allows for having separate datasets used for training/testing, e.g. generating training data with certain params and test data with other params.
```
# no errors
train_only_dataset = instantiate(cfg.cached_simulator, cached_data_path="path/to/train/data")
test_only_dataset = instantiate(cfg.cached_simulator, cached_data_path="path/to/test/data")

trainer.fit(encoder, datamodule=train_only_dataset)
trainer.test(encoder, datamodule=test_only_dataset)

# AssertionError: no cached data found
trainer.fit(encoder, datamodule=test_only_dataset)
trainer.test(encoder, datamodule=train_only_dataset)
```