### PR TITLE
Rewrite API tests to mock downloads, simplify test behavior

### DIFF
--- a/tests/mock_tests.py
+++ b/tests/mock_tests.py
@@ -1,0 +1,26 @@
+import base64
+
+
+class MockGetResponse:
+    def __init__(self):
+        self.content = base64.b64encode(b"test\n :\n 1")
+
+    def json(self):
+        return {"sha": "sha", "content": self.content, "encoding": "base64"}
+
+
+class MockPostResponse:
+    def json(self):
+        return {"objects": [{"actions": {"download": {"href": "test"}}}]}
+
+
+def mock_get(*args, **kwargs):
+    return MockGetResponse()
+
+
+def mock_post(*args, **kwargs):
+    return MockPostResponse()
+
+
+def mock_train(*args, **kwargs):
+    pass

--- a/tests/testing_config.yaml
+++ b/tests/testing_config.yaml
@@ -52,6 +52,8 @@ training:
         log_every_n_steps: 1
         accelerator: "cpu"
         devices: 1
+    testing:
+        file: True
 
 predict:
     decals_frame: ${paths.decals}/tractor-3366m010.fits


### PR DESCRIPTION
This PR simplifies the behavior in `test_api` to not require downloading any files from a remote server. Instead, we mock `requests.get` and `requests.post` to mimic the expected behavior, allowing us to still test functions like `download_git_lfs_file` without needing to actually download anything.

In the new `test_load_pretrained_weights` and `test_load_survey`, we don't actually need the data for anything, so we can just check that the mocked data was saved to the right filenames. In `test_predict_sdss_default_rcf` we do actually need the data to make predictions, so we just update the paths to use the `$BLISS_HOME/data` paths instead of the temporary directory.
