### PR TITLE
Allow config overrides in parallel generate script

### DIFF
--- a/case_studies/diskrw_gsimages_721/config.yaml
+++ b/case_studies/diskrw_gsimages_721/config.yaml
@@ -10,6 +10,10 @@ paths:
     pretrained_models: ${paths.data}/pretrained_models
 
 simulator:
+    prior:
+        mean_sources: 0.2
+        n_tiles_h: 16
+        n_tiles_w: 16
     background:
         _target_: bliss.simulator.background.SimulatedSDSSBackground
         sdss_dir: ${paths.sdss}
@@ -19,13 +23,23 @@ simulator:
         bands: [2]
 
 cached_simulator:
-    n_train_batches: 192
-    val_split_file_idxs: [96, 97, 98]
-    test_split_file_idxs: [99, 100, 101]
+    # ~50GB, 16x16 sq. tiles, 0.2 mean sources
+    #  training set  : 112 files * 144 batches * 64 images/batch = 1,032,192 images (80%)
+    #  validation set: 14 files * 144 batches * 64 images/batch = 129,024 images (10%)
+    #  testing set   : 14 files * 144 batches * 64 images/batch = 129,024 images (10%)
+    n_train_batches: 10752
+    val_split_file_idxs: [113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126]
+    test_split_file_idxs: null # [127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140]
 
 generate:
-    n_batches: 6
-    max_images_per_file: 150
+    # 16x16: 576, 9216 (144 batches / file)
+    # 20x20: 384, 6144 (96 batches / file)
+    # 48x48: 64, 1024 (16 batches / file)
+    # 100x100: 16, 256 (4 batches / file)
+    n_batches: 1
+    batch_size: 64
+    max_images_per_file: 64
+    cached_data_path: /data/scratch/zhteoh/cached_dataset_${simulator.prior.mean_sources}_${simulator.prior.n_tiles_h}tiles_50GB
 
 training:
     name: "encoder"

--- a/scripts/generate_data_in_parallel.sh
+++ b/scripts/generate_data_in_parallel.sh
@@ -3,23 +3,12 @@
 # gracefully exit
 trap "cleanup" SIGINT SIGTERM EXIT
 
-# Usage: generate_data_in_parallel.sh <relative config_path> <num_files_per_process> <num_processes> <num_workers_per_process>
+# Usage: generate_data_in_parallel.sh <relative config_path> <num_files_per_process> [<config_overrides> <num_processes> <num_workers_per_process>]
 CONFIG_PATH=$1
 N_FILES_PER_PROCESS=$2
 CONFIG_OVERRIDES=${3:-""}
 NUM_PROCESSES=${4:-32}
 N_WORKERS_PER_PROCESS=${5:-0}
-
-# Gracefully exit when interrupted
-pids=()
-cleanup() {
-    echo "Ending background processes"
-    for pid in "${pids[@]}";
-    do
-        kill -15 $pid
-    done
-}
-trap cleanup SIGINT
 
 # Error if CONFIG_PATH, N_FILES_PER_PROCESS not specified
 if [ -z "$CONFIG_PATH" ] || [ -z "$N_FILES_PER_PROCESS" ]; then
@@ -40,9 +29,11 @@ for pid in "${pids[@]}"; do
     wait $pid
 done
 
+# Gracefully exit when interrupted
 cleanup() {
-    echo "Killing bliss data generation processes..."
-    for pid in "${pids[@]}"; do
-        kill $pid
+    echo "Ending background processes"
+    for pid in "${pids[@]}";
+    do
+        kill -15 $pid
     done
 }

--- a/scripts/generate_data_in_parallel.sh
+++ b/scripts/generate_data_in_parallel.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+# gracefully exit
+trap "cleanup" SIGINT SIGTERM EXIT
+
 # Usage: generate_data_in_parallel.sh <relative config_path> <num_files_per_process> <num_processes> <num_workers_per_process>
 CONFIG_PATH=$1
 N_FILES_PER_PROCESS=$2
-NUM_PROCESSES=${3:-32}
-N_WORKERS_PER_PROCESS=${4:-0}
+CONFIG_OVERRIDES=${3:-""}
+NUM_PROCESSES=${4:-32}
+N_WORKERS_PER_PROCESS=${5:-0}
 
 # Gracefully exit when interrupted
 pids=()
@@ -23,10 +27,22 @@ if [ -z "$CONFIG_PATH" ] || [ -z "$N_FILES_PER_PROCESS" ]; then
     exit 1
 fi
 
+pids=()
 for ((i=0; i<$NUM_PROCESSES; i++));
 do
     files_start_idx=$((i * N_FILES_PER_PROCESS))
-    bliss -cp $CONFIG_PATH 'mode=generate' "simulator.num_workers=$N_WORKERS_PER_PROCESS" "generate.files_start_idx=$files_start_idx" &
+    bliss -cp $CONFIG_PATH 'mode=generate' "simulator.num_workers=$N_WORKERS_PER_PROCESS" "generate.files_start_idx=$files_start_idx" $CONFIG_OVERRIDES &
     pids+=($!) # store PID in array
 done
-wait
+
+# wait for all bliss processes to finish
+for pid in "${pids[@]}"; do
+    wait $pid
+done
+
+cleanup() {
+    echo "Killing bliss data generation processes..."
+    for pid in "${pids[@]}"; do
+        kill $pid
+    done
+}


### PR DESCRIPTION
Allow overriding hydra config parameters in `scripts/generate_data_in_parallel.sh`, and also add graceful exit.