### PR TITLE
truncate location distribution in the unit box

### DIFF
--- a/bliss/encoder.py
+++ b/bliss/encoder.py
@@ -21,7 +21,7 @@ from bliss.surveys.sdss import SloanDigitalSkySurvey as SDSS
 from bliss.transforms import z_score
 from bliss.unconstrained_dists import (
     UnconstrainedBernoulli,
-    UnconstrainedDiagonalBivariateNormal,
+    UnconstrainedTDBN,
     UnconstrainedLogitNormal,
     UnconstrainedLogNormal,
 )
@@ -98,7 +98,7 @@ class Encoder(pl.LightningModule):
     def dist_param_groups(self):
         d = {
             "on_prob": UnconstrainedBernoulli(),
-            "loc": UnconstrainedDiagonalBivariateNormal(),
+            "loc": UnconstrainedTDBN(),
             "galaxy_prob": UnconstrainedBernoulli(),
             # galsim parameters
             "galsim_disk_frac": UnconstrainedLogitNormal(),

--- a/bliss/encoder.py
+++ b/bliss/encoder.py
@@ -21,9 +21,9 @@ from bliss.surveys.sdss import SloanDigitalSkySurvey as SDSS
 from bliss.transforms import z_score
 from bliss.unconstrained_dists import (
     UnconstrainedBernoulli,
-    UnconstrainedTDBN,
     UnconstrainedLogitNormal,
     UnconstrainedLogNormal,
+    UnconstrainedTDBN,
 )
 
 

--- a/bliss/unconstrained_dists.py
+++ b/bliss/unconstrained_dists.py
@@ -51,6 +51,14 @@ class TruncatedDiagonalMVN(Distribution):
         # https://cran.r-project.org/web/packages/truncnorm/
         raise NotImplementedError("sampling a truncated normal isn't straightforward")
 
+    @property
+    def mode(self):
+        mu = self.base_dist.mean
+        # a mode still exists if this assertion is false, but I haven't implemented code
+        # to compute it because I don't think we need it
+        assert (mu >= 0).all() and (mu <= 1).all()
+        return self.base_dist.mode
+
     def log_prob(self, value):
         assert (value >= 0).all() and (value <= 1).all()
         # subtracting log probability that the base RV is in the unit box

--- a/bliss/unconstrained_dists.py
+++ b/bliss/unconstrained_dists.py
@@ -2,12 +2,12 @@ import torch
 from torch.distributions import (
     AffineTransform,
     Categorical,
+    Distribution,
     Independent,
     LogNormal,
     Normal,
     SigmoidTransform,
     TransformedDistribution,
-    Distribution
 )
 
 
@@ -34,8 +34,11 @@ class UnconstrainedNormal:
 
 
 class TruncatedDiagonalMVN(Distribution):
-    """A truncated diagonal multivariate normal distribution"""
+    """A truncated diagonal multivariate normal distribution."""
+
     def __init__(self, mu, sigma):
+        super().__init__()
+
         multiple_normals = Normal(mu, sigma)
         prob_in_unit_box_hw = multiple_normals.cdf(torch.ones_like(mu))
         prob_in_unit_box_hw -= multiple_normals.cdf(torch.zeros_like(mu))
@@ -43,10 +46,10 @@ class TruncatedDiagonalMVN(Distribution):
 
         self.base_dist = Independent(multiple_normals, 1)
 
-    def sample(**args):
+    def sample(self, **args):
         # some ideas for how to sample it here, if we need to:
         # https://cran.r-project.org/web/packages/truncnorm/
-        raise NotImplemented("sampling a truncated normal isn't straightforward")
+        raise NotImplementedError("sampling a truncated normal isn't straightforward")
 
     def log_prob(self, value):
         assert (value >= 0).all() and (value <= 1).all()
@@ -56,9 +59,8 @@ class TruncatedDiagonalMVN(Distribution):
 
 
 class UnconstrainedTDBN:
-    """A factory for truncated bivariate normal distributions with support on the unit square
-    and diagonal covariance
-    """
+    """Produces truncated bivariate normal distributions from unconstrained parameters."""
+
     def __init__(self):
         self.dim = 4
 

--- a/tests/test_unconstained_dists.py
+++ b/tests/test_unconstained_dists.py
@@ -1,0 +1,37 @@
+import torch
+from torch.distributions import Normal
+
+from bliss.unconstrained_dists import TruncatedDiagonalMVN
+
+
+class TestUnconstainedDists:
+    def test_tdbn_univariate(self, cfg):
+        # first check that a univariate normal distribution with neglible probablity mass
+        # outside of the unit interval is equivalent to a truncated mvn with the same parameters
+        mu = torch.ones(1) * 0.6
+        sigma = torch.ones(1) * 1e-3
+        tdmn = TruncatedDiagonalMVN(mu, sigma)
+        claimed = tdmn.log_prob(mu)
+        approx_true = Normal(mu, sigma).log_prob(mu)
+        assert torch.isclose(claimed, approx_true)
+
+        # a standard normal has about 68% of its mass in [-1,1], and therefore 34% in [0, 1].
+        # check that its density function is therefore 34% of our truncated standard normal
+        mu = torch.zeros(1)
+        sigma = torch.ones(1)
+        tdmn = TruncatedDiagonalMVN(mu, sigma)
+        x = torch.ones(1) * 0.1234
+        claimed = 0.34 * tdmn.log_prob(x).exp()
+        approx_true = Normal(mu, sigma).log_prob(x).exp()
+        assert torch.isclose(claimed, approx_true, atol=0.01)
+
+
+    def test_tdbn_multivariate(self, cfg):
+        # first check that a bivariate normal distribution with neglible probablity mass
+        # outside of the unit box is equivalent to a truncated mvn with the same parameters
+        mu = torch.ones(32, 2) * 0.6
+        sigma = torch.ones(32, 2) * 1e-3
+        tdmn = TruncatedDiagonalMVN(mu, sigma)
+        claimed = tdmn.log_prob(mu)
+        approx_true = Normal(mu, sigma).log_prob(mu).sum(-1)
+        assert torch.isclose(claimed, approx_true).all()

--- a/tests/test_unconstained_dists.py
+++ b/tests/test_unconstained_dists.py
@@ -25,7 +25,6 @@ class TestUnconstainedDists:
         approx_true = Normal(mu, sigma).log_prob(x).exp()
         assert torch.isclose(claimed, approx_true, atol=0.01)
 
-
     def test_tdbn_multivariate(self, cfg):
         # first check that a bivariate normal distribution with neglible probablity mass
         # outside of the unit box is equivalent to a truncated mvn with the same parameters


### PR DESCRIPTION
This PR fixes #692 and may help with #806. Perhaps surprisingly, the former pretrained weights still seem to work with this change.