### PR TITLE
Generalize Bliss E2E flow to different surveys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ temp/
 trials_result/
 .vscode/
 .env
+.venv
 jupyter/
 output/
 hydra_temp/

--- a/bliss/api.py
+++ b/bliss/api.py
@@ -14,7 +14,7 @@ from torch import Tensor
 from bliss.catalog import FullCatalog
 from bliss.conf.igs import base_config
 from bliss.generate import generate as _generate
-from bliss.predict import predict_sdss as _predict_sdss
+from bliss.predict import predict as _predict
 from bliss.surveys.sdss import SDSSDownloader, SloanDigitalSkySurvey
 from bliss.train import train as _train
 from bliss.utils.download_utils import download_git_lfs_file
@@ -158,12 +158,10 @@ class BlissClient:
         cfg.predict.weight_save_path = cfg.paths.output + f"/{weight_save_path}"
         for k, v in kwargs.items():
             OmegaConf.update(cfg, k, v)
-
-        est_cat, _, _, _, pred = _predict_sdss(cfg)
-        full_cat = est_cat.to_full_params()
-        est_cat_table = fullcat_to_astropy_table(full_cat)
+        est_cat, _, _, _, pred = _predict(cfg)
+        est_cat_table = fullcat_to_astropy_table(est_cat)
         pred_table = pred_to_astropy_table(pred)
-        return full_cat, est_cat_table, pred_table
+        return est_cat, est_cat_table, pred_table
 
     def plot_predictions_in_notebook(self):
         """Plot predictions in notebook."""

--- a/bliss/conf/base_config.yaml
+++ b/bliss/conf/base_config.yaml
@@ -150,7 +150,7 @@ surveys:
         psf_config:
             pixel_scale: 0.396
             psf_slen: 25
-        prior_flux_ref_band: 2 # SDSS r-band
+        reference_band: 2 # SDSS r-band
         prior_config:
             max_bands: 5
             n_tiles_h: 20
@@ -171,13 +171,10 @@ surveys:
             galaxy_a_loc: 0.8371888967872619
             galaxy_a_scale: 4.432725319432478
             galaxy_a_bd_ratio: 2.0
-        predict_device: ${predict.device}
-        predict_crop: ${predict.crop}
     decals:
         _target_: bliss.surveys.decals.DarkEnergyCameraLegacySurvey
         decals_dir: ${paths.decals}
         ra: 336.635 # in degrees
         dec: -0.96 # in degrees
         bands: ${encoder.bands}
-        predict_device: ${predict.device}
-        predict_crop: ${predict.crop}
+        reference_band: 1 # DECaLS r-band, DECaLS-indexed (via header)

--- a/bliss/conf/base_config.yaml
+++ b/bliss/conf/base_config.yaml
@@ -22,46 +22,11 @@ paths:
 
 simulator:
     _target_: bliss.simulator.simulated_dataset.SimulatedDataset
+    survey: ${surveys.sdss}
     n_batches: 128
+    num_workers: 32
     valid_n_batches: 10  # 256
     fix_validation_set: true
-    num_workers: 32
-    sdss_fields:  # Used in simulator for sampling backgrounds and PSFs for decoder
-        dir: ${paths.sdss}
-        bands: [0, 1, 2, 3, 4]
-        field_list:  # list of dictionaries, each with run, camcol, and list of fields
-          - run: 94
-            camcol: 1
-            fields: [12]
-    prior:
-        _target_: bliss.simulator.prior.ImagePrior
-        sdss_fields: ${simulator.sdss_fields}
-        n_tiles_h: 20
-        n_tiles_w: 20
-        tile_slen: 4
-        batch_size: 64
-        max_sources: 1
-        mean_sources: 0.2
-        min_sources: 0
-        prob_galaxy: 0.72
-        star_flux_min: 622
-        star_flux_max: 1e6
-        star_flux_alpha: 0.43
-        galaxy_flux_min: 622.0
-        galaxy_flux_max: 1e6
-        galaxy_alpha: 0.47
-        galaxy_a_concentration: 0.39330758068481686
-        galaxy_a_loc: 0.8371888967872619
-        galaxy_a_scale: 4.432725319432478
-        galaxy_a_bd_ratio: 2.0
-    decoder:
-        _target_: bliss.simulator.decoder.ImageDecoder
-        pixel_scale: 0.396
-        psf_slen: 25
-        sdss_fields: ${simulator.sdss_fields}
-    background:
-        _target_: bliss.simulator.background.SimulatedSDSSBackground
-        sdss_fields: ${simulator.sdss_fields}
 
 cached_simulator:
     _target_: bliss.simulator.simulated_dataset.CachedSimulatedDataset
@@ -77,7 +42,7 @@ cached_simulator:
 encoder:
     _target_: bliss.encoder.Encoder
     bands: [0, 1, 2, 3, 4]
-    tile_slen: ${simulator.prior.tile_slen}
+    tile_slen: ${simulator.survey.prior_config.tile_slen}
     tiles_to_crop: 1
     slack: 1.0
     min_flux_threshold: 0  # default 0 to take all sources
@@ -126,7 +91,7 @@ encoder:
 generate:
     n_workers_per_process: 0
     n_batches: ${simulator.n_batches}
-    batch_size: ${simulator.prior.batch_size}
+    batch_size: ${simulator.survey.prior_config.batch_size}
     max_images_per_file: 4096
     cached_data_path: ${paths.data}/cached_dataset
     file_prefix: dataset
@@ -157,7 +122,7 @@ training:
     use_cached_simulator: false
 
 predict:
-    dataset: ${datasets.sdss}
+    dataset: ${surveys.sdss}
     trainer: ${training.trainer}
     encoder: ${encoder}
     weight_save_path: ${paths.pretrained_models}/zscore_five_band.pt
@@ -174,13 +139,38 @@ predict:
         out_file_name: ${paths.output}/predict.html
     is_simulated: false
 
-datasets:
+surveys:
     sdss:
         _target_: bliss.surveys.sdss.SloanDigitalSkySurvey
         sdss_dir: ${paths.sdss}
-        run: 94
-        camcol: 1
-        fields: [12]
+        sdss_fields:
+            - run: 94
+              camcol: 1
+              fields: [12]
+        psf_config:
+            pixel_scale: 0.396
+            psf_slen: 25
+        prior_flux_ref_band: 2 # SDSS r-band
+        prior_config:
+            max_bands: 5
+            n_tiles_h: 20
+            n_tiles_w: 20
+            tile_slen: 4
+            batch_size: 64
+            max_sources: 1
+            mean_sources: 0.2
+            min_sources: 0
+            prob_galaxy: 0.72
+            star_flux_min: 622
+            star_flux_max: 1e6
+            star_flux_alpha: 0.43
+            galaxy_flux_min: 622.0
+            galaxy_flux_max: 1e6
+            galaxy_alpha: 0.47
+            galaxy_a_concentration: 0.39330758068481686
+            galaxy_a_loc: 0.8371888967872619
+            galaxy_a_scale: 4.432725319432478
+            galaxy_a_bd_ratio: 2.0
         predict_device: ${predict.device}
         predict_crop: ${predict.crop}
     decals:

--- a/bliss/generate.py
+++ b/bliss/generate.py
@@ -42,7 +42,9 @@ def generate(cfg: DictConfig):
     # use SimulatedDataset to generate data in minibatches iteratively,
     # then concatenate before caching to disk via pickle
     simulator = instantiate(
-        cfg.simulator, num_workers=n_workers_per_process, prior={"batch_size": bs}
+        cfg.simulator,
+        num_workers=n_workers_per_process,
+        survey={"prior_config": {"batch_size": bs}},
     )
     simulated_dataset = simulator.train_dataloader().dataset
 

--- a/bliss/generate.py
+++ b/bliss/generate.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from typing import Dict, List, TypedDict
 
 import torch
@@ -49,8 +49,8 @@ def generate(cfg: DictConfig):
     simulated_dataset = simulator.train_dataloader().dataset
 
     # create cached_data_path if it doesn't exist
-    if not os.path.exists(cached_data_path):
-        os.makedirs(cached_data_path)
+    if not Path(cached_data_path).exists():
+        Path(cached_data_path).mkdir(parents=True)
     print("Data will be saved to {}".format(cached_data_path))  # noqa: WPS421
 
     # Save Hydra config (used to generate data) to cached_data_path

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -1,14 +1,19 @@
 from pathlib import Path
+from typing import Any, Dict, Tuple
 
 import numpy as np
 import torch
+from astropy.wcs import WCS
 from bokeh.models import TabPanel, Tabs
 from bokeh.plotting import figure, output_file, show
 from hydra.utils import instantiate
 from reproject import reproject_interp
+from torch import Tensor
 
-from bliss.surveys.decals import DarkEnergyCameraLegacySurvey, DecalsFullCatalog
-from bliss.surveys.sdss import PhotoFullCatalog, SloanDigitalSkySurvey
+from bliss.catalog import FullCatalog
+from bliss.surveys.decals import DarkEnergyCameraLegacySurvey as DECaLS
+from bliss.surveys.decals import DecalsDownloader, DecalsFullCatalog
+from bliss.surveys.sdss import SloanDigitalSkySurvey as SDSS
 
 
 def prepare_image(x, device):
@@ -17,12 +22,32 @@ def prepare_image(x, device):
     # image dimensions must be a multiple of 16
     height = x.size(2) - (x.size(2) % 16)
     width = x.size(3) - (x.size(3) % 16)
-    x = x[:, :, :height, :width]
-
-    return x  # noqa: WPS331
+    return x[:, :, :height, :width]
 
 
-def align(img, ref_wcs):
+def crop_image(image, background, crop_params):
+    """Crop the image (and background) to a subregion for prediction."""
+    if not crop_params.do_crop:
+        return image, background
+
+    idx0 = crop_params.left_upper_corner[0]
+    idx1 = crop_params.left_upper_corner[1]
+    width = crop_params.width
+    height = crop_params.height
+    if ((idx0 + height) <= image.shape[2]) and ((idx1 + width) <= image.shape[3]):
+        image = image[:, :, idx0 : idx0 + height, idx1 : idx1 + width]
+        background = background[:, :, idx0 : idx0 + height, idx1 : idx1 + width]
+    return image, background
+
+
+def prepare_batch(images, backgrounds):
+    batch = {"images": images, "background": backgrounds}
+    batch["images"] = batch["images"].squeeze(0)
+    batch["background"] = batch["background"].squeeze(0)
+    return batch
+
+
+def align(img, ref_wcs, ref_band):
     """Reproject images based on some reference WCS for pixel alignment."""
     reproj_d = {}
     footprint_d = {}
@@ -33,7 +58,7 @@ def align(img, ref_wcs):
     for bnd in range(img.shape[0]):
         inputs = (img[bnd], ref_wcs[bnd])
         reproj, footprint = reproject_interp(  # noqa: WPS317
-            inputs, ref_wcs[2], order="bicubic", shape_out=img[bnd].shape
+            inputs, ref_wcs[ref_band], order="bicubic", shape_out=img[bnd].shape
         )
         reproj_d[bnd] = reproj
         footprint_d[bnd] = footprint
@@ -57,51 +82,6 @@ def align(img, ref_wcs):
     return reproj_out
 
 
-def predict_sdss(cfg):
-    sdss = instantiate(cfg.predict.dataset)
-    assert isinstance(
-        sdss, SloanDigitalSkySurvey
-    ), "sdss expected to be a SloanDigitalSkySurvey, but got {}".format(type(sdss))
-
-    sdss_fields = cfg.predict.dataset.sdss_fields
-    assert (
-        len(sdss_fields) == 1 and len(sdss_fields[0].fields) == 1
-    ), "Only one (run, camcol, field) is supported for prediction"
-    sdss_fields = cfg.predict.dataset.sdss_fields
-    run, camcol, fields = sdss_fields[0].values()
-    sdss_cat = PhotoFullCatalog.from_file(
-        cfg.paths.sdss,
-        run=run,
-        camcol=camcol,
-        field=fields[0],
-        sdss_obj=sdss,
-    )
-
-    sdss_plocs = sdss_cat.plocs[0]
-    sdss[0]["image"] = align(sdss[0]["image"], ref_wcs=sdss[0]["wcs"])
-    sdss[0]["background"] = align(sdss[0]["background"], ref_wcs=sdss[0]["wcs"])
-
-    # mean of the nelec_per_mgy per band
-    nelec_per_nmgy_per_band = np.mean(sdss[0]["nelec_per_nmgy_list"], axis=1)
-
-    encoder = instantiate(cfg.encoder).to(cfg.predict.device)
-    enc_state_dict = torch.load(cfg.predict.weight_save_path)
-    encoder.load_state_dict(enc_state_dict)
-    encoder.eval()
-    trainer = instantiate(cfg.predict.trainer)
-    est_cat, images, background, pred = trainer.predict(encoder, datamodule=sdss)[0].values()
-
-    est_cat = nelec_to_nmgy_for_catalog(est_cat, nelec_per_nmgy_per_band)
-    est_full = est_cat.to_full_params()
-    if cfg.predict.plot.show_plot and (sdss_plocs is not None):
-        ptc = cfg.encoder.tiles_to_crop * cfg.encoder.tile_slen
-        cropped_image = images[0, 0, ptc:-ptc, ptc:-ptc]
-        cropped_background = background[0, 0, ptc:-ptc, ptc:-ptc]
-        plot_predict(cfg, cropped_image, cropped_background, sdss_plocs, est_full)
-
-    return est_full, images[0], background[0], sdss_plocs, pred
-
-
 def nelec_to_nmgy_for_catalog(est_cat, nelec_per_nmgy_per_band):
     fluxes_suffix = "_fluxes"
     # reshape nelec_per_nmgy_per_band to (1, {n_bands}) to broadcast
@@ -118,55 +98,59 @@ def nelec_to_nmgy_for_catalog(est_cat, nelec_per_nmgy_per_band):
     return est_cat
 
 
-def decals_plocs_from_sdss(cfg):
-    """Use wcs to match sdss image with corresponding DECaLS catalog for futher plotting."""
-    sdss = instantiate(cfg.predict.dataset)
-    idx0 = cfg.predict.crop.left_upper_corner[0]
-    idx1 = cfg.predict.crop.left_upper_corner[1]
-    width = cfg.predict.crop.width
-    height = cfg.predict.crop.height
-    wcs = sdss[0]["wcs"][0]
-    ra_lim, dec_lim = wcs.all_pix2world((idx1, idx1 + width), (idx0, idx0 + height), 0)
+def predict(cfg) -> Tuple[FullCatalog, Tensor, Tensor, Any, Dict[str, Tensor]]:
+    survey = instantiate(cfg.predict.dataset)
+    assert (
+        len(survey) == 1
+    ), "Prediction only supported for one image_id (e.g., (run, camcol, field))"
+    survey_obj = survey[0]
+    survey_obj["image"] = align(
+        survey_obj["image"], ref_wcs=survey_obj["wcs"], ref_band=cfg.predict.dataset.reference_band
+    )
+    survey_obj["background"] = align(
+        survey_obj["background"],
+        ref_wcs=survey_obj["wcs"],
+        ref_band=cfg.predict.dataset.reference_band,
+    )
 
-    # TODO: 3366m010 is hardcoded brick now. Map SDSS RCF -> DECaLS brick.
-    decals_path = cfg.paths.decals + "/tractor-3366m010.fits"
-    return DecalsFullCatalog.from_file(decals_path, ra_lim, dec_lim).plocs
-
-
-def decals_plocs_from_decals(decals, cfg):
-    idx0 = cfg.predict.crop.left_upper_corner[0]
-    idx1 = cfg.predict.crop.left_upper_corner[1]
-    width = cfg.predict.crop.width
-    height = cfg.predict.crop.height
-    wcs = decals[0]["wcs"][
-        cfg.predict.dataset.bands[0]
-    ]  # TODO: somehow use all bands, not just one
-    ra_lim, dec_lim = wcs.all_pix2world((idx1, idx1 + width), (idx0, idx0 + height), 0)
-
-    tractor_filename = cfg.paths.decals + f"/tractor-{decals.brickname}.fits"
-    return DecalsFullCatalog.from_file(tractor_filename, ra_lim, dec_lim).plocs
-
-
-def predict_decals(cfg):
-    decals = instantiate(cfg.predict.dataset)
-    assert isinstance(
-        decals, DarkEnergyCameraLegacySurvey
-    ), "decals expected to be a DarkEnergyCameraLegacySurvey, but got {}".format(type(decals))
-    decals_plocs = decals_plocs_from_decals(decals, cfg)
+    cat_path = survey.downloader.download_catalog()
+    plocs = survey.catalog_cls.from_file(
+        cat_path=cat_path,
+        wcs=survey_obj["wcs"][cfg.predict.dataset.reference_band],
+        height=survey_obj["image"].shape[1],
+        width=survey_obj["image"].shape[2],
+    ).plocs[0]
 
     encoder = instantiate(cfg.encoder).to(cfg.predict.device)
     enc_state_dict = torch.load(cfg.predict.weight_save_path)
     encoder.load_state_dict(enc_state_dict)
     encoder.eval()
     trainer = instantiate(cfg.predict.trainer)
-    est_cat, images, background, pred = trainer.predict(encoder, datamodule=decals)[0].values()
-    if cfg.predict.plot.show_plot and (decals_plocs is not None):
+    images = prepare_image(survey.predict_batch["images"], cfg.predict.device)
+    backgrounds = prepare_image(survey.predict_batch["background"], cfg.predict.device)
+    images, backgrounds = crop_image(images, backgrounds, cfg.predict.crop)
+    survey.predict_batch = prepare_batch(images, backgrounds)
+    est_cat, images, background, pred = trainer.predict(encoder, datamodule=survey)[0].values()
+
+    # mean of the nelec_per_mgy per band
+    nelec_per_nmgy_per_band = np.mean(survey_obj["nelec_per_nmgy_list"], axis=1)
+    est_cat = nelec_to_nmgy_for_catalog(est_cat, nelec_per_nmgy_per_band)
+
+    est_full = est_cat.to_full_params()
+    if cfg.predict.plot.show_plot and (plocs is not None):
         ptc = cfg.encoder.tiles_to_crop * cfg.encoder.tile_slen
         cropped_image = images[0, 0, ptc:-ptc, ptc:-ptc]
         cropped_background = background[0, 0, ptc:-ptc, ptc:-ptc]
-        plot_predict(cfg, cropped_image, cropped_background, decals_plocs, est_cat)
+        plot_predict(
+            cfg,
+            cropped_image,
+            cropped_background,
+            plocs,
+            est_full,
+            survey_obj["wcs"][SDSS.BANDS.index("r")],
+        )
 
-    return est_cat, images[0], background[0], decals_plocs, pred
+    return est_full, images[0], background[0], plocs, pred
 
 
 def crop_plocs(cfg, w, h, plocs, do_crop=False):
@@ -232,11 +216,23 @@ def plot_image(cfg, img, w, h, est_plocs, true_plocs, title):
     true_plocs = np.array(crop_plocs(cfg, w, h, true_plocs, do_crop).cpu())
     decals_plocs = None
     if do_crop and (not is_simulated):
-        decals_plocs = np.array(crop_plocs(cfg, w, h, decals_plocs_from_sdss(cfg)[0], do_crop))
+        sdss = instantiate(cfg.predict.dataset)
+        wcs = sdss[0]["wcs"][0]
+
+        # Map SDSS RCF to DECaLS brickname
+        sdss_fields = cfg.surveys.sdss.sdss_fields
+        run, camcol, fields = sdss_fields[0].values()
+        brickname = DECaLS.brick_for_radec(*SDSS.radec_for_rcf(run, camcol, fields[0]))
+
+        tractor_filename = DecalsDownloader(brickname, cfg.paths.decals).download_catalog()
+        decals_plocs_from_sdss = DecalsFullCatalog.from_file(
+            tractor_filename, wcs, height=sdss[0]["image"].shape[1], width=sdss[0]["image"].shape[2]
+        ).plocs[0]
+        decals_plocs = np.array(crop_plocs(cfg, w, h, decals_plocs_from_sdss, do_crop))
     return TabPanel(child=add_cat(p, est_plocs, true_plocs, decals_plocs), title=title)
 
 
-def plot_predict(cfg, image, background, true_plocs, est_cat):
+def plot_predict(cfg, image, background, true_plocs, est_cat: FullCatalog, wcs: WCS):
     """Function that uses bokeh to save generated plots to an html file."""
     w, h = image.shape
 
@@ -246,7 +242,12 @@ def plot_predict(cfg, image, background, true_plocs, est_cat):
     est_tile = est_cat.to_tile_params(
         cfg.encoder.tile_slen, cfg.simulator.survey.prior_config.max_sources
     )
-    rcfs = np.array([[94, 1, 12]])  # TODO: find corresponding SDSS RCF for this est_cat
+    # convert plocs to RA, Dec using wcs
+    # ras, decs = wcs.all_pix2world(est_plocs[:, 1], est_plocs[:, 0], 0) # noqa: E800
+    # ra_lim, dec_lim = (np.min(ras), np.max(ras)), (np.min(decs), np.max(decs)) # noqa: E800
+    # rcfs = np.array([SDSS.rcf_for_radec(ra_lim, dec_lim)]) # noqa: E800
+    # TODO: don't hardcode 94, 1, 12. Approach above yields different RCF...
+    rcfs = np.array([[94, 1, 12]])
     images, _, _ = decoder_obj.render_images(est_tile.to("cpu"), rcfs)
     recon_img = images[0][0]  # first image in batch, first band in image
 

--- a/bliss/simulator/background.py
+++ b/bliss/simulator/background.py
@@ -8,22 +8,21 @@ from torch import Tensor, nn
 class ImageBackground(nn.Module):
     def __init__(
         self,
-        items,
+        image_items,
         bands: Tuple[int, ...],
     ):
         """Construct a background image from a set of images.
 
         Args:
-            items: list of survey image items from which to simulate the background.
+            image_items: list of survey image items from which to simulate the background.
                 Needs to contain a "background" key with a Tensor of background images.
             bands: bands to use for constructing the background, passed from Survey
         """
 
         super().__init__()
 
-        # Add all backgrounds from specified run/col/field to list
         backgrounds = []
-        backgrounds.extend(item["background"][list(bands)] for item in items)
+        backgrounds.extend(item["background"][list(bands)] for item in image_items)
         background = torch.from_numpy(np.stack(backgrounds, axis=0))
 
         self.register_buffer("background", background, persistent=False)

--- a/bliss/simulator/background.py
+++ b/bliss/simulator/background.py
@@ -1,62 +1,31 @@
-from typing import Dict, Tuple
+from typing import Tuple
 
 import numpy as np
 import torch
-from einops import rearrange
-from omegaconf import OmegaConf
-from omegaconf.dictconfig import DictConfig
 from torch import Tensor, nn
 
-# ideally this module wouldn't depend on any specific survey
-from bliss.surveys.sdss import SloanDigitalSkySurvey
 
-
-class ConstantBackground(nn.Module):
-    def __init__(self, background: Tuple[float, ...], **_kwargs):
+class ImageBackground(nn.Module):
+    def __init__(
+        self,
+        items,
+        bands: Tuple[int, ...] = (0, 1, 2, 3, 4),
+    ):
         super().__init__()
-        bg: Tensor = torch.tensor([background])
-        bg = rearrange(bg[0], "c -> 1 c 1 1")
-        self.register_buffer("background", bg, persistent=False)
-
-    def sample(self, shape, **_kwargs) -> Tensor:
-        assert isinstance(self.background, Tensor)
-        batch_size, c, hlen, wlen = shape
-        return self.background.expand(batch_size, c, hlen, wlen)
-
-
-class SimulatedSDSSBackground(nn.Module):
-    def __init__(self, sdss_fields: DictConfig):
-        super().__init__()
-        sdss_dir = sdss_fields["dir"]
-        field_list = sdss_fields["field_list"]
-        bands = sdss_fields["bands"]  # use same bands across fields
 
         # Add all backgrounds from specified run/col/field to list
         backgrounds = []
-        for param_obj in field_list:
-            params: Dict = OmegaConf.to_container(param_obj)
-            sdss = SloanDigitalSkySurvey(sdss_dir=sdss_dir, **params)
-            backgrounds.extend([field["background"][bands] for field in sdss])
-
+        backgrounds.extend(item["background"][list(bands)] for item in items)
         background = torch.from_numpy(np.stack(backgrounds, axis=0))
 
         self.register_buffer("background", background, persistent=False)
         self.height, self.width = self.background.shape[-2:]
 
-    def sample(self, shape, rcf_indices) -> Tensor:
-        """Sample a random region to use as the background for each image.
-
-        Args:
-            shape: shape of background to return (channels x height x width)
-            rcf_indices: batch_size-length array of indices to index into background list
-
-        Returns:
-            Tensor: batch_size x shape tensor of backgrounds
-        """
+    def sample(self, shape, image_id_indices) -> Tensor:
         assert isinstance(self.background, Tensor)
         batch_size, c, hlen, wlen = shape
         assert self.background.shape[1] == c
-        assert rcf_indices.shape[0] == batch_size
+        assert image_id_indices.shape[0] == batch_size
 
         # select region to sample from (same for all images in batch for simplicity)
         h_diff, w_diff = self.height - hlen, self.width - wlen
@@ -64,4 +33,4 @@ class SimulatedSDSSBackground(nn.Module):
         w = 0 if w_diff == 0 else np.random.randint(w_diff)
 
         # sample region from specified background for each image in batch
-        return self.background[rcf_indices, :, h : (h + hlen), w : (w + wlen)]
+        return self.background[image_id_indices, :, h : (h + hlen), w : (w + wlen)]

--- a/bliss/simulator/background.py
+++ b/bliss/simulator/background.py
@@ -9,8 +9,16 @@ class ImageBackground(nn.Module):
     def __init__(
         self,
         items,
-        bands: Tuple[int, ...] = (0, 1, 2, 3, 4),
+        bands: Tuple[int, ...],
     ):
+        """Construct a background image from a set of images.
+
+        Args:
+            items: list of survey image items from which to simulate the background.
+                Needs to contain a "background" key with a Tensor of background images.
+            bands: bands to use for constructing the background, passed from Survey
+        """
+
         super().__init__()
 
         # Add all backgrounds from specified run/col/field to list

--- a/bliss/simulator/decoder.py
+++ b/bliss/simulator/decoder.py
@@ -12,8 +12,15 @@ class ImageDecoder(nn.Module):
     def __init__(
         self,
         psf,
-        bands: Tuple[int, ...] = (0, 1, 2, 3, 4),
+        bands: Tuple[int, ...],
     ) -> None:
+        """Construct a decoder for a set of images.
+
+        Args:
+            psf: PSF object
+            bands: bands to use for constructing the decoder, passed from Survey
+        """
+
         super().__init__()
 
         self.n_bands = len(bands)

--- a/bliss/simulator/decoder.py
+++ b/bliss/simulator/decoder.py
@@ -1,153 +1,25 @@
-from pathlib import Path
 from typing import Tuple
 
 import galsim
 import numpy as np
 import torch
-from astropy.io import fits
-from einops import rearrange, reduce
-from omegaconf import DictConfig
 from torch import nn
 
 from bliss.catalog import SourceType, TileCatalog
-from bliss.surveys.sdss import SDSSDownloader
 
 
 class ImageDecoder(nn.Module):
     def __init__(
         self,
-        pixel_scale: float,
-        psf_slen: int,
-        sdss_fields: DictConfig,
+        psf,
+        bands: Tuple[int, ...] = (0, 1, 2, 3, 4),
     ) -> None:
         super().__init__()
 
-        self.n_bands = len(sdss_fields["bands"])
-        self.pixel_scale = pixel_scale
-        self.psf_slen = psf_slen
-        self.psf_galsim = {}  # Dictionary indexed by (run, camcol, field) tuple
-        self.psf_params = {}
-
-        sdss_dir = sdss_fields["dir"]
-        sdss_bands = sdss_fields["bands"]
-
-        for field_params in sdss_fields["field_list"]:
-            run = field_params["run"]
-            camcol = field_params["camcol"]
-            fields = field_params["fields"]
-
-            for field in fields:
-                # load raw params from file
-                field_dir = f"{sdss_dir}/{run}/{camcol}/{field}"
-                filename = f"{field_dir}/psField-{run:06}-{camcol}-{field:04}.fits"
-                if not Path(filename).exists():
-                    SDSSDownloader(run, camcol, field, download_dir=sdss_dir).download_psfield()
-                psf_params = self._get_fit_file_psf_params(filename, sdss_bands)
-
-                # load psf image from params
-                self.psf_galsim[(run, camcol, field)] = self._get_psf(psf_params)
-                self.psf_params[(run, camcol, field)] = psf_params
-
-    def _get_psf(self, params):
-        """Construct PSF image from parameters. This is the main entry point for generating the psf.
-
-        Args:
-            params: list of psf parameters, loaded from _get_fit_file_psf_params
-
-        Returns:
-            images (List[InterpolatedImage]): list of psf transformations for each band
-        """
-        # get psf in each band
-        psf_list = []
-        for i in range(self.n_bands):
-            grid = self._get_mgrid() * (self.psf_slen - 1) / 2
-            radii_grid = (grid**2).sum(2).sqrt()
-            band_psf = self._psf_fun(radii_grid, *params[i])
-            psf_list.append(band_psf.unsqueeze(0))
-        psf = torch.cat(psf_list)
-        assert (psf > 0).all()
-
-        # ensure it's normalized
-        norm = reduce(psf, "b m k -> b", "sum")
-        psf *= rearrange(1 / norm, "b -> b 1 1")
-
-        # check format
-        n_bands, psf_slen, _ = psf.shape
-        assert n_bands == self.n_bands and (psf_slen % 2) == 1 and psf_slen == psf.shape[2]
-
-        # convert to image
-        images = []
-        for i in range(self.n_bands):
-            psf_image = galsim.Image(psf.detach().numpy()[i], scale=self.pixel_scale)
-            images.append(galsim.InterpolatedImage(psf_image).withFlux(1.0))
-
-        return images
-
-    def _get_mgrid(self):
-        """Construct the base grid for the PSF."""
-        offset = (self.psf_slen - 1) / 2
-        x, y = np.mgrid[-offset : (offset + 1), -offset : (offset + 1)]
-        mgrid = torch.tensor(np.dstack((y, x))) / offset
-        return mgrid.float()
-
-    @staticmethod
-    def _get_fit_file_psf_params(psf_fit_file: str, bands: Tuple[int, ...]):
-        """Load psf parameters from fits file.
-
-        See https://data.sdss.org/datamodel/files/PHOTO_REDUX/RERUN/RUN/objcs/CAMCOL/psField.html
-        for details on the parameters.
-
-        Args:
-            psf_fit_file (str): file to load from
-            bands (Tuple[int, ...]): SDSS bands to load
-
-        Returns:
-            psf_params: tensor of parameters for each band
-        """
-        msg = (
-            f"{psf_fit_file} does not exist. "
-            + "Make sure data files are available for fields specified in config."
-        )
-        assert Path(psf_fit_file).exists(), msg
-        # HDU 6 contains the PSF header (after primary and eigenimages)
-        data = fits.open(psf_fit_file, ignore_missing_end=True).pop(6).data
-        psf_params = torch.zeros(len(bands), 6)
-        for i, band in enumerate(bands):
-            sigma1 = data["psf_sigma1"][0][band] ** 2
-            sigma2 = data["psf_sigma2"][0][band] ** 2
-            sigmap = data["psf_sigmap"][0][band] ** 2
-            beta = data["psf_beta"][0][band]
-            b = data["psf_b"][0][band]
-            p0 = data["psf_p0"][0][band]
-
-            psf_params[i] = torch.tensor([sigma1, sigma2, sigmap, beta, b, p0])
-
-        return psf_params
-
-    @staticmethod
-    def _psf_fun(r, sigma1, sigma2, sigmap, beta, b, p0):
-        """Generate the PSF from the parameters using the power-law model.
-
-        See https://data.sdss.org/datamodel/files/PHOTO_REDUX/RERUN/RUN/objcs/CAMCOL/psField.html
-        for details on the parameters and the equation used.
-
-        Args:
-            r: radius
-            sigma1: Inner gaussian sigma for the composite fit
-            sigma2: Outer gaussian sigma for the composite fit
-            sigmap: Width parameter for power law (pixels)
-            beta: Slope of power law.
-            b: Ratio of the outer PSF to the inner PSF at the origin
-            p0: The value of the power law at the origin.
-
-        Returns:
-            The psf function evaluated at r.
-        """
-
-        term1 = torch.exp(-(r**2) / (2 * sigma1))
-        term2 = b * torch.exp(-(r**2) / (2 * sigma2))
-        term3 = p0 * (1 + r**2 / (beta * sigmap)) ** (-beta / 2)
-        return (term1 + term2 + term3) / (1 + b + p0)
+        self.n_bands = len(bands)
+        self.psf_galsim = psf.psf_galsim  # Dictionary indexed by image_id
+        self.psf_params = psf.psf_params  # Dictionary indexed by image_id
+        self.pixel_scale = psf.pixel_scale
 
     def render_star(self, psf, band, source_params):
         """Render a star with given params and PSF.
@@ -167,10 +39,10 @@ class ImageDecoder(nn.Module):
         """Render a galaxy with given params and PSF.
 
         Args:
-            source_params (Tensor): Tensor containing the parameters for a particular source
-                (see prior.py for details about these parameters)
             psf (List): a list of PSFs for each band
             band (int): band
+            source_params (Tensor): Tensor containing the parameters for a particular source
+                (see prior.py for details about these parameters)
 
         Returns:
             GSObject: a galsim representation of the rendered galaxy convolved with the PSF
@@ -208,21 +80,21 @@ class ImageDecoder(nn.Module):
             SourceType.GALAXY: self.render_galaxy,
         }
 
-    def render_images(self, tile_cat: TileCatalog, rcf):
+    def render_images(self, tile_cat: TileCatalog, image_ids):
         """Render images from a tile catalog.
 
         Args:
             tile_cat (TileCatalog): the tile catalog to create images from
-            rcf (ndarray): array containing the row/camcol/field of PSFs to use
+            image_ids (ndarray): array containing the image_ids of PSFs to use
 
         Raises:
-            AssertionError: rcf must contain batch_size values
+            AssertionError: image_ids must contain `batch_size` values
 
         Returns:
             Tuple[Tensor, List, Tensor]: tensor of images, list of PSFs, tensor of PSF params
         """
         batch_size, n_tiles_h, n_tiles_w = tile_cat.n_sources.shape
-        assert rcf.shape[0] == batch_size
+        assert image_ids.shape[0] == batch_size
 
         slen_h = tile_cat.tile_slen * n_tiles_h
         slen_w = tile_cat.tile_slen * n_tiles_w
@@ -231,8 +103,8 @@ class ImageDecoder(nn.Module):
         full_cat = tile_cat.to_full_params()
 
         # use the PSF from specified row/camcol/field
-        psfs = [self.psf_galsim[tuple(rcf[b])] for b in range(batch_size)]
-        param_list = [self.psf_params[tuple(rcf[b])] for b in range(batch_size)]
+        psfs = [self.psf_galsim[tuple(image_ids[b])] for b in range(batch_size)]
+        param_list = [self.psf_params[tuple(image_ids[b])] for b in range(batch_size)]
         psf_params = torch.stack(param_list, dim=0)
 
         for b in range(batch_size):

--- a/bliss/simulator/prior.py
+++ b/bliss/simulator/prior.py
@@ -227,8 +227,8 @@ class ImagePrior(pl.LightningModule):
 
         Instead of pareto-sampling fluxes for each band, we pareto-sample `b`-band flux values,
         using prior `b`-band star/galaxy flux parameters, then apply other-band-to-`b`-band flux
-        ratios to get other-band flux values. This is primarily because Pareto distribution is
-        multimodal, and so it is not always the case that, e.g.,
+        ratios to get other-band flux values. This is primarily because it is not always the case
+        that, e.g.,
             flux_r ~ Pareto, flux_g ~ Pareto => flux_r | flux_g ~ Pareto.
 
         Args:

--- a/bliss/simulator/prior.py
+++ b/bliss/simulator/prior.py
@@ -1,17 +1,39 @@
 import itertools
 import random
-from pathlib import Path
+from typing import Tuple, TypedDict
 
 import numpy as np
 import pytorch_lightning as pl
 import torch
-from astropy.io import fits
-from omegaconf.dictconfig import DictConfig
 from torch import Tensor
 from torch.distributions import Gamma, Poisson, Uniform
 
 from bliss.catalog import SourceType, TileCatalog
-from bliss.surveys.sdss import SDSSDownloader, SloanDigitalSkySurvey, column_to_tensor
+
+PriorConfig = TypedDict(
+    "PriorConfig",
+    {
+        "max_bands": int,
+        "n_tiles_h": int,
+        "n_tiles_w": int,
+        "tile_slen": int,
+        "batch_size": int,
+        "max_sources": int,
+        "mean_sources": float,
+        "min_sources": int,
+        "prob_galaxy": float,
+        "star_flux_min": float,
+        "star_flux_max": float,
+        "star_flux_alpha": float,
+        "galaxy_flux_min": float,
+        "galaxy_flux_max": float,
+        "galaxy_alpha": float,
+        "galaxy_a_concentration": float,
+        "galaxy_a_loc": float,
+        "galaxy_a_scale": float,
+        "galaxy_a_bd_ratio": float,
+    },
+)
 
 
 class ImagePrior(pl.LightningModule):
@@ -24,7 +46,8 @@ class ImagePrior(pl.LightningModule):
 
     def __init__(
         self,
-        sdss_fields: DictConfig,
+        bands,
+        max_bands,
         n_tiles_h: int,
         n_tiles_w: int,
         tile_slen: int,
@@ -47,7 +70,8 @@ class ImagePrior(pl.LightningModule):
         """Initializes ImagePrior.
 
         Args:
-            sdss_fields: sdss frames to sample from,
+            bands: List of bands
+            max_bands: Maximum number of bands
             n_tiles_h: Image height in tiles,
             n_tiles_w: Image width in tiles,
             tile_slen: Tile side length in pixels,
@@ -72,16 +96,11 @@ class ImagePrior(pl.LightningModule):
         self.n_tiles_w = n_tiles_w
         self.tile_slen = tile_slen
         # NOTE: bands have to be non-empty
-        assert sdss_fields["bands"]
-        self.bands = sdss_fields["bands"]
-        self.n_bands = len(self.bands)
-        self.max_bands = 5  # TODO: fix hard-coding just for SDSS
+        assert bands, "Need at least one band"
+        self.bands = bands
+        self.n_bands = len(bands)  # used in SimulatedDataset
+        self.max_bands = max_bands
         self.batch_size = batch_size
-        self.sdss = sdss_fields["dir"]
-
-        self.rcf_stars_rest, self.rcf_gals_rest = self._load_color_distribution(
-            sdss_fields["field_list"]
-        )
 
         self.min_sources = min_sources
         self.max_sources = max_sources
@@ -102,11 +121,11 @@ class ImagePrior(pl.LightningModule):
         self.galaxy_a_scale = galaxy_a_scale
         self.galaxy_a_bd_ratio = galaxy_a_bd_ratio
 
-    def sample_prior(self, batch_rcfs) -> TileCatalog:
+    def sample_prior(self, batch_image_ids) -> TileCatalog:
         """Samples latent variables from the prior of an astronomical image.
 
         Args:
-            batch_rcfs: run, camcol, field combinations needed for sampling.
+            batch_image_ids: image_ids needed for sampling.
 
         Returns:
             A dictionary of tensors. Each tensor is a particular per-tile quantity; i.e.
@@ -115,25 +134,25 @@ class ImagePrior(pl.LightningModule):
             The remaining dimensions are variable-specific.
         """
         locs = self._sample_locs()
-        select_gal_rcfs = []
-        select_star_rcfs = []
+        select_gal_flux_ratios = []
+        select_star_flux_ratios = []
 
-        for rcf in batch_rcfs:
-            rcf = tuple(rcf)
+        for batch_image_id in batch_image_ids:
+            image_id = tuple(batch_image_id)
             # get value if key exists, otherwise pick randomly
-            select_gal_rcfs.append(
-                self.rcf_gals_rest[rcf]
-                if rcf in self.rcf_gals_rest
-                else random.choice(list(self.rcf_gals_rest.values()))
+            select_gal_flux_ratios.append(
+                self.gals_fluxes[image_id]
+                if image_id in self.gals_fluxes
+                else random.choice(list(self.gals_fluxes.values()))
             )
-            select_star_rcfs.append(
-                self.rcf_stars_rest[rcf]
-                if rcf in self.rcf_stars_rest
-                else random.choice(list(self.rcf_stars_rest.values()))
+            select_star_flux_ratios.append(
+                self.stars_fluxes[image_id]
+                if image_id in self.stars_fluxes
+                else random.choice(list(self.stars_fluxes.values()))
             )
 
-        galaxy_fluxes, galaxy_params = self._sample_galaxy_prior(select_gal_rcfs)
-        star_fluxes = self._sample_star_fluxes(select_star_rcfs)
+        galaxy_fluxes, galaxy_params = self._sample_galaxy_prior(select_gal_flux_ratios)
+        star_fluxes = self._sample_star_fluxes(select_star_flux_ratios)
 
         n_sources = self._sample_n_sources()
         source_type = self._sample_source_type()
@@ -167,24 +186,30 @@ class ImagePrior(pl.LightningModule):
         star_bool = galaxy_bool.bitwise_not()
         return SourceType.STAR * star_bool + SourceType.GALAXY * galaxy_bool
 
+    def _draw_truncated_pareto(self, alpha, min_x, max_x, n_samples) -> Tensor:
+        # draw pareto conditioned on being less than f_max
+        u_max = 1 - (min_x / max_x) ** alpha
+        uniform_samples = torch.rand(n_samples) * u_max
+        return min_x / (1.0 - uniform_samples) ** (1 / alpha)
+
     def _sample_star_fluxes(self, star_ratios):
         latent_dims = (self.batch_size, self.n_tiles_h, self.n_tiles_w, self.max_sources)
-        r_flux = self._draw_truncated_pareto(
+        b_flux = self._draw_truncated_pareto(
             self.star_flux_alpha, self.star_flux_min, self.star_flux_max, latent_dims
         )
-        total_flux = self.multiflux(star_ratios, r_flux)
+        total_flux = self.multiflux(star_ratios, b_flux)
 
         # select specified bands
         bands = np.array(self.bands)
         return total_flux[..., bands]
 
-    def multiflux(self, rcf_ratios, flux_base) -> Tensor:
+    def multiflux(self, flux_ratios, flux_base) -> Tensor:
         """Generate flux values for remaining bands based on draw."""
         total_flux = torch.zeros(
             self.batch_size, self.n_tiles_h, self.n_tiles_w, self.max_sources, 5
         )
 
-        for b, obj_ratios in enumerate(rcf_ratios):
+        for b, obj_ratios in enumerate(flux_ratios):
             for h, w, s, bnd in itertools.product(  # noqa: WPS352
                 range(self.n_tiles_h),
                 range(self.n_tiles_w),
@@ -197,103 +222,33 @@ class ImagePrior(pl.LightningModule):
 
         return total_flux
 
-    def _load_color_distribution(self, sdss_fields):
-        rcf_stars_rest = {}
-        rcf_gals_rest = {}
+    def _flux_ratios_against_b(self, survey_data_dir, image_ids, items, b) -> Tuple[dict, dict]:
+        """Sample and compute all star, galaxy fluxes relative to `b`-band based on real image data.
 
-        # load all star, galaxy fluxes relative to r-band required for sampling
-        for field_params in sdss_fields:
-            run = field_params["run"]
-            camcol = field_params["camcol"]
-            fields = field_params["fields"]
-
-            # load SDSS object to iterate over field frames
-            sdss = SloanDigitalSkySurvey(self.sdss, run, camcol, fields)
-
-            # load project SDSS dir
-            sdss_path = Path(self.sdss)
-
-            for i, field in enumerate(fields):
-                # Set photoObj file path
-                field_dir = sdss_path / str(run) / str(camcol) / str(field)
-                po_path = field_dir / f"photoObj-{run:06d}-{camcol:d}-{field:04d}.fits"
-
-                if not po_path.exists():
-                    SDSSDownloader(run, camcol, field, str(sdss_path)).download_po()
-                msg = (
-                    f"{po_path} does not exist. "
-                    + "Make sure data files are available for fields specified in config."
-                )
-                assert Path(po_path).exists(), msg
-                po_fits = fits.getdata(po_path)
-
-                # retrieve object-specific information for ratio computing
-                objc_type = column_to_tensor(po_fits, "objc_type").numpy()
-                thing_id = column_to_tensor(po_fits, "thing_id").numpy()
-
-                # mask fluxes based on object identity & validity
-                galaxy_bools = (objc_type == 3) & (thing_id != -1)
-                star_bools = (objc_type == 6) & (thing_id != -1)
-                star_fluxes = column_to_tensor(po_fits, "psfflux") * star_bools.reshape(-1, 1)
-                gal_fluxes = column_to_tensor(po_fits, "cmodelflux") * galaxy_bools.reshape(-1, 1)
-                fluxes = star_fluxes + gal_fluxes
-
-                # containers for light source ratios in current field
-                star_fluxes_rest = []
-                gal_fluxes_rest = []
-
-                # SDSS object for current field
-                sdss_obj = sdss[i]
-
-                for obj, _ in enumerate(objc_type):
-                    if thing_id[obj] != -1 and torch.all(fluxes[obj] > 0):
-                        ratios = self._compute_flux_ratio(fluxes[obj], sdss_obj)  # noqa: WPS220
-                        if objc_type[obj] == 6:  # noqa: WPS220
-                            star_fluxes_rest.append(ratios)  # noqa: WPS220
-                        elif objc_type[obj] == 3:  # noqa: WPS220
-                            gal_fluxes_rest.append(ratios)  # noqa: WPS220
-
-                if star_fluxes_rest:
-                    rcf_stars_rest[(run, camcol, field)] = star_fluxes_rest
-                if gal_fluxes_rest:
-                    rcf_gals_rest[(run, camcol, field)] = gal_fluxes_rest
-        return rcf_stars_rest, rcf_gals_rest
-
-    @staticmethod
-    def _draw_truncated_pareto(alpha, min_x, max_x, n_samples) -> Tensor:
-        # draw pareto conditioned on being less than f_max
-        u_max = 1 - (min_x / max_x) ** alpha
-        uniform_samples = torch.rand(n_samples) * u_max
-        return min_x / (1.0 - uniform_samples) ** (1 / alpha)
-
-    def _compute_flux_ratio(self, obj_fluxes, sdss_obj):
-        """Query SDSS frames to get flux ratios in units of electron count.
+        Instead of pareto-sampling fluxes for each band, we pareto-sample `b`-band flux values,
+        using prior `b`-band star/galaxy flux parameters, then apply other-band-to-`b`-band flux
+        ratios to get other-band flux values. This is primarily because Pareto distribution is
+        multimodal, and so it is not always the case that, e.g.,
+            flux_r ~ Pareto, flux_g ~ Pareto => flux_r | flux_g ~ Pareto.
 
         Args:
-            obj_fluxes: tensor of electron counts for a particular SDSS object
-            sdss_obj: SloanDigitalSkySurvey object entry for a particular field
+            survey_data_dir (str): path to survey data directory
+            image_ids (list): list of image ids corresponding to `items`
+            items (list): list of image items
+            b (int): index of reference band
 
         Returns:
-            ratios (Tensor): Ratio of electron counts for each light source in field
-            relative to r-band
+            stars_fluxes (dict): image_id-indexed dict of star flux ratios # noqa: DAR202
+                relative to `b`-band
+            gals_fluxes (dict): image_id-indexed dict of galaxy flux ratios   # noqa: DAR202
+                relative to `b`-band
+
+        Raises:
+            NotImplementedError: if this method is not implemented in a subclass
         """
-        ratios = torch.zeros(obj_fluxes.size())
+        raise NotImplementedError
 
-        # distribution of nelec_per_nmgy very clustered around mean
-        nelec_per_nmgys = sdss_obj["nelec_per_nmgy_list"]
-        r_rat = nelec_per_nmgys[2].mean()  # fix r-band (count:nmgy) ratio
-
-        for i in range(self.max_bands):
-            # distribution of nelec_per_nmgy very clustered around mean
-            nelec_per_nmgy_rat = nelec_per_nmgys[i].mean() / r_rat
-
-            # (nmgy ratio relative to r-band) * (nelec/nmgy ratio relative to r band)
-            # result: ratio in units of electron counts
-            ratios[i] = (obj_fluxes[i] / obj_fluxes[2]) * nelec_per_nmgy_rat
-
-        return ratios
-
-    def _sample_galaxy_prior(self, gal_ratios):
+    def _sample_galaxy_prior(self, gal_ratios) -> Tuple[Tensor, Tensor]:
         """Sample the latent galaxy params.
 
         Args:

--- a/bliss/simulator/psf.py
+++ b/bliss/simulator/psf.py
@@ -1,0 +1,88 @@
+from typing import TypedDict
+
+import galsim
+import numpy as np
+import torch
+from einops import rearrange, reduce
+
+PSFConfig = TypedDict(
+    "PSFConfig",
+    {
+        "pixel_scale": float,
+        "psf_slen": int,
+    },
+)
+
+
+class ImagePointSpreadFunction:
+    def __init__(self, bands, pixel_scale, psf_slen):
+        self.n_bands = len(bands)
+        self.pixel_scale = pixel_scale
+        self.psf_slen = psf_slen
+
+    def _get_psf(self, params):
+        """Construct PSF image from parameters. This is the main entry point for generating the psf.
+
+        Args:
+            params: list of psf parameters, loaded from _get_fit_file_psf_params
+
+        Returns:
+            images (List[InterpolatedImage]): list of psf transformations for each band
+        """
+        # get psf in each band
+        psf_list = []
+        for i in range(self.n_bands):
+            grid = self._get_mgrid() * (self.psf_slen - 1) / 2
+            radii_grid = (grid**2).sum(2).sqrt()
+            band_psf = self._psf_fun(radii_grid, *params[i])
+            psf_list.append(band_psf.unsqueeze(0))
+        psf = torch.cat(psf_list)
+        assert (psf > 0).all()
+
+        # ensure it's normalized
+        norm = reduce(psf, "b m k -> b", "sum")
+        psf *= rearrange(1 / norm, "b -> b 1 1")
+
+        # check format
+        n_bands, psf_slen, _ = psf.shape
+        assert n_bands == self.n_bands and (psf_slen % 2) == 1 and psf_slen == psf.shape[2]
+
+        # convert to image
+        images = []
+        for i in range(self.n_bands):
+            psf_image = galsim.Image(psf.detach().numpy()[i], scale=self.pixel_scale)
+            images.append(galsim.InterpolatedImage(psf_image).withFlux(1.0))
+
+        return images
+
+    def _get_mgrid(self):
+        """Construct the base grid for the PSF."""
+        offset = (self.psf_slen - 1) / 2
+        x, y = np.mgrid[-offset : (offset + 1), -offset : (offset + 1)]
+        mgrid = torch.tensor(np.dstack((y, x))) / offset
+        return mgrid.float()
+
+    @staticmethod
+    def _psf_fun(r, sigma1, sigma2, sigmap, beta, b, p0):
+        """Generate the PSF from the parameters using the power-law model.
+
+        See https://data.sdss.org/datamodel/files/PHOTO_REDUX/RERUN/RUN/objcs/CAMCOL/psField.html
+        for details on the parameters and the equation used.
+
+        Args:
+            r: radius
+            sigma1: Inner gaussian sigma for the composite fit
+            sigma2: Outer gaussian sigma for the composite fit
+            sigmap: Width parameter for power law (pixels)
+            beta: Slope of power law.
+            b: Ratio of the outer PSF to the inner PSF at the origin
+            p0: The value of the power law at the origin.
+
+        Returns:
+            The psf function evaluated at r.
+        """
+
+        term1 = torch.exp(-(r**2) / (2 * sigma1))
+        term2 = b * torch.exp(-(r**2) / (2 * sigma2))
+        term3 = p0 * (1 + r**2 / (beta * sigmap)) ** (-beta / 2)
+        return (term1 + term2 + term3) / (1 + b + p0)

--- a/bliss/simulator/psf.py
+++ b/bliss/simulator/psf.py
@@ -14,7 +14,7 @@ PSFConfig = TypedDict(
 )
 
 
-class ImagePointSpreadFunction:
+class ImagePSF:
     def __init__(self, bands, pixel_scale, psf_slen):
         self.n_bands = len(bands)
         self.pixel_scale = pixel_scale
@@ -62,27 +62,14 @@ class ImagePointSpreadFunction:
         mgrid = torch.tensor(np.dstack((y, x))) / offset
         return mgrid.float()
 
-    @staticmethod
-    def _psf_fun(r, sigma1, sigma2, sigmap, beta, b, p0):
-        """Generate the PSF from the parameters using the power-law model.
-
-        See https://data.sdss.org/datamodel/files/PHOTO_REDUX/RERUN/RUN/objcs/CAMCOL/psField.html
-        for details on the parameters and the equation used.
+    def _psf_fun(self, r, **params):
+        """Generate the PSF from the parameters.
 
         Args:
             r: radius
-            sigma1: Inner gaussian sigma for the composite fit
-            sigma2: Outer gaussian sigma for the composite fit
-            sigmap: Width parameter for power law (pixels)
-            beta: Slope of power law.
-            b: Ratio of the outer PSF to the inner PSF at the origin
-            p0: The value of the power law at the origin.
+            **params: psf parameters (e.g., (sigma1, sigma2, sigmap, beta, b, p0) for SDSS)
 
-        Returns:
-            The psf function evaluated at r.
+        Raises:
+            NotImplementedError: if the psf function is not implemented
         """
-
-        term1 = torch.exp(-(r**2) / (2 * sigma1))
-        term2 = b * torch.exp(-(r**2) / (2 * sigma2))
-        term3 = p0 * (1 + r**2 / (beta * sigmap)) ** (-beta / 2)
-        return (term1 + term2 + term3) / (1 + b + p0)
+        raise NotImplementedError

--- a/bliss/simulator/simulated_dataset.py
+++ b/bliss/simulator/simulated_dataset.py
@@ -41,8 +41,10 @@ class SimulatedDataset(pl.LightningDataModule, IterableDataset):
         self.background.requires_grad_(False)
 
         assert survey.psf is not None, "Survey psf cannot be None."
+        assert survey.bands is not None, "Survey bands cannot be None."
         self.image_decoder = ImageDecoder(
             psf=survey.psf,
+            bands=survey.bands,
         )
 
         self.n_batches = n_batches
@@ -54,14 +56,15 @@ class SimulatedDataset(pl.LightningDataModule, IterableDataset):
         # list of (run, camcol, field) tuples from config
         self.image_ids = np.array(self.survey.image_ids())
 
-    def randomized_image_ids(self, num_samples=1):
-        """Get random run, camcol, field combination from loaded params.
+    def randomized_image_ids(self, num_samples=1) -> Tuple[np.ndarray, np.ndarray]:
+        """Get random image_id from loaded params.
 
         Args:
             num_samples (int, optional): number of random samples to get. Defaults to 1.
 
         Returns:
-            Array of (row, camcol, field) pairs and index of each pair in self.image_ids.
+            Tuple[np.ndarray, np.ndarray]: tuple of image_ids and their corresponding
+                `self.image_ids` indices.
         """
         n = np.random.randint(len(self.image_ids), size=(num_samples,), dtype=int)
         return self.image_ids[n], n
@@ -80,7 +83,7 @@ class SimulatedDataset(pl.LightningDataModule, IterableDataset):
 
         Args:
             tile_catalog (TileCatalog): The TileCatalog to render.
-            image_id_indices: Indices of row/camcol/field in self.image_ids to sample from.
+            image_id_indices: Indices in self.image_ids to sample from.
 
         Returns:
             Tuple[Tensor, Tensor, Tensor, Tensor]: tuple of images, backgrounds, deconvolved images,

--- a/bliss/surveys/decals.py
+++ b/bliss/surveys/decals.py
@@ -1,24 +1,25 @@
 import warnings
 from pathlib import Path
-from typing import Tuple
+from typing import List
 from urllib.error import HTTPError
 
 import numpy as np
-import pytorch_lightning as pl
 import torch
 from astropy.io import fits
 from astropy.table import Table
 from astropy.utils.data import download_file
 from astropy.wcs import WCS
-from torch.utils.data import DataLoader, Dataset
+from pytorch_lightning.utilities.types import EVAL_DATALOADERS
+from torch.utils.data import DataLoader
 
 from bliss.catalog import FullCatalog, SourceType
 from bliss.surveys.sdss import SloanDigitalSkySurvey as SDSS
-from bliss.surveys.sdss import column_to_tensor, prepare_batch, prepare_image
-from bliss.utils.download_utils import download_file_to_dst, download_git_lfs_file
+from bliss.surveys.sdss import column_to_tensor
+from bliss.surveys.survey import Survey, SurveyDownloader
+from bliss.utils.download_utils import download_file_to_dst
 
 
-class DarkEnergyCameraLegacySurvey(pl.LightningDataModule, Dataset):
+class DarkEnergyCameraLegacySurvey(Survey):
     BANDS = ("g", "r", "i", "z")
     PIXEL_SCALE = 0.262
     PIXEL_SIZE = 3600  # arcsec/degree
@@ -32,14 +33,14 @@ class DarkEnergyCameraLegacySurvey(pl.LightningDataModule, Dataset):
     @staticmethod
     def brick_for_radec(ra: float, dec: float) -> str:
         """Get brick name for specified RA, Dec."""
-        survey_bricks = DecalsDownloader.survey_bricks()
+        bricks = DecalsDownloader.survey_bricks()
         # ra1 - lower RA boundary; ra2 - upper RA boundary
         # dec1 - lower DEC boundary; dec2 - upper DEC boundary
-        return survey_bricks[
-            (survey_bricks["ra1"] <= ra)
-            & (survey_bricks["ra2"] >= ra)
-            & (survey_bricks["dec1"] <= dec)
-            & (survey_bricks["dec2"] >= dec)
+        return bricks[
+            (bricks["ra1"] <= ra)
+            & (bricks["ra2"] >= ra)
+            & (bricks["dec1"] <= dec)
+            & (bricks["dec2"] >= dec)
         ]["brickname"][0]
 
     def __init__(
@@ -48,9 +49,8 @@ class DarkEnergyCameraLegacySurvey(pl.LightningDataModule, Dataset):
         ra=336.635,
         dec=-0.96,
         # TODO: fix band-indexing after DECaLS E2E
-        bands=(1, 2, 3, 4),  # SDSS.BANDS indexing, for SDSS-trained encoder.
-        predict_device=None,
-        predict_crop=None,
+        bands=(1, 2, 3, 4),  # SDSS.BANDS indexing, for SDSS-trained encoder
+        reference_band: int = 1,  # r-band
     ):
         super().__init__()
 
@@ -60,12 +60,12 @@ class DarkEnergyCameraLegacySurvey(pl.LightningDataModule, Dataset):
         self.bands = bands
         self.brickname = DarkEnergyCameraLegacySurvey.brick_for_radec(ra, dec)
 
-        self.downloader = DecalsDownloader(ra, dec, self.decals_path)
+        self.downloader = DecalsDownloader(self.brickname, self.decals_path)
 
         self.prepare_data()
 
-        self.predict_device = predict_device
-        self.predict_crop = predict_crop
+        self.catalog_cls = DecalsFullCatalog
+        self._predict_batch = {"images": self[0]["image"], "background": self[0]["background"]}
 
     def prepare_data(self):
         for b, bl in enumerate(SDSS.BANDS):
@@ -73,13 +73,22 @@ class DarkEnergyCameraLegacySurvey(pl.LightningDataModule, Dataset):
                 image_filename = self.decals_path / f"legacysurvey-{self.brickname}-image-{bl}.fits"
                 if not Path(image_filename).exists():
                     self.downloader.download_image(bl)
-        self.downloader.download_catalog(self.brickname)
+        self.downloader.download_catalog()
 
     def __len__(self):
         return 1
 
     def __getitem__(self, idx):
         return self.get_from_disk(idx)
+
+    def image_id(self, idx) -> str:
+        return self.brickname
+
+    def idx(self, image_id: str) -> int:
+        return 0
+
+    def image_ids(self) -> List[str]:
+        return [self.brickname]
 
     def get_from_disk(self, idx):
         image_list = []
@@ -99,6 +108,7 @@ class DarkEnergyCameraLegacySurvey(pl.LightningDataModule, Dataset):
                         "image": np.zeros_like(first_target_band_img["image"]).astype(np.float32),
                         "background": first_target_band_img["background"],
                         "wcs": first_target_band_img["wcs"],
+                        "nelec_per_nmgy_list": first_target_band_img["nelec_per_nmgy_list"],
                     }
                 )
 
@@ -125,16 +135,30 @@ class DarkEnergyCameraLegacySurvey(pl.LightningDataModule, Dataset):
                 np.float32
             ),  # TODO: replace with actual background
             "wcs": wcs,
+            "nelec_per_nmgy_list": np.ones(
+                shape=(1, len(self.bands))
+            ),  # TODO: replace with actual ratios
         }
 
-    def predict_dataloader(self):
-        img = prepare_image(self[0]["image"], device=self.predict_device)
-        bg = prepare_image(self[0]["background"], device=self.predict_device)
-        batch = prepare_batch(img, bg, self.predict_crop)
-        return DataLoader([batch], batch_size=1)
+    @property
+    def predict_batch(self):
+        if not self._predict_batch:
+            self._predict_batch = {
+                "images": self[0]["image"],
+                "background": self[0]["background"],
+            }
+        return self._predict_batch
+
+    @predict_batch.setter
+    def predict_batch(self, value):
+        self._predict_batch = value
+
+    def predict_dataloader(self) -> EVAL_DATALOADERS:
+        assert self.predict_batch is not None, "predict_batch must be set."
+        return DataLoader([self.predict_batch], batch_size=1)
 
 
-class DecalsDownloader:
+class DecalsDownloader(SurveyDownloader):
     """Class for downloading DECaLS data."""
 
     URLBASE = "https://portal.nersc.gov/cfs/cosmo/data/legacysurvey/dr9"
@@ -165,13 +189,9 @@ class DecalsDownloader:
             cls.download_survey_bricks()
         return cls._survey_bricks  # pylint: disable=no-member
 
-    def __init__(self, ra, dec, download_dir):
-        self.ra = ra
-        self.dec = dec
+    def __init__(self, brickname, download_dir):
+        self.brickname = brickname
         self.download_dir = download_dir
-
-        # get brick name from (ra, dec) via survey-bricks.fits
-        self.brickname = DarkEnergyCameraLegacySurvey.brick_for_radec(ra, dec)
 
     def download_image(self, band="r"):
         """Download image for specified band, for this brick."""
@@ -188,13 +208,19 @@ class DecalsDownloader:
             )
             raise e
 
-    def download_catalog(self, brickname):
-        """Download tractor catalog for this brick."""
-        tractor_filename = self.download_dir / f"tractor-{brickname}.fits"
+    def download_catalog(self) -> str:
+        """Download tractor catalog for this brick.
+
+        Returns:
+            str: path to downloaded tractor catalog
+        """
+        tractor_filename = Path(self.download_dir) / f"tractor-{self.brickname}.fits"
         download_file_to_dst(
-            f"{DecalsDownloader.URLBASE}/south/tractor/{brickname[:3]}/tractor-{brickname}.fits",
+            f"{DecalsDownloader.URLBASE}/south/tractor/{self.brickname[:3]}/"
+            f"tractor-{self.brickname}.fits",
             tractor_filename,
         )
+        return tractor_filename
 
 
 class DecalsFullCatalog(FullCatalog):
@@ -214,32 +240,29 @@ class DecalsFullCatalog(FullCatalog):
     @classmethod
     def from_file(
         cls,
-        decals_cat_path: str,
-        ra_lim: Tuple[int, int] = (-360, 360),
-        dec_lim: Tuple[int, int] = (-90, 90),
+        cat_path,
+        wcs: WCS,
+        height,
+        width,
         band: str = "r",
-        wcs: WCS = None,
     ):
         """Loads DECaLS catalog from FITS file.
 
         Args:
-            decals_cat_path (str): Path to .fits file.
-            ra_lim (Tuple[int, int]): Range of RA values to keep.
-                Defaults to (-360, 360).
-            dec_lim (Tuple[int, int]): Range of DEC values to keep.
-                Defaults to (-90, 90).
+            cat_path (str): Path to .fits file.
             band (str): Band to read from. Defaults to "r".
-            wcs (WCS): An optional WCS object to use to convert the RA/DEC values to pixel
-                coordinates. If not provided, the returned plocs will all be zero.
+            wcs (WCS): WCS object for the image.
+            height (int): Height of the image.
+            width (int): Width of the image.
 
         Returns:
-            A DecalsFullCatalog containing data from the provided file. Note that the
-            coordinates in (RA, DEC) are not converted to plocs by default. For this,
-            use get_plocs_from_ra_dec after loading the data.
+            A DecalsFullCatalog containing data from the provided file.
         """
-        catalog_path = Path(decals_cat_path)
+        catalog_path = Path(cat_path)
         if not catalog_path.exists():
             DecalsDownloader.download_catalog_from_filename(catalog_path.name)
+        assert catalog_path.exists(), f"File {catalog_path} does not exist"
+
         table = Table.read(catalog_path, format="fits", unit_parse_strict="silent")
         table = {k.upper(): v for k, v in table.items()}  # uppercase keys
         band = band.capitalize()
@@ -259,86 +282,44 @@ class DecalsFullCatalog(FullCatalog):
             | (objc_type == "SER")
         )
         is_star = torch.from_numpy(objc_type == "PSF")
-        ra = column_to_tensor(table, "RA")
-        dec = column_to_tensor(table, "DEC")
-        flux = column_to_tensor(table, f"FLUX_{band}")
+        ras = column_to_tensor(table, "RA")
+        decs = column_to_tensor(table, "DEC")
+        fluxes = column_to_tensor(table, f"FLUX_{band}")
         mask = torch.from_numpy((bits & bitmask) == 0).bool()
 
-        galaxy_bool = is_galaxy & mask & (flux > 0)
-        star_bool = is_star & mask & (flux > 0)
+        galaxy_bools = is_galaxy & mask & (fluxes > 0)
+        star_bools = is_star & mask & (fluxes > 0)
 
-        # filter on locations
-        # first lims imposed on frame
-        keep_coord = (ra > ra_lim[0]) & (ra < ra_lim[1]) & (dec > dec_lim[0]) & (dec < dec_lim[1])
-        keep = (galaxy_bool | star_bool) & keep_coord
+        # true light source mask
+        keep = galaxy_bools | star_bools
 
         # filter quantities
         objid = objid[keep]
-        galaxy_bool = galaxy_bool[keep]
-        star_bool = star_bool[keep]
-        ra = ra[keep]
-        dec = dec[keep]
-        flux = flux[keep]
-        mag = cls._flux_to_mag(flux)
+
+        galaxy_bools = galaxy_bools[keep]
+        star_bools = star_bools[keep]
+        ras = ras[keep]
+        decs = decs[keep]
+        fluxes = fluxes[keep]
+        mags = cls._flux_to_mag(fluxes)
         nobj = objid.shape[0]
 
-        assert torch.all(star_bool + galaxy_bool)
-        source_type = SourceType.STAR * star_bool + SourceType.GALAXY * galaxy_bool
+        # get pixel coordinates
+        plocs = cls.plocs_from_ra_dec(ras, decs, wcs)
+
+        # Verify each tile contains either a star or a galaxy
+        assert torch.all(star_bools + galaxy_bools)
+        source_type = SourceType.STAR * star_bools + SourceType.GALAXY * galaxy_bools
 
         d = {
+            "plocs": plocs.reshape(1, nobj, 2),
             "objid": objid.reshape(1, nobj, 1),
-            "ra": ra.reshape(1, nobj, 1),
-            "dec": dec.reshape(1, nobj, 1),
-            "plocs": torch.zeros((1, nobj, 2)),  # compatibility with FullCatalog
             "n_sources": torch.tensor((nobj,)),
             "source_type": source_type.reshape(1, nobj, 1),
-            "fluxes": flux.reshape(1, nobj, 1),
-            "mags": mag.reshape(1, nobj, 1),
+            "fluxes": fluxes.reshape(1, nobj, 1),
+            "mags": mags.reshape(1, nobj, 1),
+            "ra": ras.reshape(1, nobj, 1),
+            "dec": decs.reshape(1, nobj, 1),
         }
 
-        height = dec_lim[1] - dec_lim[0]
-        width = ra_lim[1] - ra_lim[0]
-        cat = cls(height, width, d)
-
-        # if WCS provided, convert RA/DEC to plocs
-        if wcs is not None:
-            plocs = cat.get_plocs_from_ra_dec(wcs)
-            cat.plocs = plocs
-            cat.height, cat.width = wcs.array_shape
-
-        return cat
-
-    def get_plocs_from_ra_dec(self, wcs: WCS):
-        """Converts RA/DEC coordinates into pixel coordinates.
-
-        Args:
-            wcs (WCS): WCS object to use for transformation.
-
-        Returns:
-            A 1xNx2 tensor containing the locations of the light sources in pixel coordinates. This
-            function does not write self.plocs, so you should do that manually if necessary.
-        """
-        ra = self["ra"].numpy().squeeze()
-        dec = self["dec"].numpy().squeeze()
-
-        pt, pr = wcs.all_world2pix(ra, dec, 0)  # convert to pixel coordinates
-        pt = torch.tensor(pt)
-        pr = torch.tensor(pr)
-        plocs = torch.stack((pr, pt), dim=-1)
-        return plocs.reshape(1, plocs.size()[0], 2) + 0.5  # BLISS consistency
-
-
-# TODO: 3366m010 is hardcoded brick now. Remove this when able to map SDSS RCF -> DECaLS brick.
-def download_decals_base(download_dir: str):
-    cutout_filename = "cutout_336.635_-0.9600.fits"
-    tractor_filename = "tractor-3366m010.fits"
-    cutout = download_git_lfs_file(
-        f"https://api.github.com/repos/prob-ml/bliss/contents/data/decals/{cutout_filename}"
-    )
-    tractor = download_git_lfs_file(
-        f"https://api.github.com/repos/prob-ml/bliss/contents/data/decals/{tractor_filename}"
-    )
-    cutout_path = Path(download_dir) / cutout_filename
-    tractor_path = Path(download_dir) / tractor_filename
-    cutout_path.write_bytes(cutout)
-    tractor_path.write_bytes(tractor)
+        return cls(height, width, d)

--- a/bliss/surveys/decals.py
+++ b/bliss/surveys/decals.py
@@ -20,12 +20,14 @@ from bliss.utils.download_utils import download_file_to_dst, download_git_lfs_fi
 
 class DarkEnergyCameraLegacySurvey(pl.LightningDataModule, Dataset):
     BANDS = ("g", "r", "i", "z")
-    PIX_SCALE = 0.262  # arcsec/pixel
-    PIX_SIZE = 3600  # arcsec/degree
+    PIXEL_SCALE = 0.262
+    PIXEL_SIZE = 3600  # arcsec/degree
 
     @staticmethod
     def pix_to_deg(pix: int) -> float:
-        return pix * DarkEnergyCameraLegacySurvey.PIX_SCALE / DarkEnergyCameraLegacySurvey.PIX_SIZE
+        return (
+            pix * DarkEnergyCameraLegacySurvey.PIXEL_SCALE / DarkEnergyCameraLegacySurvey.PIXEL_SIZE
+        )
 
     @staticmethod
     def brick_for_radec(ra: float, dec: float) -> str:

--- a/bliss/surveys/survey.py
+++ b/bliss/surveys/survey.py
@@ -1,0 +1,76 @@
+import pytorch_lightning as pl
+from torch.utils.data import Dataset
+
+
+class Survey(pl.LightningDataModule, Dataset):
+    def __init__(
+        self,
+        predict_device=None,
+        predict_crop=None,
+    ):
+        super().__init__()
+
+        self.predict_device = predict_device
+        self.predict_crop = predict_crop
+
+        self._prior = None
+        self._background = None
+        self._psf = None
+
+    def prepare_data(self):
+        """pl.LightningDataModule override."""
+        return NotImplemented
+
+    def __len__(self):
+        """Dataset override."""
+        raise NotImplementedError
+
+    def __getitem__(self, idx):
+        """Dataset override."""
+        return NotImplemented
+
+    def image_id(self, idx: int):
+        """Return the image_id for the given index."""
+        return NotImplemented
+
+    def idx(self, image_id):
+        """Return the index for the given image_id."""
+        return NotImplemented
+
+    def image_ids(self):
+        """Return a list of all image_ids."""
+        return NotImplemented
+
+    def predict_dataloader(self):
+        """pl.LightningDataModule override."""
+        return NotImplemented
+
+    @property
+    def prior(self):
+        """Get the prior."""
+        return self._prior
+
+    @prior.setter
+    def prior(self, prior):
+        """Set the prior."""
+        self._prior = prior
+
+    @property
+    def background(self):
+        """Get the image background."""
+        return self._background
+
+    @background.setter
+    def background(self, background):
+        """Set the image background."""
+        self._background = background
+
+    @property
+    def psf(self):
+        """Get the image PSF."""
+        return self._psf
+
+    @psf.setter
+    def psf(self, psf):
+        """Set the image PSF."""
+        self._psf = psf

--- a/bliss/surveys/survey.py
+++ b/bliss/surveys/survey.py
@@ -1,8 +1,10 @@
+from abc import ABC, abstractmethod
+
 import pytorch_lightning as pl
 from torch.utils.data import Dataset
 
 
-class Survey(pl.LightningDataModule, Dataset):
+class Survey(pl.LightningDataModule, Dataset, ABC):
     def __init__(
         self,
         predict_device=None,
@@ -13,64 +15,35 @@ class Survey(pl.LightningDataModule, Dataset):
         self.predict_device = predict_device
         self.predict_crop = predict_crop
 
-        self._prior = None
-        self._background = None
-        self._psf = None
+        self.bands = None
+        self.prior = None
+        self.background = None
+        self.psf = None
 
+    @abstractmethod
     def prepare_data(self):
         """pl.LightningDataModule override."""
-        return NotImplemented
 
+    @abstractmethod
     def __len__(self):
         """Dataset override."""
-        raise NotImplementedError
 
+    @abstractmethod
     def __getitem__(self, idx):
         """Dataset override."""
-        return NotImplemented
 
+    @abstractmethod
     def image_id(self, idx: int):
         """Return the image_id for the given index."""
-        return NotImplemented
 
+    @abstractmethod
     def idx(self, image_id):
         """Return the index for the given image_id."""
-        return NotImplemented
 
+    @abstractmethod
     def image_ids(self):
         """Return a list of all image_ids."""
-        return NotImplemented
 
+    @abstractmethod
     def predict_dataloader(self):
         """pl.LightningDataModule override."""
-        return NotImplemented
-
-    @property
-    def prior(self):
-        """Get the prior."""
-        return self._prior
-
-    @prior.setter
-    def prior(self, prior):
-        """Set the prior."""
-        self._prior = prior
-
-    @property
-    def background(self):
-        """Get the image background."""
-        return self._background
-
-    @background.setter
-    def background(self, background):
-        """Set the image background."""
-        self._background = background
-
-    @property
-    def psf(self):
-        """Get the image PSF."""
-        return self._psf
-
-    @psf.setter
-    def psf(self, psf):
-        """Set the image PSF."""
-        self._psf = psf

--- a/bliss/surveys/survey.py
+++ b/bliss/surveys/survey.py
@@ -5,20 +5,15 @@ from torch.utils.data import Dataset
 
 
 class Survey(pl.LightningDataModule, Dataset, ABC):
-    def __init__(
-        self,
-        predict_device=None,
-        predict_crop=None,
-    ):
+    def __init__(self):
         super().__init__()
-
-        self.predict_device = predict_device
-        self.predict_crop = predict_crop
 
         self.bands = None
         self.prior = None
         self.background = None
         self.psf = None
+
+        self.catalog_cls = None  # TODO: better way than `survey.catalog_cls`?
 
     @abstractmethod
     def prepare_data(self):
@@ -44,6 +39,18 @@ class Survey(pl.LightningDataModule, Dataset, ABC):
     def image_ids(self):
         """Return a list of all image_ids."""
 
+    @property
     @abstractmethod
-    def predict_dataloader(self):
-        """pl.LightningDataModule override."""
+    def predict_batch(self):
+        """Return a batch of data for prediction."""
+
+    @predict_batch.setter
+    @abstractmethod
+    def predict_batch(self):
+        """Set a batch of data for prediction."""
+
+
+class SurveyDownloader:
+    def download_catalog(self) -> str:
+        """Download the catalog and return the path to the catalog file."""
+        raise NotImplementedError

--- a/bliss/utils/download_utils.py
+++ b/bliss/utils/download_utils.py
@@ -65,10 +65,12 @@ def download_git_lfs_file(url, headers: Optional[Dict[str, str]] = None) -> byte
 
 
 def download_file_to_dst(url, dst_filename, preprocess_fn=lambda x: x):  # noqa: WPS404
-    if Path(dst_filename).exists():
+    dst_path = Path(dst_filename)
+    if dst_path.exists():
         return
 
-    filename = download_file(url, cache=True, show_progress=False, timeout=10)
+    filename = download_file(url, cache=False, show_progress=False, timeout=10)
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(filename, dst_filename)
     with open(dst_filename, "rb") as f:
         file_contents = f.read()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,8 @@ def encoder(cfg):
 
 @pytest.fixture(scope="session")
 def decoder(cfg):
-    return instantiate(cfg.simulator.decoder)
+    simulator = instantiate(cfg.simulator)
+    return simulator.image_decoder
 
 
 @pytest.fixture(scope="session")

--- a/tests/mock_tests.py
+++ b/tests/mock_tests.py
@@ -102,7 +102,7 @@ def mock_checkpoint_callback(*args, **kwargs):
     return MockCallback()
 
 
-def mock_predict_sdss(cfg, *args, **kwargs):
+def mock_predict(cfg, *args, **kwargs):
     test_data_path = "data/tests"
 
     # copy prediction file to temp directory so tests can find it
@@ -113,4 +113,4 @@ def mock_predict_sdss(cfg, *args, **kwargs):
     with open(test_data_path + "/sdss_preds.pt", "rb") as f:
         data = torch.load(f)
     tile_cat = TileCatalog(cfg.simulator.survey.prior_config.tile_slen, data["catalog"])
-    return tile_cat, data["image"], data["background"], None, data["pred"]
+    return tile_cat.to_full_params(), data["image"], data["background"], None, data["pred"]

--- a/tests/mock_tests.py
+++ b/tests/mock_tests.py
@@ -112,5 +112,5 @@ def mock_predict_sdss(cfg, *args, **kwargs):
     # return catalog and preds like predict_sdss
     with open(test_data_path + "/sdss_preds.pt", "rb") as f:
         data = torch.load(f)
-    tile_cat = TileCatalog(cfg.simulator.prior.tile_slen, data["catalog"])
+    tile_cat = TileCatalog(cfg.simulator.survey.prior_config.tile_slen, data["catalog"])
     return tile_cat, data["image"], data["background"], None, data["pred"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,7 +52,7 @@ class TestApi:
         assert Path(f"{cached_data_path}/hparams.yaml").exists()
         assert Path(f"{cached_data_path}/dataset_0.pt").exists()
         assert Path(f"{cached_data_path}/dataset_1.pt").exists()
-        assert not Path(f"{cached_data_path}/dataset2.pt").exists()
+        assert not Path(f"{cached_data_path}/dataset_2.pt").exists()
 
         # need generated data to test get_dataset_file
         dataset0 = bliss_client.get_dataset_file(filename="dataset_0.pt")
@@ -126,7 +126,7 @@ class TestApi:
         ).exists()
 
     def test_predict_sdss_default_rcf(self, bliss_client, monkeypatch):
-        monkeypatch.setattr(api, "_predict_sdss", mock_tests.mock_predict_sdss)
+        monkeypatch.setattr(api, "_predict", mock_tests.mock_predict)
         # cached predict data copied to temp dir in mock_tests.mock_predict_sdss
         cat, cat_table, pred_table = bliss_client.predict_sdss("test_path")
         assert isinstance(cat, FullCatalog)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,12 +16,14 @@ from bliss.catalog import FullCatalog, SourceType
 def bliss_client(cfg, tmpdir_factory):
     cwd = str(tmpdir_factory.mktemp("cwd"))
     client = BlissClient(cwd)
-    mock_tests.MockSDSSDownloader(
-        run=cfg.datasets.sdss.run,
-        camcol=cfg.datasets.sdss.camcol,
-        fields=cfg.datasets.sdss.fields,
-        download_dir=cwd + "/data/sdss",
-    )
+    for sdss_field in cfg.surveys.sdss.sdss_fields:
+        run, camcol, fields = sdss_field.values()
+        mock_tests.MockSDSSDownloader(
+            run=run,
+            camcol=camcol,
+            fields=fields,
+            download_dir=cwd + "/data/sdss",
+        )
     # Hack to apply select conftest.py overrides, since client.base_cfg should be private
     overrides = {
         "training.trainer.accelerator": cfg.training.trainer.accelerator,
@@ -85,7 +87,7 @@ class TestApi:
         assert Path(f"{model_path}.log.json").exists()
 
     def test_train_on_cached_data(self, bliss_client):
-        simulator_cfg = {"cached_data_path": "data/tests/multiband_data"}
+        cached_simulator_cfg = {"cached_data_path": "data/tests/multiband_data"}
         training_cfg = {
             "n_epochs": 1,
             "trainer": {"check_val_every_n_epoch": 1, "log_every_n_steps": 1},
@@ -97,7 +99,7 @@ class TestApi:
             batch_size=8,
             val_split_file_idxs=[1],
             test_split_file_idxs=[1],
-            cached_simulator=simulator_cfg,
+            cached_simulator=cached_simulator_cfg,
             training=training_cfg,
         )
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -39,10 +39,14 @@ class TestGenerate:
                 len(cached_dataset[0]["images"]) == 5
             ), "cached_dataset[0]['images'] must be a 5-D tensor"
             assert cached_dataset[0]["images"][0].shape == (
-                cfg.simulator.prior.n_tiles_h * cfg.simulator.prior.tile_slen,
-                cfg.simulator.prior.n_tiles_w * cfg.simulator.prior.tile_slen,
+                cfg.simulator.survey.prior_config.n_tiles_h
+                * cfg.simulator.survey.prior_config.tile_slen,
+                cfg.simulator.survey.prior_config.n_tiles_w
+                * cfg.simulator.survey.prior_config.tile_slen,
             )
             assert cached_dataset[0]["background"][0].shape == (
-                cfg.simulator.prior.n_tiles_h * cfg.simulator.prior.tile_slen,
-                cfg.simulator.prior.n_tiles_w * cfg.simulator.prior.tile_slen,
+                cfg.simulator.survey.prior_config.n_tiles_h
+                * cfg.simulator.survey.prior_config.tile_slen,
+                cfg.simulator.survey.prior_config.n_tiles_w
+                * cfg.simulator.survey.prior_config.tile_slen,
             )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,19 +6,21 @@ from bliss.catalog import FullCatalog, TileCatalog
 from bliss.metrics import BlissMetrics, MetricsMode, three_way_matching
 from bliss.predict import align, prepare_image
 from bliss.surveys.decals import DecalsFullCatalog
-from bliss.surveys.sdss import PhotoFullCatalog, SloanDigitalSkySurvey
+from bliss.surveys.sdss import PhotoFullCatalog
 
 
 class TestMetrics:
     def _get_sdss_data(self, cfg):
         """Loads SDSS frame and Photo Catalog."""
-        sdss = SloanDigitalSkySurvey(cfg.paths.sdss, 94, 1, (12,))
+        sdss = instantiate(cfg.surveys.sdss)
 
+        sdss_fields = cfg.predict.dataset.sdss_fields
+        run, camcol, fields = sdss_fields[0].values()
         photo_cat = PhotoFullCatalog.from_file(
             cfg.paths.sdss,
-            run=cfg.predict.dataset.run,
-            camcol=cfg.predict.dataset.camcol,
-            field=cfg.predict.dataset.fields[0],
+            run=run,
+            camcol=camcol,
+            field=fields[0],
             sdss_obj=sdss,
         )
         return photo_cat, sdss
@@ -77,7 +79,7 @@ class TestMetrics:
     def tile_catalog(self, cfg, multiband_dataloader):
         """Generate a tile catalog for testing classification metrics."""
         tile_cat = next(iter(multiband_dataloader))["tile_catalog"]
-        return TileCatalog(cfg.simulator.prior.tile_slen, tile_cat)
+        return TileCatalog(cfg.simulator.survey.prior_config.tile_slen, tile_cat)
 
     def test_metrics(self):
         """Tests basic computations using simple toy data."""

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,12 +1,14 @@
 import numpy as np
 import pytest
 import torch
+from hydra.utils import instantiate
 
 from bliss.catalog import FullCatalog, TileCatalog
 from bliss.metrics import BlissMetrics, MetricsMode, three_way_matching
 from bliss.predict import align, prepare_image
 from bliss.surveys.decals import DecalsFullCatalog
 from bliss.surveys.sdss import PhotoFullCatalog
+from bliss.surveys.sdss import SloanDigitalSkySurvey as SDSS
 
 
 class TestMetrics:
@@ -14,14 +16,13 @@ class TestMetrics:
         """Loads SDSS frame and Photo Catalog."""
         sdss = instantiate(cfg.surveys.sdss)
 
-        sdss_fields = cfg.predict.dataset.sdss_fields
-        run, camcol, fields = sdss_fields[0].values()
+        run, camcol, field = sdss.image_id(0)
         photo_cat = PhotoFullCatalog.from_file(
-            cfg.paths.sdss,
-            run=run,
-            camcol=camcol,
-            field=fields[0],
-            sdss_obj=sdss,
+            cat_path=cfg.paths.sdss
+            + f"/{run}/{camcol}/{field}/photoObj-{run:06d}-{camcol}-{field:04d}.fits",
+            wcs=sdss[0]["wcs"][cfg.predict.dataset.reference_band],
+            height=sdss[0]["image"].shape[1],
+            width=sdss[0]["image"].shape[2],
         )
         return photo_cat, sdss
 
@@ -30,8 +31,8 @@ class TestMetrics:
         image = sdss[0]["image"]
         background = sdss[0]["background"]
 
-        image = align(image, sdss[0]["wcs"])
-        background = align(background, sdss[0]["wcs"])
+        image = align(image, sdss[0]["wcs"], SDSS.BANDS.index("r"))
+        background = align(background, sdss[0]["wcs"], SDSS.BANDS.index("r"))
 
         # crop to center fourth
         height, width = image[0].shape
@@ -51,11 +52,11 @@ class TestMetrics:
         wcs = sdss[0]["wcs"][2]
         image, background, w_lim, h_lim = self._get_image_and_background(sdss)
 
-        # get RA/DEC limits of cropped image and construct catalogs
+        # get RA/DEC limits of cropped image and construct d
         ra_lim, dec_lim = wcs.all_pix2world(w_lim, h_lim, 0)
         photo_cat = base_photo_cat.restrict_by_ra_dec(ra_lim, dec_lim).to(torch.device("cpu"))
         decals_path = cfg.predict.decals_frame
-        decals_cat = DecalsFullCatalog.from_file(decals_path, ra_lim, dec_lim, wcs=wcs)
+        decals_cat = DecalsFullCatalog.from_file(decals_path, wcs, image.shape[1], image.shape[2])
         decals_cat = decals_cat.to(torch.device("cpu"))
 
         # get predicted BLISS catalog

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,22 +1,26 @@
-from bliss.predict import predict_decals, predict_sdss
+from bliss.predict import predict
 
 
 class TestPredict:
     def test_predict_sdss(self, cfg):
         the_cfg = cfg.copy()
         the_cfg.predict.plot.show_plot = True
-        predict_sdss(the_cfg)
+        predict(the_cfg)
+
+        # TODO: test output of predictions plot
 
     def test_predict_sdss_single_band(self, cfg):
         the_cfg = cfg.copy()
         the_cfg.predict.plot.show_plot = True
         the_cfg.encoder.bands = [2]
         the_cfg.predict.weight_save_path = "${paths.pretrained_models}/single_band_base.pt"
-        predict_sdss(the_cfg)
+        predict(the_cfg)
+
+        # TODO: test output of predictions plot
 
     def test_predict_decals(self, cfg):
         the_cfg = cfg.copy()
         the_cfg.predict.dataset = cfg.surveys.decals
         the_cfg.encoder.bands = [2]
         the_cfg.predict.weight_save_path = "${paths.pretrained_models}/single_band_base.pt"
-        predict_decals(the_cfg)
+        predict(the_cfg)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -16,7 +16,7 @@ class TestPredict:
 
     def test_predict_decals(self, cfg):
         the_cfg = cfg.copy()
-        the_cfg.predict.dataset = cfg.datasets.decals
+        the_cfg.predict.dataset = cfg.surveys.decals
         the_cfg.encoder.bands = [2]
         the_cfg.predict.weight_save_path = "${paths.pretrained_models}/single_band_base.pt"
         predict_decals(the_cfg)

--- a/tests/test_sdss.py
+++ b/tests/test_sdss.py
@@ -1,18 +1,13 @@
 import numpy as np
 import pytest
-
-from bliss.surveys.sdss import SloanDigitalSkySurvey
+from hydra.utils import instantiate
 
 
 class TestSDSS:
     def test_sdss(self, cfg):
-        sdss_dir = cfg.paths.sdss
-        sdss_obj = SloanDigitalSkySurvey(
-            sdss_dir,
-            run=3900,
-            camcol=6,
-            fields=[269],
-        )
+        the_cfg = cfg.copy()
+        the_cfg.surveys.sdss.sdss_fields = [{"run": 3900, "camcol": 6, "fields": [269]}]
+        sdss_obj = instantiate(the_cfg.surveys.sdss)
         an_obj = sdss_obj[0]
         for k in ("image", "background", "gain", "nelec_per_nmgy_list", "calibration"):
             assert isinstance(an_obj[k], np.ndarray)

--- a/tests/test_sdss.py
+++ b/tests/test_sdss.py
@@ -15,3 +15,9 @@ class TestSDSS:
         assert an_obj["field"] == 269
         assert an_obj["gain"][3] == pytest.approx(4.76)
         assert isinstance(an_obj["wcs"], list)
+
+    def test_sdss_custom_dir(self, cfg, tmpdir_factory):
+        the_cfg = cfg.copy()
+        the_cfg.paths.root = str(tmpdir_factory.mktemp("root"))
+        sdss_obj = instantiate(the_cfg.surveys.sdss)[0]
+        assert sdss_obj["image"].shape == (5, 1489, 2048)

--- a/tests/test_sdss_reconstruct.py
+++ b/tests/test_sdss_reconstruct.py
@@ -1,17 +1,18 @@
 import numpy as np
-from hydra.utils import instantiate
-from mock_tests import mock_predict_sdss
+from mock_tests import mock_predict
 
 
 class TestSdssReconstruct:
     def test_sdss_reconstruct(self, cfg, decoder):
-        est_tile, true_img, true_bg, _, _ = mock_predict_sdss(cfg)
+        est_tile, true_img, true_bg, _, _ = mock_predict(cfg)
 
         # reconstruction test only considers r-band image/catalog params
-        simulator = instantiate(cfg.simulator)
-        decoder = simulator.image_decoder
         rcfs = np.array([[94, 1, 12]])
-        imgs = decoder.render_images(est_tile.to("cpu"), rcfs)
+        tile_cat = est_tile.to_tile_params(
+            tile_slen=cfg.simulator.survey.prior_config.tile_slen,
+            max_sources_per_tile=cfg.simulator.survey.prior_config.max_sources,
+        )
+        imgs = decoder.render_images(tile_cat.to("cpu"), rcfs)
         recon_img = imgs[0][0, 2]  # r_band
 
         ptc = cfg.encoder.tile_slen * cfg.encoder.tiles_to_crop

--- a/tests/test_sdss_reconstruct.py
+++ b/tests/test_sdss_reconstruct.py
@@ -1,4 +1,5 @@
 import numpy as np
+from hydra.utils import instantiate
 from mock_tests import mock_predict_sdss
 
 
@@ -7,6 +8,8 @@ class TestSdssReconstruct:
         est_tile, true_img, true_bg, _, _ = mock_predict_sdss(cfg)
 
         # reconstruction test only considers r-band image/catalog params
+        simulator = instantiate(cfg.simulator)
+        decoder = simulator.image_decoder
         rcfs = np.array([[94, 1, 12]])
         imgs = decoder.render_images(est_tile.to("cpu"), rcfs)
         recon_img = imgs[0][0, 2]  # r_band

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -6,8 +6,8 @@ from pytorch_lightning.utilities.types import EVAL_DATALOADERS
 from torch.utils.data import DataLoader
 
 from bliss.catalog import TileCatalog
+from bliss.predict import crop_image
 from bliss.surveys.sdss import SloanDigitalSkySurvey as SDSS
-from bliss.surveys.sdss import prepare_batch
 
 
 class SDSSTest(pl.LightningDataModule):
@@ -18,7 +18,10 @@ class SDSSTest(pl.LightningDataModule):
 
     def predict_dataloader(self) -> EVAL_DATALOADERS:
         images, background = self.items[0].values()
-        batch = prepare_batch(images, background, self.cfg.predict.dataset.predict_crop)
+        images, background = crop_image(images, background, self.cfg.predict.crop)
+        batch = {"images": images, "background": background}
+        batch["images"] = batch["images"].squeeze(0)
+        batch["background"] = batch["background"].squeeze(0)
         return DataLoader([batch], batch_size=1)
 
 

--- a/tests/testing_config.yaml
+++ b/tests/testing_config.yaml
@@ -7,19 +7,6 @@ simulator:
     valid_n_batches: 1
     n_batches: 2
     num_workers: 0
-    sdss_fields:
-        dir: ${paths.sdss}
-        bands: [0, 1, 2, 3, 4]
-        field_list:  # list of dictionaries, each with run, camcol, and list of fields
-          - run: 94
-            camcol: 1
-            fields: [12]
-    prior:
-        n_tiles_h: 4
-        n_tiles_w: 4
-        batch_size: 2
-        prob_galaxy: 0.5
-        star_flux_min: 1e5
 
 cached_simulator:
     num_workers: 0
@@ -61,3 +48,17 @@ predict:
         height: 160
     plot:
         show_plot: false
+
+surveys:
+    sdss:
+        sdss_dir: ${paths.sdss}
+        sdss_fields:  # list of dictionaries, each with run, camcol, and list of fields
+            - run: 94
+              camcol: 1
+              fields: [12]
+        prior_config:
+            n_tiles_h: 4
+            n_tiles_w: 4
+            batch_size: 2
+            prob_galaxy: 0.5
+            star_flux_min: 1e5


### PR DESCRIPTION
Generalize Bliss E2E flow to different surveys
    
Key idea is `image_id` now denotes the survey-specific image-identifying data structure that abstracts away survey-specific details from Bliss end-to-end generation, training, prediction functions.
    
However, the new change more tightly couples survey dataset (e.g., `SloanDigitalSkySurvey`) with its constituent/related modules `ImageDecoder`, `ImagePrior`, and `ImagePointSpreadFunction`; of note here is that `ImageDecoder` cannot now be as easily instantiated via `instantiate(cfg.simulator.decoder)` as before.

Fixes #853.

P.S. Tagged everyone because this is a large refactor that probably will touch some part of code that people have worked on before and are actively working on now.