### PR TITLE
Add early stopping

### DIFF
--- a/conf/base_config.yaml
+++ b/conf/base_config.yaml
@@ -131,6 +131,7 @@ training:
         check_val_every_n_epoch: 10
         log_every_n_steps: 10  # corresponds to n_batches
         max_epochs: ${training.n_epochs}
+        min_epochs: 1
         accelerator: "gpu"
         devices: 1
     testing:

--- a/conf/base_config.yaml
+++ b/conf/base_config.yaml
@@ -119,6 +119,8 @@ training:
     version: null
     n_epochs: 50
     save_top_k: 1
+    enable_early_stopping: true
+    patience: 3
     pretrained_weights: null
     trainer:
         _target_: pytorch_lightning.Trainer
@@ -129,7 +131,6 @@ training:
         check_val_every_n_epoch: 10
         log_every_n_steps: 10  # corresponds to n_batches
         max_epochs: ${training.n_epochs}
-        min_epochs: ${training.n_epochs}
         accelerator: "gpu"
         devices: 1
     testing:

--- a/tests/testing_config.yaml
+++ b/tests/testing_config.yaml
@@ -27,6 +27,7 @@ training:
     name: "pytest_encoder"
     version: "version0"
     n_epochs: 1
+    enable_early_stopping: false
     pretrained_weights: ${paths.pretrained_models}/sdss.pt
     seed: 42
     weight_save_path: null

--- a/tests/testing_config.yaml
+++ b/tests/testing_config.yaml
@@ -27,13 +27,13 @@ training:
     name: "pytest_encoder"
     version: "version0"
     n_epochs: 1
-    enable_early_stopping: false
+    enable_early_stopping: true
     pretrained_weights: ${paths.pretrained_models}/sdss.pt
     seed: 42
     weight_save_path: null
     trainer:
         logger: false
-        enable_checkpointing: false
+        enable_checkpointing: true
         profiler: null
         check_val_every_n_epoch: 1001
         log_every_n_steps: 10


### PR DESCRIPTION
Add option to stop training early if validation loss hasn't decreased for a set number of epochs. This is configurable using the `enable_early_stopping` and `patience` flags in `config.trainer`.

I removed the `min_epochs` flag from trainer because that overrides early stopping. I also suppressed a pylint warning for too-many-statements in `train` - we should maybe consider factoring some of the stuff that isn't directly related to training, like loading best weights, into a separate function. 