### PR TITLE
fixed tests on gpu

### DIFF
--- a/tests/test_sdss_reconstruct.py
+++ b/tests/test_sdss_reconstruct.py
@@ -10,14 +10,14 @@ class TestSdssReconstrust:
         est_tile = est_full.to_tile_params(cfg.encoder.tile_slen, cfg.simulator.prior.max_sources)
 
         decoder_obj = instantiate(cfg.simulator.decoder)
-        recon_img = decoder_obj.render_images(est_tile)[0, 0]
+        recon_img = decoder_obj.render_images(est_tile.to("cpu"))[0, 0]
 
         ptc = cfg.encoder.tile_slen * cfg.encoder.tiles_to_crop
         true_img_crop = true_img[0][ptc:-ptc, ptc:-ptc]
         true_bg_crop = true_bg[0][ptc:-ptc, ptc:-ptc]
         true_bright = true_img_crop - true_bg_crop
 
-        bright_pix_mask = torch.tensor(recon_img - 100) > 0
+        bright_pix_mask = (recon_img - 100) > 0
         res_bright = recon_img[bright_pix_mask] - torch.tensor(true_bright)[bright_pix_mask]
 
         recon_img += true_bg_crop

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -12,9 +12,14 @@ class TestSimulate:
 
         for i in range(4):
             sim_tile = torch.load(cfg.paths.data + "/test_image/sim_tile" + str(i) + ".pt")
-            sim_img = sim_dataset.simulate_image(sim_tile)
+            image, background = sim_dataset.simulate_image(sim_tile)
 
-            est_full = predict(cfg, sim_img[0], sim_img[1])
+            # move data to the device the encoder is on
+            sim_tile = sim_tile.to(cfg.predict.device)
+            image = image.to(cfg.predict.device)
+            background = background.to(cfg.predict.device)
+
+            est_full = predict(cfg, image, background)
             est_tile = est_full.to_tile_params(tile_slen, max_sources)
             ttc = cfg.encoder.tiles_to_crop
             sim_galaxy_bools = sim_tile["galaxy_bools"][:, ttc:-ttc, ttc:-ttc]


### PR DESCRIPTION
It looks like some data structures weren't moved over to whatever device the encoder is on. As a result, though `pytest` passes, `pytest --gpu` wasn't passing before this PR.