### PR TITLE
Removing band logic in PhotoFullCatalog + Circular instantiation of SDSS object, Updating metrics tests 

### DIFF
--- a/bliss/conf/base_config.yaml
+++ b/bliss/conf/base_config.yaml
@@ -165,7 +165,6 @@ predict:
         run: 94
         camcol: 1
         fields: [12]
-        bands: ${encoder.bands}
         predict_device: ${predict.device}
         predict_crop: ${predict.crop}
     photo_catalog:
@@ -174,7 +173,7 @@ predict:
         run: ${predict.dataset.run}
         camcol: ${predict.dataset.camcol}
         fields: ${predict.dataset.fields}
-        bands: ${predict.dataset.bands}
+        bands: ${encoder.bands}
     trainer: ${training.trainer}
     encoder: ${encoder}
     weight_save_path: ${paths.pretrained_models}/zscore_five_band.pt

--- a/bliss/encoder.py
+++ b/bliss/encoder.py
@@ -139,6 +139,8 @@ class Encoder(pl.LightningModule):
                 input transformations to use
         """
         # If using five-band cached simulator, only select bands encoder is expecting
+        if batch["images"].shape[1] < self.n_bands:
+            warnings.warn("Encoder is expecting additional bands from input.")
         imgs = batch["images"][:, self.bands]
         bgs = batch["background"][:, self.bands]
         inputs = [imgs, bgs]

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -55,15 +55,17 @@ def align(img, sdss):
 
 
 def predict_sdss(cfg):
+    sdss = instantiate(cfg.predict.dataset)
+
     sdss_frame = PhotoFullCatalog.from_file(
         cfg.paths.sdss,
         run=cfg.predict.dataset.run,
         camcol=cfg.predict.dataset.camcol,
         field=cfg.predict.dataset.fields[0],
-        band=cfg.predict.photo_catalog.bands[2],
+        sdss_obj=sdss,
     )
+
     sdss_plocs = sdss_frame.plocs[0]
-    sdss = instantiate(cfg.predict.dataset)
     img = sdss[0]["image"]
     bg = sdss[0]["background"]
     img = align(img, sdss)

--- a/bliss/simulator/background.py
+++ b/bliss/simulator/background.py
@@ -35,8 +35,8 @@ class SimulatedSDSSBackground(nn.Module):
         backgrounds = []
         for param_obj in field_list:
             params: Dict = OmegaConf.to_container(param_obj)
-            sdss = SloanDigitalSkySurvey(sdss_dir=sdss_dir, bands=bands, **params)
-            backgrounds.extend([field["background"] for field in sdss])
+            sdss = SloanDigitalSkySurvey(sdss_dir=sdss_dir, **params)
+            backgrounds.extend([field["background"][bands] for field in sdss])
 
         background = torch.from_numpy(np.stack(backgrounds, axis=0))
 

--- a/tests/test_sdss.py
+++ b/tests/test_sdss.py
@@ -12,7 +12,6 @@ class TestSDSS:
             run=3900,
             camcol=6,
             fields=[269],
-            bands=range(5),
         )
         an_obj = sdss_obj[0]
         for k in ("image", "background", "gain", "nelec_per_nmgy_list", "calibration"):
@@ -27,6 +26,5 @@ class TestSDSS:
             run=3900,
             camcol=6,
             fields=[269, 745],
-            bands=range(5),
         )
         assert (len(sdss_obj9)) == 2


### PR DESCRIPTION
This PR resolves #842 and removes the need to only compute metrics on the brightest light sources via `brightest_fixtures`. This was previously necessary with the single-band BLISS model but is no longer needed to attain better detection metrics when using DECaLS as ground truth. 