### PR TITLE
Unstage docs/docsrc/bin before commit and push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,7 @@ jobs:
           poetry run make github
           popd
           git add --force ./docs
+          git restore --staged ./docs/docsrc/bin
 
       - name: Commit files
         run: |


### PR DESCRIPTION
Attempt to fix docs build error introduced by #786 - https://github.com/prob-ml/bliss/actions/runs/5250650821