### PR TITLE
Miscellaneous fixes

### DIFF
--- a/bliss/api.py
+++ b/bliss/api.py
@@ -218,7 +218,6 @@ class BlissClient:
 
 def fullcat_to_astropy_table(est_cat: FullCatalog):
     required_keys = [
-        "star_log_fluxes",
         "star_fluxes",
         "source_type",
         "galaxy_params",
@@ -238,12 +237,10 @@ def fullcat_to_astropy_table(est_cat: FullCatalog):
             on_vals[k] = v[is_on_mask].cpu()
     # Split to different columns for each band
     for b, bl in enumerate(SloanDigitalSkySurvey.BANDS):
-        on_vals[f"star_log_flux_{bl}"] = on_vals["star_log_fluxes"][..., b]
         on_vals[f"star_flux_{bl}"] = on_vals["star_fluxes"][..., b]
         on_vals[f"galaxy_flux_{bl}"] = on_vals["galaxy_fluxes"][..., b]
     # Remove combined flux columns
     on_vals.pop("star_fluxes")
-    on_vals.pop("star_log_fluxes")
     on_vals.pop("galaxy_fluxes")
     n = is_on_mask.sum()  # number of (predicted) objects
     rows = [{k: v[i].cpu() for k, v in on_vals.items()} for i in range(n)]
@@ -252,7 +249,6 @@ def fullcat_to_astropy_table(est_cat: FullCatalog):
     est_cat_table = Table(rows)
     # Convert all _fluxes columns to u.Quantity
     for bl in SloanDigitalSkySurvey.BANDS:
-        est_cat_table[f"star_log_flux_{bl}"].unit = u.LogUnit(u.nmgy)
         est_cat_table[f"star_flux_{bl}"].unit = u.nmgy
         est_cat_table[f"galaxy_flux_{bl}"].unit = u.nmgy
 
@@ -323,8 +319,8 @@ def pred_to_astropy_table(pred: Dict[str, Tensor]) -> Table:
     # convert values to astropy units
     bands = SloanDigitalSkySurvey.BANDS  # NOTE: SDSS-specific!
     for bnd in bands:
-        pred_table[f"star_log_flux {bnd}_mean"].unit = u.LogUnit(u.nmgy)
-        pred_table[f"star_log_flux {bnd}_std"].unit = u.LogUnit(u.nmgy)
+        pred_table[f"star_flux_{bnd}_mean"].unit = u.nmgy
+        pred_table[f"star_flux_{bnd}_std"].unit = u.nmgy
         pred_table[f"galaxy_flux_{bnd}_mean"].unit = u.nmgy
         pred_table[f"galaxy_flux_{bnd}_std"].unit = u.nmgy
 

--- a/bliss/api.py
+++ b/bliss/api.py
@@ -228,7 +228,9 @@ def fullcat_to_astropy_table(est_cat: FullCatalog):
     # Convert dictionary of tensors to list of dictionaries
     on_vals = {}
     is_on_mask = est_cat.get_is_on_mask()
-    for k, v in est_cat.items():
+    for k, v in est_cat.to_dict().items():
+        if k == "n_sources":
+            continue
         if k == "galaxy_params":
             # reshape get_is_on_mask() to have same last dimension as galaxy_params
             galaxy_params_mask = is_on_mask.unsqueeze(-1).expand_as(v)

--- a/bliss/catalog.py
+++ b/bliss/catalog.py
@@ -6,7 +6,6 @@ from typing import Dict, Tuple
 
 import torch
 from einops import rearrange, reduce, repeat
-from matplotlib.pyplot import Axes
 from torch import Tensor
 
 
@@ -460,16 +459,3 @@ class FullCatalog(UserDict):
                 tile_n_sources[ii, coords[0], coords[1]] = source_idx + 1
         tile_params.update({"locs": tile_locs, "n_sources": tile_n_sources})
         return TileCatalog(tile_slen, tile_params)
-
-    def plot_plocs(self, ax: Axes, idx: int, object_type: str, bp: int = 0, **kwargs):
-        if object_type == "galaxy":
-            keep = self.galaxy_bools[idx, :].squeeze(-1).bool()
-        elif object_type == "star":
-            keep = self.star_bools[idx, :].squeeze(-1).bool()
-        elif object_type == "all":
-            keep = torch.ones(self.max_sources, dtype=torch.bool, device=self.plocs.device)
-        else:
-            raise NotImplementedError()
-        plocs = self.plocs[idx, keep] - 0.5 + bp
-        plocs = plocs.detach().cpu()
-        ax.scatter(plocs[:, 1], plocs[:, 0], **kwargs)

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -97,14 +97,11 @@ def predict_sdss(cfg):
 
 
 def nelec_to_nmgy_for_catalog(est_cat, nelec_per_nmgy_per_band):
-    log_fluxes_suffix = "_log_fluxes"
     fluxes_suffix = "_fluxes"
     # reshape nelec_per_nmgy_per_band to (1, {n_bands}) to broadcast
     nelec_per_nmgy_per_band = nelec_per_nmgy_per_band.reshape(1, -1)
     for key in est_cat.keys():
-        if key.endswith(log_fluxes_suffix):
-            est_cat[key] = torch.tensor(np.array(est_cat[key]) - np.log(nelec_per_nmgy_per_band))
-        elif key.endswith(fluxes_suffix):
+        if key.endswith(fluxes_suffix):
             est_cat[key] = torch.tensor(np.array(est_cat[key]) / nelec_per_nmgy_per_band)
         elif key == "galaxy_params":
             clone = est_cat[key].clone()

--- a/bliss/simulator/prior.py
+++ b/bliss/simulator/prior.py
@@ -134,7 +134,6 @@ class ImagePrior(pl.LightningModule):
 
         galaxy_fluxes, galaxy_params = self._sample_galaxy_prior(select_gal_rcfs)
         star_fluxes = self._sample_star_fluxes(select_star_rcfs)
-        star_log_fluxes = star_fluxes.log()
 
         n_sources = self._sample_n_sources()
         source_type = self._sample_source_type()
@@ -146,7 +145,6 @@ class ImagePrior(pl.LightningModule):
             "galaxy_fluxes": galaxy_fluxes,
             "galaxy_params": galaxy_params,
             "star_fluxes": star_fluxes,
-            "star_log_fluxes": star_log_fluxes,
         }
 
         return TileCatalog(self.tile_slen, catalog_params)

--- a/data/tests/multiband_data/dataset_0.pt
+++ b/data/tests/multiband_data/dataset_0.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1283d67f255a86173197c666f37dd9fa6a2f48eb2dc2050f3824ed75986563a
-size 6859545
+oid sha256:ff3262e196cb9653bac9596719bc3d4c0be5e61342b75d2fe7f2c45d776e11a8
+size 142599

--- a/data/tests/multiband_data/dataset_1.pt
+++ b/data/tests/multiband_data/dataset_1.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ecd2872f6ab738bb5f8e45a6fa51ae3e96a7aac2d0529c4220b39eb216dbf2ad
-size 6859545
+oid sha256:82dfd12399d5980cba6891cf3c82df13e859ad689d00678cbe2b867a2a0c730d
+size 142599

--- a/data/tests/sdss_preds.pt
+++ b/data/tests/sdss_preds.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6eeadc14db16a7c159cc9fad6294c7b83a46a8eb5d4255c6b496136c974854a8
-size 1574315
+oid sha256:3c2b415c3fe61a8229f153d22f5729f5122daa825beb30198eaf7953bde5eb1e
+size 1551947

--- a/data/tests/sdss_preds.pt
+++ b/data/tests/sdss_preds.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c2b415c3fe61a8229f153d22f5729f5122daa825beb30198eaf7953bde5eb1e
-size 1551947
+oid sha256:1495585aade4d2e91274413aed75869f3f30e143a8451db6c40ab9bc1df3bb1d
+size 1574158

--- a/data/tests/test_multi_source.pt
+++ b/data/tests/test_multi_source.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c097894deec443086f0686d60b6111892e55a96e9324b1e83ba7184c44ed3bf
+size 152839

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 from hydra import compose, initialize
 from hydra.utils import instantiate
+from torch.utils.data import DataLoader
 
 
 # command line arguments for tests
@@ -58,3 +59,17 @@ def encoder(cfg):
 @pytest.fixture(scope="session")
 def decoder(cfg):
     return instantiate(cfg.simulator.decoder)
+
+
+@pytest.fixture(scope="session")
+def multiband_dataloader(cfg):
+    with open(cfg.paths.data + "/tests/multiband_data/dataset_0.pt", "rb") as f:
+        data = torch.load(f)
+    return DataLoader(data, batch_size=8, shuffle=False)
+
+
+@pytest.fixture(scope="session")
+def multi_source_dataloader(cfg):
+    with open(cfg.paths.data + "/tests/test_multi_source.pt", "rb") as f:
+        data = torch.load(f)
+    return DataLoader(data, batch_size=8, shuffle=False)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -136,6 +136,7 @@ class TestApi:
 
         # check that cat_table, gal_params_table contains all expected columns
         expected_table_columns = [
+            "plocs",
             "star_flux_u",
             "star_flux_g",
             "star_flux_r",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -136,11 +136,6 @@ class TestApi:
 
         # check that cat_table, gal_params_table contains all expected columns
         expected_table_columns = [
-            "star_log_flux_u",
-            "star_log_flux_g",
-            "star_log_flux_r",
-            "star_log_flux_i",
-            "star_log_flux_z",
             "star_flux_u",
             "star_flux_g",
             "star_flux_r",
@@ -163,14 +158,10 @@ class TestApi:
             col in cat_table.colnames for col in expected_table_columns
         ), "cat_table missing columns"
 
-        # check that cat_table, gal_params_table fluxes and log_fluxes in correct order of
-        # magnitude (i.e., O(10^1) / O(10^2) for fluxes, O(10^0) for log_fluxes)
+        # check that fluxes are in correct order of magnitude (i.e., O(10^1) / O(10^2))
         assert np.all(
             np.log10(cat_table["star_flux_u"].value) <= 2
         ), "star_fluxes_u not O(10^1); ensure units are in nmgy"
-        assert np.all(
-            np.log10(cat_table["star_log_flux_u"].value) <= 1
-        ), "star_log_fluxes_u not O(10^0); ensure units are in log(nmgy)"
         assert np.all(
             np.log10(cat_table["galaxy_flux_u"].value) <= 3
         ), "galaxy_flux_u not O(10^1); ensure units are in nmgy"
@@ -186,7 +177,6 @@ class TestApi:
             "mags": torch.tensor([[[0.0]]]),
             "ra": torch.tensor([[[0.0]]]),
             "dec": torch.tensor([[[0.0]]]),
-            "star_log_fluxes": torch.tensor([[[0.0, 0.0, 0.0, 0.0, 0.0]]]),
             "star_fluxes": torch.tensor([[[0.0, 0.0, 0.0, 0.0, 0.0]]]),
             "source_type": torch.tensor([[[SourceType.STAR]]]),
             "galaxy_params": torch.rand(1, 1, 6),

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,0 +1,26 @@
+import torch
+from hydra.utils import instantiate
+
+
+class TestEncoder:
+    def test_encode_multi_source_catalog(self, cfg, multi_source_dataloader, encoder):
+        batch = next(iter(multi_source_dataloader))
+        for key, val in batch.items():
+            if isinstance(val, torch.Tensor):
+                batch[key] = val.to(cfg.predict.device)
+        pred = encoder.encode_batch(batch)
+        encoder.variational_mode(pred)
+
+    def test_encode_with_psf(self, cfg, multiband_dataloader):
+        batch = next(iter(multiband_dataloader))
+        for key, val in batch.items():
+            if isinstance(val, torch.Tensor):
+                batch[key] = val.to(cfg.predict.device)
+
+        encoder_params = {
+            "bands": [2],
+            "input_transform_params": {"use_deconv_channel": True, "concat_psf_params": True},
+        }
+        encoder = instantiate(cfg.encoder, **encoder_params).to(cfg.predict.device)
+        pred = encoder.encode_batch(batch)
+        encoder.variational_mode(pred)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 import torch
-from torch.utils.data import DataLoader
 
 from bliss.catalog import FullCatalog, TileCatalog
 from bliss.metrics import BlissMetrics, MetricsMode
@@ -75,12 +74,9 @@ class TestMetrics:
         return {"decals": decals_cat, "photo": photo_cat, "bliss": bliss_cat}
 
     @pytest.fixture(scope="class")
-    def tile_catalog(self, cfg):
+    def tile_catalog(self, cfg, multiband_dataloader):
         """Generate a tile catalog for testing classification metrics."""
-        with open("data/tests/multiband_data/dataset_0.pt", "rb") as f:
-            data = torch.load(f)
-        dataloader = DataLoader(data, batch_size=cfg.simulator.prior.batch_size, shuffle=False)
-        tile_cat = next(iter(dataloader))["tile_catalog"]
+        tile_cat = next(iter(multiband_dataloader))["tile_catalog"]
         return TileCatalog(cfg.simulator.prior.tile_slen, tile_cat)
 
     def test_metrics(self):

--- a/tests/test_sdss_reconstruct.py
+++ b/tests/test_sdss_reconstruct.py
@@ -1,16 +1,14 @@
 import numpy as np
-from hydra.utils import instantiate
 from mock_tests import mock_predict_sdss
 
 
 class TestSdssReconstruct:
-    def test_sdss_reconstruct(self, cfg):
+    def test_sdss_reconstruct(self, cfg, decoder):
         est_tile, true_img, true_bg, _, _ = mock_predict_sdss(cfg)
 
         # reconstruction test only considers r-band image/catalog params
-        decoder_obj = instantiate(cfg.simulator.decoder)
         rcfs = np.array([[94, 1, 12]])
-        imgs = decoder_obj.render_images(est_tile.to("cpu"), rcfs)
+        imgs = decoder.render_images(est_tile.to("cpu"), rcfs)
         recon_img = imgs[0][0, 2]  # r_band
 
         ptc = cfg.encoder.tile_slen * cfg.encoder.tiles_to_crop

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -24,7 +24,7 @@ class SDSSTest(pl.LightningDataModule):
 
 
 class TestSimulate:
-    def test_simulate(self, cfg):
+    def test_simulate(self, cfg, encoder):
         # loads single r-band model with correct number of outputs
         sim_dataset = instantiate(cfg.simulator)
         sim_tile = torch.load(cfg.paths.data + "/tests/test_image/dataset_0.pt")
@@ -40,9 +40,6 @@ class TestSimulate:
         background = background.to(cfg.predict.device)
 
         sdss_test = SDSSTest(image, background, cfg)
-        encoder = instantiate(cfg.encoder).to(cfg.predict.device)
-        enc_state_dict = torch.load(cfg.predict.weight_save_path)
-        encoder.load_state_dict(enc_state_dict)
         encoder.eval()
         trainer = instantiate(cfg.predict.trainer)
         est_tile = trainer.predict(encoder, datamodule=sdss_test)[0]["est_cat"].to(


### PR DESCRIPTION
Fixes #863, #864, #866, and #868.

Main changes:
- We now model the star fluxes in the variational distribution as a `LogNormal`, instead of modeling the log fluxes as a `Normal` distribution. This is consistent with galaxy fluxes, which are modeled as `LogNormal`.
- `plot_plocs` has been moved to `plotting.py`, and now accepts either a string or a list of indices to determine which sources to plot
- Added `plocs` to the astropy table returned in `api.fullcat_to_astropy_table`. This was missed initially since `plocs` isn't in the dictionary, so isn't found in `catalog.items()`.

Minor changes:
- Added tests for using the deconvolution/psf params to encode the psf, and for encoding a batch with multiple sources per tile.
- Modified some tests to use `encoder` and `decoder` fixtures