### PR TITLE
Add CDF for TruncatedDiagonalMVN

### DIFF
--- a/tests/test_unconstained_dists.py
+++ b/tests/test_unconstained_dists.py
@@ -34,3 +34,11 @@ class TestUnconstainedDists:
         claimed = tdmn.log_prob(mu)
         approx_true = Normal(mu, sigma).log_prob(mu).sum(-1)
         assert torch.isclose(claimed, approx_true).all()
+
+    def test_tdbn_cdf(self):
+        mu = torch.ones(32, 2) * 0.6
+        sigma = torch.ones(32, 2) * 1e-3
+        tdmn = TruncatedDiagonalMVN(mu, sigma)
+        assert torch.all(tdmn.cdf(torch.zeros_like(mu)) == 0)
+        assert torch.all(tdmn.cdf(torch.ones_like(mu)) == 1)
+        assert torch.all((tdmn.cdf(mu) >= 0).bool() & (tdmn.cdf(mu) <= 1).bool())


### PR DESCRIPTION
Another quick fix for `TruncatedDiagonalMVN` - I think we need the CDF for #806 to evaluate the probability that a source is within the interior region,
$$q_\phi(z^{(i)}) = \mathbb{I}[z^{(i)} = \varnothing](1 - q_{\phi_i}(y_i = 1)\mathbf{q_{\phi_i}(\ell_i \in R_i)}) + \mathbb{I}[z^{(i)} \neq \varnothing]q_{\phi_i}(z^{(i)})$$

In code this first term would translate to
```
loss += (true_cat.n_sources == 0) * (1 - on_prob * (pred["loc"].cdf([0.95, 0.95]) - pred["loc"].cdf([0.05, 0.05]))
```