### PR TITLE
Use percent slices for splits

### DIFF
--- a/bliss/api.py
+++ b/bliss/api.py
@@ -96,10 +96,8 @@ class BlissClient:
     def train_on_cached_data(
         self,
         weight_save_path,
-        train_n_batches,
+        splits,
         batch_size,
-        val_split_file_idxs,
-        test_split_file_idxs,
         pretrained_weights_filename: Optional[str] = None,
         **kwargs,
     ) -> None:
@@ -108,10 +106,8 @@ class BlissClient:
         Args:
             weight_save_path (str): Path to directory after cwd where trained model
                 weights will be stored.
-            train_n_batches (int): Number of batches to train on.
+            splits (str): train/val/test splits as percent ranges (e.g. "0:80/80:90/90:100")
             batch_size (int): Number of images per batch.
-            val_split_file_idxs (List[int]): List of file indices to use for validation.
-            test_split_file_idxs (List[int]): List of file indices to use for testing.
             pretrained_weights_filename (str): Name of pretrained weights file to load.
             **kwargs: Keyword arguments to override default configuration values.
         """
@@ -119,10 +115,8 @@ class BlissClient:
         cfg.training.use_cached_simulator = True
         # apply overrides
         cfg.training.weight_save_path = cfg.paths.output + f"/{weight_save_path}"
-        cfg.cached_simulator.train_n_batches = train_n_batches
+        cfg.cached_simulator.splits = splits
         cfg.cached_simulator.batch_size = batch_size
-        cfg.cached_simulator.val_split_file_idxs = val_split_file_idxs
-        cfg.cached_simulator.test_split_file_idxs = test_split_file_idxs
         if pretrained_weights_filename is not None:
             cfg.training.pretrained_weights = (
                 cfg.paths.pretrained_models + f"/{pretrained_weights_filename}"

--- a/bliss/conf/base_config.yaml
+++ b/bliss/conf/base_config.yaml
@@ -55,7 +55,7 @@ simulator:
 cached_simulator:
     _target_: bliss.simulator.simulated_dataset.CachedSimulatedDataset
     batch_size: ${generate.batch_size} # 128 for large cached
-    splits: 0:80/80:90/90:100
+    splits: 0:80/80:90/90:100  # train/val/test splits as percent ranges
     num_workers: 0
     cached_data_path: ${generate.cached_data_path}
     file_prefix: ${generate.file_prefix}

--- a/bliss/conf/base_config.yaml
+++ b/bliss/conf/base_config.yaml
@@ -55,13 +55,11 @@ simulator:
 cached_simulator:
     _target_: bliss.simulator.simulated_dataset.CachedSimulatedDataset
     batch_size: ${generate.batch_size} # 128 for large cached
+    splits: 0:80/80:90/90:100
     num_workers: 0
     cached_data_path: ${generate.cached_data_path}
-    train_n_batches: null
     file_prefix: ${generate.file_prefix}
     bands: [0, 1, 2, 3, 4]
-    val_split_file_idxs: null # inclusive range
-    test_split_file_idxs: null # inclusive range
 
 encoder:
     _target_: bliss.encoder.Encoder

--- a/bliss/simulator/simulated_dataset.py
+++ b/bliss/simulator/simulated_dataset.py
@@ -237,10 +237,10 @@ class CachedSimulatedDataset(pl.LightningDataModule, Dataset):
 
     def train_dataloader(self):
         assert self.data, "No cached train data loaded; run `generate.py` first"
-        assert len(self.data[self.slices[0]]) > self.batch_size, (
+        assert len(self.data[self.slices[0]]) >= self.batch_size, (
             f"Insufficient cached data loaded; "
             f"need at least {self.batch_size} "
-            f"but only have {self.data[self.slices[0]]}. Re-run `generate.py` with "
+            f"but only have {len(self.data[self.slices[0]])}. Re-run `generate.py` with "
             f"different generation `train_n_batches` and/or `batch_size`."
         )
         return DataLoader(

--- a/bliss/simulator/simulated_dataset.py
+++ b/bliss/simulator/simulated_dataset.py
@@ -215,14 +215,15 @@ class CachedSimulatedDataset(pl.LightningDataModule, Dataset):
         # parse slices from percentages to indices
         self.slices = self.parse_slices(splits, len(self.data))
 
-    def pct_to_idx(self, x, length):
+    def _percent_to_idx(self, x, length):
+        """Converts string in percent to an integer index."""
         return int(float(x.strip()) / 100 * length) if x.strip() else None
 
     def parse_slices(self, splits: str, length: int):
         slices = [slice(0, 0) for _ in range(3)]  # default to empty slice for each split
         for i, data_split in enumerate(splits.split("/")):
-            # map "start_pct:stop_pct" to slice(start_idx, stop_idx)
-            slices[i] = slice(*(self.pct_to_idx(val, length) for val in data_split.split(":")))
+            # map "start_percent:stop_percent" to slice(start_idx, stop_idx)
+            slices[i] = slice(*(self._percent_to_idx(val, length) for val in data_split.split(":")))
         return slices
 
     def read_file(self, filename: str) -> List[FileDatum]:

--- a/bliss/simulator/simulated_dataset.py
+++ b/bliss/simulator/simulated_dataset.py
@@ -190,77 +190,74 @@ class SimulatedDataset(pl.LightningDataModule, IterableDataset):
 class CachedSimulatedDataset(pl.LightningDataModule, Dataset):
     def __init__(
         self,
-        train_n_batches: int,
+        splits: str,
         batch_size: int,
         bands: List,
         num_workers: int,
         cached_data_path: str,
         file_prefix: str,
-        val_split_file_idxs: List[int],
-        test_split_file_idxs: List[int],
     ):
         super().__init__()
 
-        self.train_n_batches = train_n_batches
         self.num_workers = num_workers
         self.batch_size = batch_size
         self.cached_data_path = cached_data_path
         self.file_prefix = file_prefix
         self.bands = bands
-        self.val_split_file_idxs = val_split_file_idxs or []
-        self.test_split_file_idxs = test_split_file_idxs or []
-
-        self.data: List[FileDatum] = []
-        self.valid: List[FileDatum] = []
-        self.test: List[FileDatum] = []
 
         # assume cached image files exist, read from disk
+        self.data: List[FileDatum] = []
         for filename in os.listdir(self.cached_data_path):
             if not filename.endswith(".pt"):
                 continue
+            self.data += self.read_file(f"{self.cached_data_path}/{filename}")
 
-            file_idx = int(filename.split("_")[-1].split(".")[0])
-            if file_idx in self.val_split_file_idxs or file_idx in self.test_split_file_idxs:
-                continue
-            if filename.startswith(self.file_prefix) and filename.endswith(".pt"):
-                self.data += self.read_file(f"{self.cached_data_path}/{filename}")
+        # parse slices from percentages to indices
+        self.slices = self.parse_slices(splits, len(self.data))
 
-        # fix validation set
-        for idx in self.val_split_file_idxs:
-            filename = f"{self.file_prefix}_{idx}.pt"
-            self.valid += self.read_file(f"{self.cached_data_path}/{filename}")
+    def pct_to_idx(self, x, length):
+        return int(float(x.strip()) / 100 * length) if x.strip() else None
 
-        # fix test set
-        for idx in self.test_split_file_idxs:
-            filename = f"{self.file_prefix}_{idx}.pt"
-            self.test += self.read_file(f"{self.cached_data_path}/{filename}")
+    def parse_slices(self, splits: str, length: int):
+        slices = [slice(0, 0) for _ in range(3)]  # default to empty slice for each split
+        for i, data_split in enumerate(splits.split("/")):
+            # map "start_pct:stop_pct" to slice(start_idx, stop_idx)
+            slices[i] = slice(*(self.pct_to_idx(val, length) for val in data_split.split(":")))
+        return slices
 
     def read_file(self, filename: str) -> List[FileDatum]:
         with open(filename, "rb") as f:
             return torch.load(f)
 
     def __len__(self):
-        return self.train_n_batches * self.batch_size
+        return len(self.data[self.slices[0]])
 
     def __getitem__(self, idx):
         return self.data[idx]
 
     def train_dataloader(self):
         assert self.data, "No cached train data loaded; run `generate.py` first"
-        assert len(self.data) >= self.train_n_batches * self.batch_size, (
+        assert len(self.data[self.slices[0]]) > self.batch_size, (
             f"Insufficient cached data loaded; "
-            f"need at least {self.train_n_batches * self.batch_size} "
-            f"but only have {len(self.data)}. Re-run `generate.py` with "
+            f"need at least {self.batch_size} "
+            f"but only have {self.data[self.slices[0]]}. Re-run `generate.py` with "
             f"different generation `train_n_batches` and/or `batch_size`."
         )
         return DataLoader(
-            self, shuffle=True, batch_size=self.batch_size, num_workers=self.num_workers
+            self.data[self.slices[0]],
+            shuffle=True,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
         )
 
     def val_dataloader(self):
-        assert self.valid, "No cached validation data found; run `generate.py` first"
-        return DataLoader(self.valid, batch_size=self.batch_size, num_workers=self.num_workers)
+        assert self.data[self.slices[1]], "No cached validation data found; run `generate.py` first"
+        return DataLoader(
+            self.data[self.slices[1]], batch_size=self.batch_size, num_workers=self.num_workers
+        )
 
     def test_dataloader(self):
-        assert self.test, "No cached test data found; run `generate.py` first"
-        return DataLoader(self.test, batch_size=self.batch_size, num_workers=self.num_workers)
+        assert self.data[self.slices[2]], "No cached test data found; run `generate.py` first"
+        return DataLoader(
+            self.data[self.slices[2]], batch_size=self.batch_size, num_workers=self.num_workers
+        )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -92,10 +92,8 @@ class TestApi:
         weight_save_path = "tests/test_model.pt"
         bliss_client.train_on_cached_data(
             weight_save_path=weight_save_path,
-            train_n_batches=1,
+            splits="0:50/50:100/50:100",
             batch_size=8,
-            val_split_file_idxs=[1],
-            test_split_file_idxs=[1],
             cached_simulator=cached_simulator_cfg,
             training=training_cfg,
         )


### PR DESCRIPTION
Fixes #880. Parsing full slices ("0:80/80:90/90:100") was easier than relative values ("80/10/10") so I just went with this for now, since it allows for more flexibility anyway. Not sure if we need more sophisticated input validation - let me know if you think I should add it.