### PR TITLE
Metrics for galaxy parameters

### DIFF
--- a/bliss/encoder.py
+++ b/bliss/encoder.py
@@ -254,15 +254,10 @@ class Encoder(pl.LightningModule):
 
     def validation_step(self, batch, batch_idx):
         """Pytorch lightning method."""
-        self._generic_step(batch, "val", log_metrics=True, plot_images=True)
-        return batch  # do we really need to save all these batches?
-
-    def validation_epoch_end(self, outputs):
-        """Pytorch lightning method."""
-        batch: Dict[str, Tensor] = outputs[-1]
-        self._generic_step(batch, "val")
+        # only plot images on the first batch of epoch
+        plot_images = batch_idx == 0
+        self._generic_step(batch, "val", log_metrics=True, plot_images=plot_images)
 
     def test_step(self, batch, batch_idx):
         """Pytorch lightning method."""
         self._generic_step(batch, "test", log_metrics=True)
-        return batch  # do we really need to save all these batches?

--- a/bliss/simulator/decoder.py
+++ b/bliss/simulator/decoder.py
@@ -145,6 +145,23 @@ class ImageDecoder(nn.Module):
         return (term1 + term2 + term3) / (1 + b + p0)
 
     def render_galaxy(self, galaxy_params: Tensor, psf, bnd: int):
+        """Render a galaxy with given params and PSF.
+
+        Args:
+            galaxy_params (Tensor): Tensor containing the following parameters:
+                - total_flux: the total flux of the galaxy
+                - disk_frac: the fraction of flux attributed to the disk (rest goes to bulge)
+                - beta_radians: the angle of shear in radians
+                - disk_q: the minor-to-major axis ratio of the disk
+                - a_d: semi-major axis of disk
+                - bulge_q: minor-to-major axis ratio of the bulge
+                - a_b: semi-major axis of bulge
+            psf (List): a list of PSFs for each band
+            bnd (int): band
+
+        Returns:
+            GSObject: a galsim representation of the rendered galaxy convolved with the PSF
+        """
         galaxy_params = galaxy_params.cpu().detach()
         total_flux, disk_frac, beta_radians, disk_q, a_d, bulge_q, a_b = galaxy_params
         bulge_frac = 1 - disk_frac


### PR DESCRIPTION
Added metrics for point estimates of galaxy parameters to make it easier to interpret model performance. Namely, we compute the median absolute error for `{disk/bulge}_flux`, `{disk/bulge}_q`, `{disk/bulge}_hlr` (half-light radius), and `beta_radians` between the estimated and true catalogs. Note that these metrics are only computed when these parameters are available in the true catalog, i.e. from the simulated data. 

Other changes:

- documented the galsim parameters in `decoder.render_galaxy`
- refactored `metrics.update` into two main functions, `_update_detection_metrics` (which contains the old metrics) and `_update_classification_metrics` (which is new and only gets called when classification metrics can be computed)
- add test for classification metrics
- speed up validation by removing `validation_epoch_end` in encoder (no useful behavior) and only plot images on first batch in validation loop

![image](https://github.com/prob-ml/bliss/assets/26699876/181d6b32-56af-4e92-b387-57778318cd6b)
