### PR TITLE
Add average_keep_distance metric for distance only on good matches

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -206,8 +206,10 @@ class TestMetrics:
 
     def test_bliss_photo_agree(self, brightest_catalogs):
         """Compares metrics for agreement between BLISS-inferred catalog and Photo catalog."""
-        results = BlissMetrics(slack=1.0)(brightest_catalogs["photo"], brightest_catalogs["bliss"])
+        slack = 1.0
+        results = BlissMetrics(slack)(brightest_catalogs["photo"], brightest_catalogs["bliss"])
         assert results["f1"] > 0.8
+        assert results["avg_keep_distance"] < slack
 
     def test_bliss_photo_agree_comp_decals(self, brightest_catalogs):
         """Compares metrics between BLISS and Photo catalog with DECaLS as GT."""


### PR DESCRIPTION
`metrics.avg_distance` is the average distance over all matched objects, not just over those we consider a "good" match (i.e. distance < slack). This can be useful in the case where there are no good matches at all, but also having a measure of how good the good matches are would be useful.

![image](https://github.com/prob-ml/bliss/assets/26699876/039ce01e-f816-444d-ac67-33475bec020f)
