### PR TITLE
Make predictions on multiple image units

### DIFF
--- a/bliss/api.py
+++ b/bliss/api.py
@@ -1,7 +1,7 @@
 import logging
 from os import environ, getenv
 from pathlib import Path
-from typing import Dict, Literal, Optional, Tuple, TypeAlias
+from typing import Any, Dict, Literal, Optional, Tuple, TypeAlias
 
 import hydra
 import torch
@@ -26,8 +26,8 @@ class BlissClient:
     """Client for interacting with the BLISS API."""
 
     def __init__(self, cwd: str):
-        self._cwd = cwd
         self.base_cfg = base_config()
+        self._cwd = cwd
         self.base_cfg.paths.root = self.cwd
 
     def generate(
@@ -133,14 +133,14 @@ class BlissClient:
         _train(cfg)
 
     def load_survey(self, survey: SurveyType, run, camcol, field, download_dir: str):
-        SDSSDownloader(run, camcol, field, self.cwd + f"/{download_dir}").download_all()
+        SDSSDownloader([(run, camcol, field)], self.cwd + f"/{download_dir}").download_all()
         # assert files downloaded at download_dir
 
     def predict_sdss(
         self,
         weight_save_path: str,
         **kwargs,
-    ) -> Tuple[FullCatalog, Table, Table]:
+    ) -> Tuple[FullCatalog, Table, Dict[Any, Table]]:
         """Predict on SDSS images.
 
         Args:
@@ -158,10 +158,12 @@ class BlissClient:
         cfg.predict.weight_save_path = cfg.paths.output + f"/{weight_save_path}"
         for k, v in kwargs.items():
             OmegaConf.update(cfg, k, v)
-        est_cat, _, _, _, pred = _predict(cfg)
+        est_cat, _, _, _, pred_for_image_id = _predict(cfg)
         est_cat_table = fullcat_to_astropy_table(est_cat)
-        pred_table = pred_to_astropy_table(pred)
-        return est_cat, est_cat_table, pred_table
+        pred_tables = {}  # indexed by image_id
+        for image_id, pred in pred_for_image_id.items():
+            pred_tables[image_id] = pred_to_astropy_table(pred)
+        return est_cat, est_cat_table, pred_tables
 
     def plot_predictions_in_notebook(self):
         """Plot predictions in notebook."""
@@ -194,6 +196,7 @@ class BlissClient:
             cwd (str): Current working directory.
         """
         self._cwd = cwd
+        self.base_cfg.paths.root = self.cwd
 
     @property
     def cached_data_path(self) -> str:

--- a/bliss/conf/base_config.yaml
+++ b/bliss/conf/base_config.yaml
@@ -174,7 +174,9 @@ surveys:
     decals:
         _target_: bliss.surveys.decals.DarkEnergyCameraLegacySurvey
         decals_dir: ${paths.decals}
-        ra: 336.635 # in degrees
-        dec: -0.96 # in degrees
+        sky_coords: # in degrees
+            # brick '3366m010' corresponds to SDSS RCF 94-1-12
+            - ra: 336.6643042496718
+              dec: -0.9316385797930247
         bands: ${encoder.bands}
         reference_band: 1 # DECaLS r-band, DECaLS-indexed (via header)

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -10,7 +10,8 @@ from torch import Tensor
 
 from bliss.catalog import FullCatalog
 from bliss.surveys.decals import DarkEnergyCameraLegacySurvey as DECaLS
-from bliss.surveys.decals import DecalsDownloader, DecalsFullCatalog
+from bliss.surveys.decals import DecalsFullCatalog
+from bliss.surveys.sdss import PhotoFullCatalog
 from bliss.surveys.sdss import SloanDigitalSkySurvey as SDSS
 
 
@@ -28,13 +29,15 @@ def crop_image(image, background, crop_params):
     if not crop_params.do_crop:
         return image, background
 
-    idx0 = crop_params.left_upper_corner[0]
-    idx1 = crop_params.left_upper_corner[1]
+    top_left_y = crop_params.left_upper_corner[0]
+    top_left_x = crop_params.left_upper_corner[1]
     width = crop_params.width
     height = crop_params.height
-    if ((idx0 + height) <= image.shape[2]) and ((idx1 + width) <= image.shape[3]):
-        image = image[:, :, idx0 : idx0 + height, idx1 : idx1 + width]
-        background = background[:, :, idx0 : idx0 + height, idx1 : idx1 + width]
+    if ((top_left_y + height) <= image.shape[2]) and ((top_left_x + width) <= image.shape[3]):
+        image = image[:, :, top_left_y : top_left_y + height, top_left_x : top_left_x + width]
+        background = background[
+            :, :, top_left_y : top_left_y + height, top_left_x : top_left_x + width
+        ]
     return image, background
 
 
@@ -143,7 +146,7 @@ def predict(cfg):
         backgrounds = prepare_image(survey_obj["background"], cfg.predict.device).float()
         images, backgrounds = crop_image(images, backgrounds, cfg.predict.crop)
         survey.predict_batch = prepare_batch(images, backgrounds)
-        est_cat, images, background, pred = trainer.predict(encoder, datamodule=survey)[0].values()
+        est_cat, images, backgrounds, pred = trainer.predict(encoder, datamodule=survey)[0].values()
 
         # mean of the nelec_per_mgy per band
         nelec_per_nmgy_per_band = np.mean(survey_obj["nelec_per_nmgy_list"], axis=1)
@@ -151,7 +154,7 @@ def predict(cfg):
         est_full = est_cat.to_full_params()
 
         images_for_frame[survey.image_id(i)] = images
-        backgrounds_for_frame[survey.image_id(i)] = background
+        backgrounds_for_frame[survey.image_id(i)] = backgrounds
         preds_for_frame[survey.image_id(i)] = pred
 
         if plocs_all is None:
@@ -183,6 +186,9 @@ def predict(cfg):
             plocs_all,
             est_full_all,
         )
+
+    images_for_frame = {k: v[0] for k, v in images_for_frame.items()}
+    backgrounds_for_frame = {k: v[0] for k, v in backgrounds_for_frame.items()}
     return est_full_all, images_for_frame, backgrounds_for_frame, plocs_all, preds_for_frame
 
 
@@ -206,7 +212,7 @@ def crop_plocs(cfg, w, h, plocs, do_crop=False):
     return plocs[x_mask].cpu() - torch.tensor([minh, minw])
 
 
-def add_cat(p, est_plocs, true_plocs, decals_plocs):
+def add_cat(p, est_plocs, survey_true_plocs, sdss_plocs, decals_plocs):
     """Function to overlay scatter plots on given image using different catalogs."""
     p.scatter(
         est_plocs[:, 1],
@@ -218,20 +224,30 @@ def add_cat(p, est_plocs, true_plocs, decals_plocs):
         fill_color=None,
     )
     p.scatter(
-        true_plocs[:, 1],
-        true_plocs[:, 0],
+        survey_true_plocs[:, 1],
+        survey_true_plocs[:, 0],
         marker="circle",
-        color="cyan",
-        legend_label="sdss catalog",
+        color="hotpink",
+        legend_label="consolidated survey catalog",
         size=20,
         fill_color=None,
     )
+    if sdss_plocs is not None:
+        p.scatter(
+            sdss_plocs[:, 1],
+            sdss_plocs[:, 0],
+            marker="circle",
+            color="lightgreen",
+            legend_label="sdss catalog",
+            size=5,
+            fill_color=None,
+        )
     if decals_plocs is not None:
         p.scatter(
             decals_plocs[:, 1],
             decals_plocs[:, 0],
             marker="circle",
-            color="lightgreen",
+            color="cyan",
             legend_label="decals catalog",
             size=5,
         )
@@ -239,34 +255,57 @@ def add_cat(p, est_plocs, true_plocs, decals_plocs):
     return p
 
 
-def plot_image(cfg, img, w, h, est_plocs, true_plocs, title):
+def plot_image(cfg, ra, dec, img, w, h, est_plocs, survey_true_plocs, title):
     """Function that generate plots for images."""
     p = figure(width=cfg.predict.plot.width, height=cfg.predict.plot.height)
     p.image(image=[img], x=0, y=0, dw=w, dh=h, palette="Viridis256")
     do_crop = cfg.predict.crop.do_crop
     is_simulated = cfg.predict.is_simulated
 
-    true_plocs = np.array(crop_plocs(cfg, w, h, true_plocs, do_crop).cpu())
+    survey_true_plocs = np.array(crop_plocs(cfg, w, h, survey_true_plocs, do_crop).cpu())
+    sdss_plocs = None
     decals_plocs = None
     if do_crop and (not is_simulated):
-        sdss = instantiate(cfg.predict.dataset)
-        wcs = sdss[0]["wcs"][0]
+        # DECaLS one-instance catalog plocs
+        decals = instantiate(
+            cfg.surveys.decals, bands=[SDSS.BANDS.index("r")], sky_coords=[{"ra": ra, "dec": dec}]
+        )
 
-        # Map SDSS RCF to DECaLS brickname
-        sdss_fields = cfg.surveys.sdss.sdss_fields
-        run, camcol, fields = sdss_fields[0].values()
-        brickname = DECaLS.brick_for_radec(*SDSS.radec_for_rcf(run, camcol, fields[0]))
-
-        tractor_filename = DecalsDownloader(brickname, cfg.paths.decals).download_catalog(brickname)
-        decals_plocs_from_sdss = DecalsFullCatalog.from_file(
-            tractor_filename, wcs, height=sdss[0]["image"].shape[1], width=sdss[0]["image"].shape[2]
+        brickname = DECaLS.brick_for_radec(ra, dec)
+        tractor_filename = decals.downloader.download_catalog(brickname)
+        decals_plocs = DecalsFullCatalog.from_file(
+            tractor_filename,
+            wcs=decals[0]["wcs"][cfg.predict.dataset.reference_band],
+            height=decals[0]["image"].shape[1],
+            width=decals[0]["image"].shape[2],
         ).plocs[0]
-        decals_plocs = np.array(crop_plocs(cfg, w, h, decals_plocs_from_sdss, do_crop))
-    return TabPanel(child=add_cat(p, est_plocs, true_plocs, decals_plocs), title=title)
+        decals_plocs = np.array(crop_plocs(cfg, w, h, decals_plocs, do_crop).cpu())
+
+        # SDSS one-instance catalog plocs
+        run, camcol, field = SDSS.rcf_for_radec(ra, dec)
+        sdss = instantiate(
+            cfg.surveys.sdss, sdss_fields=[{"run": run, "camcol": camcol, "fields": [field]}]
+        )
+        photocat_filename = sdss.downloader.download_catalog((run, camcol, field))
+        sdss_plocs = PhotoFullCatalog.from_file(
+            photocat_filename,
+            wcs=sdss[0]["wcs"][cfg.predict.dataset.reference_band],
+            height=sdss[0]["image"].shape[1],
+            width=sdss[0]["image"].shape[2],
+        ).plocs[0]
+        sdss_plocs = np.array(crop_plocs(cfg, w, h, sdss_plocs, do_crop).cpu())
+    return TabPanel(
+        child=add_cat(p, est_plocs, survey_true_plocs, sdss_plocs, decals_plocs), title=title
+    )
 
 
 def plot_predict(
-    cfg, images_for_frame, backgrounds_for_frame, radecs_for_frame, true_plocs, est_cat: FullCatalog
+    cfg,
+    images_for_frame,
+    backgrounds_for_frame,
+    radecs_for_frame,
+    survey_true_plocs,
+    est_cat: FullCatalog,
 ):
     """Function that uses bokeh to save generated plots to an html file."""
     if cfg.predict.plot.out_file_name is not None:
@@ -275,13 +314,12 @@ def plot_predict(
         output_file(out_filepath)
 
     est_plocs = np.array(est_cat.plocs.cpu())[0]
-    simulator = instantiate(cfg.simulator)
-    decoder_obj = simulator.image_decoder
     est_tile = est_cat.to_tile_params(
         cfg.encoder.tile_slen,
         cfg.simulator.survey.prior_config.max_sources,
         ignore_extra_sources=True,
-    )
+    ).to("cpu")
+
     tabs = []
     for image_id in images_for_frame.keys():
         image = images_for_frame[image_id]
@@ -294,8 +332,13 @@ def plot_predict(
         w, h = image.shape
 
         ra, dec = radecs_for_frame[image_id]
-        rcfs = np.array([SDSS.rcf_for_radec(ra, dec)])
-        recon_images, _, _ = decoder_obj.render_images(est_tile.to("cpu"), rcfs)
+        run, camcol, field = SDSS.rcf_for_radec(ra, dec)
+        simulator = instantiate(
+            cfg.simulator,
+            survey={"sdss_fields": [{"run": run, "camcol": camcol, "fields": [field]}]},
+        )
+        decoder_obj = simulator.image_decoder
+        recon_images, _, _ = decoder_obj.render_images(est_tile, np.array([[run, camcol, field]]))
         recon_img = recon_images[0][0]  # first image in batch, first band in image
 
         image = image.to("cpu")
@@ -303,29 +346,22 @@ def plot_predict(
         res = image - recon_img - background
 
         # normalize for big image
-        title = ""
+        title_suffix = f" (RA: {float(ra):.2f}, Dec: {float(dec):.2f})"
+        title_prefix = ""
         if w >= 150:
             image = np.log((image - image.min()) + 10)
             recon_img = np.log((recon_img - recon_img.min()) + 10)
-            title = "log-"
+            title_prefix = "log-"
 
         np_image = np.array(image)
         np_recon = np.array(recon_img)
-        tab1 = plot_image(
-            cfg, np_image, w, h, est_plocs, true_plocs, f"{title}true image (RA: {ra}, Dec: {dec})"
-        )
-        tab2 = plot_image(
-            cfg,
-            np_recon,
-            w,
-            h,
-            est_plocs,
-            true_plocs,
-            f"{title}reconstructed image (RA: {ra}, Dec: {dec})",
-        )
-        tab3 = plot_image(
-            cfg, np.array(res), w, h, est_plocs, true_plocs, f"residual (RA: {ra}, Dec: {dec})"
-        )
+        np_res = np.array(res)
+        tab1_title = f"{title_prefix}true image{title_suffix}"
+        tab2_title = f"{title_prefix}reconstructed image{title_suffix}"
+        tab3_title = f"residual{title_suffix}"
+        tab1 = plot_image(cfg, ra, dec, np_image, w, h, est_plocs, survey_true_plocs, tab1_title)
+        tab2 = plot_image(cfg, ra, dec, np_recon, w, h, est_plocs, survey_true_plocs, tab2_title)
+        tab3 = plot_image(cfg, ra, dec, np_res, w, h, est_plocs, survey_true_plocs, tab3_title)
         tabs.extend([tab1, tab2, tab3])
 
     show(Tabs(tabs=tabs))

--- a/bliss/simulator/decoder.py
+++ b/bliss/simulator/decoder.py
@@ -109,7 +109,7 @@ class ImageDecoder(nn.Module):
 
         full_cat = tile_cat.to_full_params()
 
-        # use the PSF from specified row/camcol/field
+        # use the PSF from specified image_id
         psfs = [self.psf_galsim[tuple(image_ids[b])] for b in range(batch_size)]
         param_list = [self.psf_params[tuple(image_ids[b])] for b in range(batch_size)]
         psf_params = torch.stack(param_list, dim=0)

--- a/bliss/surveys/decals.py
+++ b/bliss/surveys/decals.py
@@ -73,7 +73,7 @@ class DarkEnergyCameraLegacySurvey(Survey):
                 image_filename = self.decals_path / f"legacysurvey-{self.brickname}-image-{bl}.fits"
                 if not Path(image_filename).exists():
                     self.downloader.download_image(bl)
-        self.downloader.download_catalog()
+        self.downloader.download_catalog(self.brickname)
 
     def __len__(self):
         return 1
@@ -208,19 +208,22 @@ class DecalsDownloader(SurveyDownloader):
             )
             raise e
 
-    def download_catalog(self) -> str:
+    def download_catalog(self, brickname) -> str:
         """Download tractor catalog for this brick.
+
+        Args:
+            brickname (str): brick name
 
         Returns:
             str: path to downloaded tractor catalog
         """
-        tractor_filename = Path(self.download_dir) / f"tractor-{self.brickname}.fits"
+        tractor_filename = Path(self.download_dir) / f"tractor-{brickname}.fits"
         download_file_to_dst(
-            f"{DecalsDownloader.URLBASE}/south/tractor/{self.brickname[:3]}/"
-            f"tractor-{self.brickname}.fits",
+            f"{DecalsDownloader.URLBASE}/south/tractor/{brickname[:3]}/"
+            f"tractor-{brickname}.fits",
             tractor_filename,
         )
-        return tractor_filename
+        return str(tractor_filename)
 
 
 class DecalsFullCatalog(FullCatalog):

--- a/bliss/surveys/sdss.py
+++ b/bliss/surveys/sdss.py
@@ -41,16 +41,14 @@ class SloanDigitalSkySurvey(Survey):
         return (ra_center, dec_center)
 
     @staticmethod
-    def rcf_for_radec(ra_lim, dec_lim) -> Tuple[int, int, int]:
+    def rcf_for_radec(ra, dec) -> Tuple[int, int, int]:
         """Get run, camcol, field for a given RA, DEC."""
-        ramin, ramax = ra_lim
-        decmin, decmax = dec_lim
         extents = SDSSDownloader.field_extents()
         row = extents[
-            (extents["ramin"] <= ramin)
-            & (extents["ramax"] >= ramax)
-            & (extents["decmin"] <= decmin)
-            & (extents["decmax"] >= decmax)
+            (extents["ramin"] <= ra)
+            & (extents["ramax"] >= ra)
+            & (extents["decmin"] <= dec)
+            & (extents["decmax"] >= dec)
         ][0]
         return (row["run"], row["camcol"], row["field"])
 
@@ -70,10 +68,8 @@ class SloanDigitalSkySurvey(Survey):
         self.sdss_fields = sdss_fields
         self.bands = tuple(range(len(self.BANDS)))
 
+        self.downloader = SDSSDownloader(self.image_ids(), download_dir=str(self.sdss_path))
         self.prepare_data()
-
-        # TODO: remove this self.downloader
-        self.downloader = SDSSDownloader(*self.image_id(0), download_dir=str(self.sdss_path))
 
         self.prior = SDSSPrior(
             sdss_dir, self.image_ids(), self, self.bands, reference_band, prior_config
@@ -85,40 +81,38 @@ class SloanDigitalSkySurvey(Survey):
         self._predict_batch = {"images": self[0]["image"], "background": self[0]["background"]}
 
     def prepare_data(self):
+        self.downloader.download_pfs()
         for rcf_conf in self.sdss_fields:
             run, camcol, fields = rcf_conf["run"], rcf_conf["camcol"], rcf_conf["fields"]
-            downloader = SDSSDownloader(run, camcol, fields[0], download_dir=str(self.sdss_path))
 
             pf_file = f"photoField-{run:06d}-{camcol:d}.fits"
             pf_path = self.sdss_path / str(run) / str(camcol) / pf_file
-            if not Path(pf_path).exists():
-                downloader.download_pf()
             msg = (
                 f"{pf_path} does not exist. "
-                + "Make sure data files are available for specified fields."
+                + "Make sure data files are available for specified (run, camcol)."
             )
             assert Path(pf_path).exists(), msg
             pf_fits = fits.getdata(pf_path)
-
             assert pf_fits is not None, f"Could not load fits file {pf_path}."
+
             fieldnums = pf_fits["FIELD"]
             fieldgains = pf_fits["GAIN"]
 
-            # get desired field
-            for i, field in enumerate(fieldnums):
-                gain = fieldgains[i]
-                if (not fields) or field in fields:
+            if fields:
+                for field in fields:
+                    gain = fieldgains[fieldnums == field][0]
+                    self.rcfgcs.append((run, camcol, field, gain))
+            else:
+                for field, gain in zip(fieldnums, fieldgains):
                     self.rcfgcs.append((run, camcol, field, gain))
 
+        self.downloader.download_images()
         for rcfgc in self.rcfgcs:
             run, camcol, field, _ = rcfgc
-            downloader = SDSSDownloader(run, camcol, field, download_dir=str(self.sdss_path))
-            field_path = self.sdss_path.joinpath(str(run), str(camcol), str(field))
+            field_path = self.sdss_path / f"{run}/{camcol}/{field}"
             for bl in SloanDigitalSkySurvey.BANDS:
                 frame_name = f"frame-{bl}-{run:06d}-{camcol:d}-{field:04d}.fits"
-                frame_path = str(field_path.joinpath(frame_name))
-                if not Path(frame_path).exists():
-                    downloader.download_image(band=bl)
+                frame_path = field_path / frame_name
                 assert Path(frame_path).exists(), f"{frame_path} does not exist."
 
         self.items = [None for _ in range(len(self.rcfgcs))]
@@ -153,7 +147,12 @@ class SloanDigitalSkySurvey(Survey):
         Returns:
             List[Tuple[int, int, int]]: List of (run, camcol, field) image_ids.
         """
-        return [self.image_id(i) for i in range(len(self))]
+        rcfs = []
+        for rcf_conf in self.sdss_fields:
+            run, camcol, fields = rcf_conf["run"], rcf_conf["camcol"], rcf_conf["fields"]
+            for field in fields:
+                rcfs.append((run, camcol, field))
+        return rcfs
 
     def get_from_disk(self, idx):
         if self.rcfgcs[idx] is None:
@@ -242,18 +241,29 @@ class SDSSDownloader:
 
     URLBASE = "https://data.sdss.org/sas/dr12/boss"
 
-    def __init__(self, run, camcol, field, download_dir):
-        self.run = run
-        self.camcol = camcol
-        self._field = field
-        self.download_dir = download_dir
+    @staticmethod
+    def stripped(val):
+        return str(val).lstrip("0")
 
-        self.run_stripped = str(run).lstrip("0")
-        self.field_stripped = str(field).lstrip("0")
-        self.run6 = f"{int(self.run_stripped):06d}"
-        self.field4 = f"{int(self.field_stripped):04d}"
-        self.subdir2 = f"{self.run_stripped}/{camcol}"
-        self.subdir3 = f"{self.run_stripped}/{camcol}/{self.field_stripped}"
+    @staticmethod
+    def run6(run) -> str:
+        return f"{int(SDSSDownloader.stripped(run)):06d}"
+
+    @staticmethod
+    def field4(field) -> str:
+        return f"{int(SDSSDownloader.stripped(field)):04d}"
+
+    @staticmethod
+    def subdir2(run, camcol) -> str:
+        return f"{SDSSDownloader.stripped(run)}/{camcol}"
+
+    @staticmethod
+    def subdir3(run, camcol, field) -> str:
+        return f"{SDSSDownloader.subdir2(run, camcol)}/{SDSSDownloader.stripped(field)}"
+
+    def __init__(self, image_ids, download_dir):
+        self.image_ids = image_ids
+        self.download_dir = download_dir
 
     @classmethod
     def download_field_extents(cls):
@@ -272,48 +282,71 @@ class SDSSDownloader:
             cls.download_field_extents()
         return cls._field_extents  # pylint: disable=no-member
 
-    def download_pf(self):
+    def download_pfs(self):
+        for image_id in self.image_ids:
+            run, camcol, _ = image_id
+            self.download_pf(run, camcol)
+
+    def download_pf(self, run, camcol):
         download_file_to_dst(
-            f"{SDSSDownloader.URLBASE}/photoObj/301/{self.run_stripped}/"
-            f"photoField-{self.run6}-{self.camcol}.fits",
-            f"{self.download_dir}/{self.subdir2}/" f"photoField-{self.run6}-{self.camcol}.fits",
+            f"{SDSSDownloader.URLBASE}/photoObj/301/{self.stripped(run)}/"
+            f"photoField-{self.run6(run)}-{camcol}.fits",
+            f"{self.download_dir}/{self.subdir2(run, camcol)}/"
+            f"photoField-{self.run6(run)}-{camcol}.fits",
         )
 
-    def download_catalog(self) -> str:
+    def download_catalogs(self):
+        for image_id in self.image_ids:
+            run, camcol, field = image_id
+            self.download_catalog((run, camcol, field))
+
+    def download_catalog(self, rcf) -> str:
+        run, camcol, field = rcf
         cat_path = (
-            f"{self.download_dir}/{self.subdir3}/"
-            + f"photoObj-{self.run6}-{self.camcol}-{self.field4}.fits"
+            f"{self.download_dir}/{self.subdir3(run, camcol, field)}/"
+            + f"photoObj-{self.run6(run)}-{camcol}-{self.field4(field)}.fits"
         )
         download_file_to_dst(
-            f"{SDSSDownloader.URLBASE}/photoObj/301/{self.run_stripped}/{self.camcol}/"
-            f"photoObj-{self.run6}-{self.camcol}-{self.field4}.fits",
+            f"{SDSSDownloader.URLBASE}/photoObj/301/{self.stripped(run)}/{camcol}/"
+            f"photoObj-{self.run6(run)}-{camcol}-{self.field4(field)}.fits",
             cat_path,
         )
         return cat_path
 
-    def download_image(self, band="r"):
+    def download_images(self):
+        for image_id in self.image_ids:
+            run, camcol, field = image_id
+            for bl in SloanDigitalSkySurvey.BANDS:
+                self.download_image(run, camcol, field, bl)
+
+    def download_image(self, run, camcol, field, band="r"):
         download_file_to_dst(
-            f"{SDSSDownloader.URLBASE}/photo/redux/301/{self.run_stripped}/objcs/{self.camcol}/"
-            f"fpM-{self.run6}-{band}{self.camcol}-{self.field4}.fit.gz",
-            f"{self.download_dir}/{self.subdir3}/"
-            f"fpM-{self.run6}-{band}{self.camcol}-{self.field4}.fits",
+            f"{SDSSDownloader.URLBASE}/photo/redux/301/{self.stripped(run)}/objcs/{camcol}/"
+            f"fpM-{self.run6(run)}-{band}{camcol}-{self.field4(field)}.fit.gz",
+            f"{self.download_dir}/{self.subdir3(run, camcol, field)}/"
+            f"fpM-{self.run6(run)}-{band}{camcol}-{self.field4(field)}.fits",
             gzip.decompress,
         )
 
         download_file_to_dst(
-            f"{SDSSDownloader.URLBASE}/photoObj/frames/301/{self.run_stripped}/{self.camcol}/"
-            f"frame-{band}-{self.run6}-{self.camcol}-{self.field4}.fits.bz2",
-            f"{self.download_dir}/{self.subdir3}/"
-            f"frame-{band}-{self.run6}-{self.camcol}-{self.field4}.fits",
+            f"{SDSSDownloader.URLBASE}/photoObj/frames/301/{self.stripped(run)}/{camcol}/"
+            f"frame-{band}-{self.run6(run)}-{camcol}-{self.field4(field)}.fits.bz2",
+            f"{self.download_dir}/{self.subdir3(run, camcol, field)}/"
+            f"frame-{band}-{self.run6(run)}-{camcol}-{self.field4(field)}.fits",
             bz2.decompress,
         )
 
-    def download_psfield(self):
+    def download_psfields(self):
+        for image_id in self.image_ids:
+            run, camcol, field = image_id
+            self.download_psfield(run, camcol, field)
+
+    def download_psfield(self, run, camcol, field):
         download_file_to_dst(
-            f"{SDSSDownloader.URLBASE}/photo/redux/301/{self.run_stripped}/objcs/{self.camcol}/"
-            f"psField-{self.run6}-{self.camcol}-{self.field4}.fit",
-            f"{self.download_dir}/{self.subdir3}/"
-            f"psField-{self.run6}-{self.camcol}-{self.field4}.fits",
+            f"{SDSSDownloader.URLBASE}/photo/redux/301/{self.stripped(run)}/objcs/{camcol}/"
+            f"psField-{self.run6(run)}-{camcol}-{self.field4(field)}.fit",
+            f"{self.download_dir}/{self.subdir3(run, camcol, field)}/"
+            f"psField-{self.run6(run)}-{camcol}-{self.field4(field)}.fits",
         )
 
     def download_all(self):
@@ -321,24 +354,10 @@ class SDSSDownloader:
             # create download directory
             Path(self.download_dir).mkdir(parents=True, exist_ok=True)
 
-        self.download_pf()
-        self.download_catalog()
-
-        for band in SloanDigitalSkySurvey.BANDS:
-            self.download_image(band)
-
-        self.download_psfield()
-
-    @property
-    def field(self):
-        return self._field
-
-    @field.setter
-    def field(self, value):
-        self._field = value
-        self.field_stripped = str(self._field).lstrip("0")
-        self.field4 = f"{int(self.field_stripped):04d}"
-        self.subdir3 = f"{self.run_stripped}/{self.camcol}/{self.field_stripped}"
+        self.download_pfs()
+        self.download_catalogs()
+        self.download_images()
+        self.download_psfields()
 
 
 class PhotoFullCatalog(FullCatalog):
@@ -431,12 +450,12 @@ class SDSSPSF(ImagePSF):
 
         self.psf_galsim = {}
         self.psf_params = {}
+        SDSSDownloader(image_ids, download_dir=survey_data_dir).download_psfields()
         for run, camcol, field in image_ids:
             # load raw params from file
             field_dir = f"{survey_data_dir}/{run}/{camcol}/{field}"
             filename = f"{field_dir}/psField-{run:06}-{camcol}-{field:04}.fits"
-            if not Path(filename).exists():
-                SDSSDownloader(run, camcol, field, download_dir=survey_data_dir).download_psfield()
+            assert Path(filename).exists(), f"psField file {filename} not found"
             psf_params = self._get_fit_file_psf_params(filename, bands)
 
             # load psf image from params
@@ -515,6 +534,7 @@ class SDSSPrior(ImagePrior):
         stars_fluxes = {}
         gals_fluxes = {}
 
+        SDSSDownloader(image_ids, download_dir=survey_data_dir).download_catalogs()
         for i, image_id in enumerate(image_ids):
             run, camcol, field = image_id
             image = items[i]
@@ -526,8 +546,6 @@ class SDSSPrior(ImagePrior):
             field_dir = sdss_path / str(run) / str(camcol) / str(field)
             po_path = field_dir / f"photoObj-{run:06d}-{camcol:d}-{field:04d}.fits"
 
-            if not po_path.exists():
-                SDSSDownloader(run, camcol, field, str(sdss_path)).download_catalog()
             msg = (
                 f"{po_path} does not exist. "
                 + "Make sure data files are available for fields specified in config."

--- a/bliss/surveys/survey.py
+++ b/bliss/surveys/survey.py
@@ -51,6 +51,6 @@ class Survey(pl.LightningDataModule, Dataset, ABC):
 
 
 class SurveyDownloader:
-    def download_catalog(self) -> str:
+    def download_catalog(self, **kwargs) -> str:
         """Download the catalog and return the path to the catalog file."""
         raise NotImplementedError

--- a/data/decals/legacysurvey-1358p297-image-r.fits
+++ b/data/decals/legacysurvey-1358p297-image-r.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bec5ed24818b9f3bae3b7985a72492f24345e34b41dc6dcc3a917a6f54d5755
+size 13469760

--- a/data/decals/tractor-1358p297.fits
+++ b/data/decals/tractor-1358p297.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f376bbefa7a0c74163ef4e31c5e933e198f3ed3f983514d27dd64a2363434138
+size 11292480

--- a/data/sdss/3635/1/169/fpM-003635-g1-0169.fits
+++ b/data/sdss/3635/1/169/fpM-003635-g1-0169.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8076595b7b785e7a59874c438834fffe59a7545a53294f384496be5245595852
+size 305280

--- a/data/sdss/3635/1/169/fpM-003635-i1-0169.fits
+++ b/data/sdss/3635/1/169/fpM-003635-i1-0169.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab0153255b1ff7cb7a9130b30ea981e07e635f36eee732fdb5e1cbd3227c2ca3
+size 472320

--- a/data/sdss/3635/1/169/fpM-003635-r1-0169.fits
+++ b/data/sdss/3635/1/169/fpM-003635-r1-0169.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e1d7c607076836d0b141477393b3523fd926b7fc777359d50f8661ddc1f6142
+size 331200

--- a/data/sdss/3635/1/169/fpM-003635-u1-0169.fits
+++ b/data/sdss/3635/1/169/fpM-003635-u1-0169.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31ed06e42a318eedff2d0f3ea46bd79ba7d8b051cfadb638d7c62c473c270167
+size 509760

--- a/data/sdss/3635/1/169/fpM-003635-z1-0169.fits
+++ b/data/sdss/3635/1/169/fpM-003635-z1-0169.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e91b7b9220db7b6673bc8b0fbc71ee0b8e437c8b03cae6a765600377c9d72dc
+size 259200

--- a/data/sdss/3635/1/169/frame-g-003635-1-0169.fits
+++ b/data/sdss/3635/1/169/frame-g-003635-1-0169.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76da2f57bf82beec9dc83ee6c6aaba42e9ff2a488c39b1b9fc5689c650e1eac0
+size 12447360

--- a/data/sdss/3635/1/169/frame-i-003635-1-0169.fits
+++ b/data/sdss/3635/1/169/frame-i-003635-1-0169.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97219618cbfc6a94d4f707938d30d66b3447ab122cbdb74cc844ddfbb37844aa
+size 12447360

--- a/data/sdss/3635/1/169/frame-r-003635-1-0169.fits
+++ b/data/sdss/3635/1/169/frame-r-003635-1-0169.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00be43541a1ee34f8d266be0ac993c9ff0401e7091f638417caf02a316719cda
+size 12447360

--- a/data/sdss/3635/1/169/frame-u-003635-1-0169.fits
+++ b/data/sdss/3635/1/169/frame-u-003635-1-0169.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e3d53a3816f8f6ac23a706e84666b9fdb28cb0619afdb7ddca4a664df462731
+size 12447360

--- a/data/sdss/3635/1/169/frame-z-003635-1-0169.fits
+++ b/data/sdss/3635/1/169/frame-z-003635-1-0169.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:595e9e577053d2f1a536e8f71bbb00bf636c29b251042f9651640b31dea32f50
+size 12447360

--- a/data/sdss/3635/1/169/photoObj-003635-1-0169.fits
+++ b/data/sdss/3635/1/169/photoObj-003635-1-0169.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27b14fd58b36c5639b6515616475302d30cbdb4628ee932cb9785464af27d386
+size 3401280

--- a/data/sdss/3635/1/169/psField-003635-1-0169.fits
+++ b/data/sdss/3635/1/169/psField-003635-1-0169.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:545b9b4aa18f413be0abc49c47a9f01af51b2da162bc30cc5ece752e3a647fea
+size 411840

--- a/data/sdss/3635/1/photoField-003635-1.fits
+++ b/data/sdss/3635/1/photoField-003635-1.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3901b8d1f06d0cac1dd2b72e173d5b9c3fa3b9de8fb374ffc455a0df1b5726d
+size 622080

--- a/data/tests/decals_preds_bulk.pt
+++ b/data/tests/decals_preds_bulk.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33f5c09eaf7706fa48e8f0eb05f9b0e13e9d975624366069170f1917e026a7b5
+size 45384727

--- a/data/tests/sdss_preds.pt
+++ b/data/tests/sdss_preds.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1495585aade4d2e91274413aed75869f3f30e143a8451db6c40ab9bc1df3bb1d
-size 1574158
+oid sha256:b2c039a481a9dfd81a88842deb1c38a76b6c1b139030d9ef9e6de0c4ec8cbfa2
+size 22694699

--- a/data/tests/sdss_preds.pt
+++ b/data/tests/sdss_preds.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2c039a481a9dfd81a88842deb1c38a76b6c1b139030d9ef9e6de0c4ec8cbfa2
-size 22694699
+oid sha256:1495585aade4d2e91274413aed75869f3f30e143a8451db6c40ab9bc1df3bb1d
+size 1574158

--- a/data/tests/sdss_preds_bulk.pt
+++ b/data/tests/sdss_preds_bulk.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddf496a432d1f49e420e42343925995221376627fec8dbac6001eddf8d818bce
+size 45387385

--- a/data/tests/sdss_preds_bulk.pt
+++ b/data/tests/sdss_preds_bulk.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ddf496a432d1f49e420e42343925995221376627fec8dbac6001eddf8d818bce
-size 45387385
+oid sha256:9c9a44b8c301880cfd46327186c7852a7333cffc3e56ecc984f8a9d7fd3df19f
+size 45386041

--- a/data/tests/sdss_preds_single.pt
+++ b/data/tests/sdss_preds_single.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c576003f545934ab7f3bd5f0355a62b47ebde4763903dc88b670ed1fe2155f1e
+size 22694916

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -18,11 +18,11 @@ class TestPredict:
 
         # TODO: test output of predictions plot
 
-    def test_predict_sdss_multiple_images(self, cfg):
+    def test_predict_sdss_multiple_rcfs(self, cfg):
         the_cfg = cfg.copy()
         the_cfg.surveys.sdss.sdss_fields = [
             {"run": 94, "camcol": 1, "fields": [12]},
-            {"run": 3900, "camcol": 6, "fields": [269]},
+            {"run": 3635, "camcol": 1, "fields": [169]},
         ]
         the_cfg.predict.plot.show_plot = True
         _, _, _, _, preds = predict(the_cfg)
@@ -34,7 +34,27 @@ class TestPredict:
 
     def test_predict_decals(self, cfg):
         the_cfg = cfg.copy()
-        the_cfg.predict.dataset = cfg.surveys.decals
+        the_cfg.predict.plot.show_plot = True
+        the_cfg.predict.dataset = "${surveys.decals}"
         the_cfg.encoder.bands = [2]
         the_cfg.predict.weight_save_path = "${paths.pretrained_models}/single_band_base.pt"
         predict(the_cfg)
+
+    def test_predict_decals_multiple_bricks(self, cfg):
+        the_cfg = cfg.copy()
+        the_cfg.predict.plot.show_plot = True
+        the_cfg.predict.dataset = "${surveys.decals}"
+        the_cfg.surveys.decals.sky_coords = [
+            # brick '3366m010' corresponds to SDSS RCF 94-1-12
+            {"ra": 336.6643042496718, "dec": -0.9316385797930247},
+            # brick '1358p297' corresponds to SDSS RCF 3635-1-169
+            {"ra": 135.95496736941683, "dec": 29.646883837721347},
+        ]
+        the_cfg.encoder.bands = [2]
+        the_cfg.predict.weight_save_path = "${paths.pretrained_models}/single_band_base.pt"
+        _, _, _, _, preds = predict(the_cfg)
+
+        # TODO: check rest of the return values from predict
+        assert len(preds) == len(
+            the_cfg.surveys.decals.sky_coords
+        ), f"Expected {len(the_cfg.surveys.decals.sky_coords)} predictions, got {len(preds)}"

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -18,6 +18,20 @@ class TestPredict:
 
         # TODO: test output of predictions plot
 
+    def test_predict_sdss_multiple_images(self, cfg):
+        the_cfg = cfg.copy()
+        the_cfg.surveys.sdss.sdss_fields = [
+            {"run": 94, "camcol": 1, "fields": [12]},
+            {"run": 3900, "camcol": 6, "fields": [269]},
+        ]
+        the_cfg.predict.plot.show_plot = True
+        _, _, _, _, preds = predict(the_cfg)
+
+        # TODO: check rest of the return values from predict
+        assert len(preds) == len(
+            the_cfg.surveys.sdss.sdss_fields
+        ), f"Expected {len(the_cfg.surveys.sdss.sdss_fields)} predictions, got {len(preds)}"
+
     def test_predict_decals(self, cfg):
         the_cfg = cfg.copy()
         the_cfg.predict.dataset = cfg.surveys.decals

--- a/tests/test_sdss_reconstruct.py
+++ b/tests/test_sdss_reconstruct.py
@@ -1,23 +1,33 @@
 import numpy as np
 from mock_tests import mock_predict
 
+from bliss.surveys.sdss import SloanDigitalSkySurvey as SDSS
+
 
 class TestSdssReconstruct:
     def test_sdss_reconstruct(self, cfg, decoder):
-        est_tile, true_img, true_bg, _, _ = mock_predict(cfg)
+        est_tile, true_imgs, true_bgs, _, _ = mock_predict(cfg)
+
+        num_image_units = len(true_imgs)
+        assert (
+            len(true_bgs) == num_image_units and num_image_units == 1
+        ), f"Expected predictions to be made on 1 image unit, got {num_image_units}"
+        true_img = true_imgs[next(iter(true_imgs))][0]
+        true_bg = true_bgs[next(iter(true_bgs))][0]
 
         # reconstruction test only considers r-band image/catalog params
         rcfs = np.array([[94, 1, 12]])
         tile_cat = est_tile.to_tile_params(
             tile_slen=cfg.simulator.survey.prior_config.tile_slen,
             max_sources_per_tile=cfg.simulator.survey.prior_config.max_sources,
+            ignore_extra_sources=True,
         )
         imgs = decoder.render_images(tile_cat.to("cpu"), rcfs)
-        recon_img = imgs[0][0, 2]  # r_band
+        recon_img = imgs[0][0, SDSS.BANDS.index("r")]
 
         ptc = cfg.encoder.tile_slen * cfg.encoder.tiles_to_crop
-        true_img_crop = true_img[2][ptc:-ptc, ptc:-ptc]
-        true_bg_crop = true_bg[2][ptc:-ptc, ptc:-ptc]
+        true_img_crop = true_img[SDSS.BANDS.index("r")][ptc:-ptc, ptc:-ptc]
+        true_bg_crop = true_bg[SDSS.BANDS.index("r")][ptc:-ptc, ptc:-ptc]
         true_bright = true_img_crop - true_bg_crop
 
         bright_pix_mask = (recon_img - 100) > 0  # originally 100

--- a/tests/test_sdss_reconstruct.py
+++ b/tests/test_sdss_reconstruct.py
@@ -1,19 +1,13 @@
 import numpy as np
-from mock_tests import mock_predict
+from mock_tests import mock_predict_sdss_recon
 
 from bliss.surveys.sdss import SloanDigitalSkySurvey as SDSS
 
 
 class TestSdssReconstruct:
     def test_sdss_reconstruct(self, cfg, decoder):
-        est_tile, true_imgs, true_bgs, _, _ = mock_predict(cfg)
-
-        num_image_units = len(true_imgs)
-        assert (
-            len(true_bgs) == num_image_units and num_image_units == 1
-        ), f"Expected predictions to be made on 1 image unit, got {num_image_units}"
-        true_img = true_imgs[next(iter(true_imgs))][0]
-        true_bg = true_bgs[next(iter(true_bgs))][0]
+        # TODO: change to use mock_predict_sdss
+        est_tile, true_img, true_bg, _, _ = mock_predict_sdss_recon(cfg)
 
         # reconstruction test only considers r-band image/catalog params
         rcfs = np.array([[94, 1, 12]])

--- a/tests/testing_config.yaml
+++ b/tests/testing_config.yaml
@@ -56,6 +56,9 @@ surveys:
             - run: 94
               camcol: 1
               fields: [12]
+            - run: 3900
+              camcol: 6
+              fields: [269]
         prior_config:
             n_tiles_h: 4
             n_tiles_w: 4

--- a/tests/testing_config.yaml
+++ b/tests/testing_config.yaml
@@ -56,9 +56,6 @@ surveys:
             - run: 94
               camcol: 1
               fields: [12]
-            - run: 3900
-              camcol: 6
-              fields: [269]
         prior_config:
             n_tiles_h: 4
             n_tiles_w: 4


### PR DESCRIPTION
Allows making predictions on multiple `image_id`s (e.g., RCF, brick)

WIP:
- Tests (`test_sdss_reconstruct.py`)
- Predictions plots per image unit

Will fix #770, #859.