### PR TITLE
Add repr to TruncatedDiagonalMVN class

### DIFF
--- a/bliss/unconstrained_dists.py
+++ b/bliss/unconstrained_dists.py
@@ -46,6 +46,9 @@ class TruncatedDiagonalMVN(Distribution):
 
         self.base_dist = Independent(multiple_normals, 1)
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.base_dist.base_dist})"
+
     def sample(self, **args):
         # some ideas for how to sample it here, if we need to:
         # https://cran.r-project.org/web/packages/truncnorm/


### PR DESCRIPTION
`torch.Distribution` doesn't have a default `__repr__` apparently, so trying to print `TruncatedDiagonalMVN` fails with `NotImplementedError`. This PR just adds a simple `__repr__` that prints it similar to what it used to be before:
```
>>> print(pred["loc"])
TruncatedDiagonalMVN(Normal(loc: torch.Size([1, 18, 18, 2]), scale: torch.Size([1, 18, 18, 2])))
```