### PR TITLE
Test API train on 1 epoch

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6034,4 +6034,4 @@ tqdm = ">=4.64.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "9b3b8708de03e5bb5ab3f510a63b9fe48a1f62991a8d7aaa0549e2082683d73a"
+content-hash = "d5c00461fbbd69b31ec31abdd26a804ff0d7dd0214614dbfd9f43d78287fdb1b"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 
@@ -18,20 +18,15 @@ def bliss_client(cwd):
 @pytest.fixture(scope="class")
 def cached_data_path(bliss_client):
     bliss_client.cached_data_path = bliss_client.cwd + "/dataset"
-    bliss_client.generate(
-        n_batches=3,
-        batch_size=64,
-        max_images_per_file=128,
-        training={"trainer": {"accelerator": "cpu"}},
-    )
+    bliss_client.generate(n_batches=3, batch_size=8, max_images_per_file=16)
     return bliss_client.cached_data_path
 
 
 @pytest.fixture(scope="class")
 def pretrained_weights_filename(bliss_client):
-    assert os.path.exists(
+    assert Path(
         bliss_client.pretrained_weights_path
-    ), f"pretrained_weights_path {bliss_client.pretrained_weights_path} not found"
+    ).exists(), f"pretrained_weights_path {bliss_client.pretrained_weights_path} not found"
     filename = "sdss_pretrained_fixture.pt"
     bliss_client.load_pretrained_weights_for_survey(
         survey="sdss",
@@ -46,10 +41,10 @@ def weight_save_path(bliss_client, pretrained_weights_filename):
     bliss_client.train_on_cached_data(
         weight_save_path=weight_save_path,
         train_n_batches=2,
-        batch_size=64,
+        batch_size=8,
         val_split_file_idxs=[1],
         pretrained_weights_filename=pretrained_weights_filename,
-        training={"trainer": {"accelerator": "cpu"}},
+        training={"trainer": {"accelerator": "cpu", "check_val_every_n_epoch": 1}, "n_epochs": 1},
     )
     return weight_save_path
 
@@ -59,37 +54,29 @@ def weight_save_path(bliss_client, pretrained_weights_filename):
 )
 class TestApi:
     def test_generate(self, bliss_client):
-        bliss_client.generate(n_batches=3, batch_size=64, max_images_per_file=128)
         # alter default cached_data_path
         bliss_client.cached_data_path = bliss_client.cwd + "/dataset_ms0.02"
         bliss_client.generate(
             n_batches=3,
-            batch_size=64,
-            max_images_per_file=128,
+            batch_size=8,
+            max_images_per_file=16,
             simulator={"prior": {"mean_sources": 0.02}},  # optional
             generate={"file_prefix": "dataset"},  # optional
-            training={"trainer": {"accelerator": "cpu"}},
         )
         # check that cached datasets generated
-        assert os.path.exists(
-            bliss_client.cwd + "/dataset/dataset_0.pt"
-        ), "{CWD}/dataset/dataset_0.pt not found"
-        assert os.path.exists(
+        assert Path(
             bliss_client.cwd + "/dataset_ms0.02/dataset_0.pt"
-        ), "{CWD}/dataset_ms0.02/dataset_0.pt not found"
+        ).exists(), "{CWD}/dataset_ms0.02/dataset_0.pt not found"
 
     def test_get_dataset_file(self, bliss_client, cached_data_path):
         bliss_client.cached_data_path = cached_data_path
-        dataset_ms0p02_0 = bliss_client.get_dataset_file(filename="dataset_0.pt")
-        assert isinstance(dataset_ms0p02_0, list), "dataset_ms0p02_0 must be a list"
-        bliss_client.cached_data_path = bliss_client.cwd + "/dataset"
         dataset0 = bliss_client.get_dataset_file(filename="dataset_0.pt")
         assert isinstance(dataset0, list), "dataset0 must be a list"
 
     def test_load_pretrained_weights(self, bliss_client):
-        assert os.path.exists(
+        assert Path(
             bliss_client.pretrained_weights_path
-        ), f"pretrained_weights_path {bliss_client.pretrained_weights_path} not found"
+        ).exists(), f"pretrained_weights_path {bliss_client.pretrained_weights_path} not found"
         bliss_client.load_pretrained_weights_for_survey(
             survey="sdss", filename="sdss_pretrained.pt"
         )
@@ -98,10 +85,13 @@ class TestApi:
         bliss_client.train_on_cached_data(
             weight_save_path="tutorial_encoder/0.pt",
             train_n_batches=2,
-            batch_size=64,
+            batch_size=8,
             val_split_file_idxs=[1],
             pretrained_weights_filename=pretrained_weights_filename,
-            training={"trainer": {"accelerator": "cpu"}},
+            training={
+                "trainer": {"accelerator": "cpu", "check_val_every_n_epoch": 1},
+                "n_epochs": 1,
+            },
         )
 
     def test_predict_sdss_default_rcf(self, bliss_client, weight_save_path):
@@ -118,5 +108,4 @@ class TestApi:
             data_path="data/sdss",
             weight_save_path=weight_save_path,
             predict={"dataset": {"run": 1011, "camcol": 3, "fields": [44]}, "device": "cpu"},
-            training={"trainer": {"accelerator": "cpu"}},
         )


### PR DESCRIPTION
Make tests run faster. Part of the issue is because test_api now uses base_config and not testing_config, as the "base config". Ideally we would want to be able to use testing_config as the base config to bliss.api.BlissClient.