### PR TITLE
Filter tile catalog by flux and restrict tile catalog to brightest source per tile

### DIFF
--- a/bliss/catalog.py
+++ b/bliss/catalog.py
@@ -199,6 +199,68 @@ class TileCatalog(UserDict):
         idx_to_gather = repeat(indices, "... -> ... k", k=param.size(-1))
         return torch.gather(param, dim=1, index=idx_to_gather)
 
+    def _get_fluxes_of_on_sources(self):
+        """Gets fluxes of "on" sources based on whether the source is a star or galaxy.
+
+        Returns:
+            Tensor: a tensor of fluxes of size (b x nth x ntw x max_sources x 1)
+        """
+        fluxes = torch.where(
+            self["galaxy_bools"], self["galaxy_params"][..., 0, None], self["star_fluxes"]
+        )
+        return torch.where(self.is_on_array[..., None], fluxes, torch.zeros_like(fluxes))
+
+    def get_brightest_source_per_tile(self):
+        """Restrict TileCatalog to only the brightest 'on' source per tile.
+
+        Returns:
+            TileCatalog: a new catalog with only one source per tile
+        """
+        if self.max_sources == 1:
+            return self
+
+        # sort by fluxes of "on" sources to get brightest source per tile
+        on_fluxes = self._get_fluxes_of_on_sources()
+        top_idx = on_fluxes.argsort(dim=3, descending=True)[
+            :, :, :, 0:1, 0
+        ]  # 0:1 keeps dims right for slicing
+
+        d = {}
+        for key, val in self.to_dict().items():
+            if key == "n_sources":
+                d[key] = self.n_sources.bool().int()  # send all positive values to 1, 0 to 0
+            else:
+                param_dim = val.size(-1)
+                idx_to_gather = repeat(top_idx, "... -> ... k", k=param_dim)
+                d[key] = torch.take_along_dim(val, idx_to_gather, dim=3)
+
+        return TileCatalog(self.tile_slen, d)
+
+    def filter_tile_catalog_by_flux(self, min_flux=622, max_flux=1e6):
+        """Restricts TileCatalog to sources that have a flux between min_flux and max_flux.
+
+        Args:
+            min_flux (float): Minimum flux value to keep. Defaults to 622.
+            max_flux (float): Maximum flux value to keep. Defaults to 1e6.
+
+        Returns:
+            TileCatalog: a new catalog with only sources within the flux range. Note that the size
+                of the tensors stays the same, but params at sources outside the range are set to 0.
+        """
+
+        # get fluxes of "on" sources to mask by
+        on_fluxes = self._get_fluxes_of_on_sources()
+        flux_mask = (on_fluxes > min_flux) & (on_fluxes < max_flux)
+
+        d = {}
+        for key, val in self.to_dict().items():
+            if key == "n_sources":
+                d[key] = flux_mask.sum(dim=3).squeeze()  # number of sources within range in tile
+            else:
+                d[key] = torch.where(flux_mask, val, torch.zeros_like(val))
+
+        return TileCatalog(self.tile_slen, d)
+
 
 class FullCatalog(UserDict):
     allowed_params = TileCatalog.allowed_params

--- a/bliss/catalog.py
+++ b/bliss/catalog.py
@@ -236,7 +236,7 @@ class TileCatalog(UserDict):
 
         return TileCatalog(self.tile_slen, d)
 
-    def filter_tile_catalog_by_flux(self, min_flux=622, max_flux=1e6):
+    def filter_tile_catalog_by_flux(self, min_flux=0, max_flux=torch.inf):
         """Restricts TileCatalog to sources that have a flux between min_flux and max_flux.
 
         Args:

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -25,6 +25,24 @@ def multi_source_tilecat():
     return TileCatalog(4, d)
 
 
+def test_unallowed_param():
+    d_tile = {
+        "n_sources": torch.zeros((1, 2, 2)),
+        "locs": torch.zeros((1, 2, 2, 1, 2)),
+        "unallowed": torch.zeros((1, 2, 2, 1, 2)),
+    }
+    with pytest.raises(ValueError):
+        TileCatalog(4, d_tile)
+
+    d_full = {
+        "n_sources": torch.tensor([1]),
+        "plocs": torch.tensor([5, 5]).reshape(1, 1, 2),
+        "unallowed": torch.zeros(1, 1, 1),
+    }
+    with pytest.raises(ValueError):
+        FullCatalog(10, 10, d_full)
+
+
 def test_multiple_sources_one_tile():
     d = {
         "n_sources": torch.tensor([2]),
@@ -83,6 +101,9 @@ def test_restrict_tile_cat_to_brightest(multi_source_tilecat):
     assert cat["galaxy_params"][0, 1, 1, 0, 0] == 600
     assert cat.n_sources.max() == 1
 
+    # do it again to make sure nothing changes
+    assert cat.get_brightest_source_per_tile().max_sources == 1
+
 
 def test_filter_tile_cat_by_flux(multi_source_tilecat):
     cat = multi_source_tilecat.filter_tile_catalog_by_flux(300, 2000)
@@ -91,3 +112,19 @@ def test_filter_tile_cat_by_flux(multi_source_tilecat):
     assert torch.equal(cat["galaxy_params"][0, 0, 1, :, 0], torch.tensor([0, 0]))
     assert torch.equal(cat["galaxy_params"][0, 1, 0, :, 0], torch.tensor([0, 0]))
     assert torch.equal(cat["galaxy_params"][0, 1, 1, :, 0], torch.tensor([0, 600]))
+
+
+def test_bin_full_cat_by_flux():
+    d = {
+        "n_sources": torch.tensor([3]),
+        "plocs": torch.tensor([[10, 10], [20, 20], [30, 30]]).reshape(1, 3, 2),
+        "galaxy_bools": torch.tensor([1, 1, 0]).reshape(1, 3, 1),
+        "mags": torch.tensor([20, 23, 22]).reshape(1, 3, 1),
+    }
+    binned_cat = FullCatalog(40, 40, d).apply_param_bin("mags", 21, 24)
+    new_plocs = binned_cat.plocs[:, 0 : binned_cat.n_sources]
+    new_mags = binned_cat.plocs[:, 0 : binned_cat.n_sources]
+
+    assert new_plocs.shape == (1, 2, 2)
+    assert new_mags.min() < 24
+    assert new_mags.max() > 21

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -123,8 +123,8 @@ def test_bin_full_cat_by_flux():
     }
     binned_cat = FullCatalog(40, 40, d).apply_param_bin("mags", 21, 24)
     new_plocs = binned_cat.plocs[:, 0 : binned_cat.n_sources]
-    new_mags = binned_cat.plocs[:, 0 : binned_cat.n_sources]
+    new_mags = binned_cat["mags"][:, 0 : binned_cat.n_sources]
 
     assert new_plocs.shape == (1, 2, 2)
-    assert new_mags.min() < 24
-    assert new_mags.max() > 21
+    assert new_mags.max() < 24
+    assert new_mags.min() > 21


### PR DESCRIPTION
Added auxiliary functions to `TileCatalog` to
1) Restrict the catalog to the brightest source per tile (for when `max_sources > 1`), and
2) Filter the tile catalog by a given flux range.

`get_brightest_source_per_tile` returns a new `TileCatalog` where only the brightest "on" source per tile is kept. Effectively, this means that there are two conditions to fulfill: the source must have been "on" in the original catalog, and it must be brighter than the other sources (if any) in that tile. The tensors change in size from (b x nth x ntw x **max_sources** x k) to (b x nth x ntw x **1** x k), where b = batch size, nth x ntw is the dimension of an image in tiles, max_sources is the old maximum sources per tile, and k is the dimension of each parameter (e.g. 2 for locs).

`filter_tile_catalog_by_flux` takes a minimum and maximum flux value and returns a new `TileCatalog` where all "on" sources are within that range. Instead of constructing new tensors, this function just masks out the sources that aren't in the range by setting all parameters for that source to 0.

In the image below, the orange sources are the ones remaining after taking the brightest source per tile and then filtering with flux between 10,000 and 500,000. Yellow are sources dropped by the flux filtering, and red are ones dropped by restricting the sources per tile.
![image](https://github.com/prob-ml/bliss/assets/26699876/1014b740-a004-43dc-ae5a-f4c9bb43f4e0)