### PR TITLE
Add codecov token to github workflows yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: unittests
           env_vars: OS,PYTHON


### PR DESCRIPTION
Following [this](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954), added codecov token to repo secrets and to CodeCov task yml, hopefully codecov doesn't fail as often anymore 