### PR TITLE
Update galsim version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1694,38 +1694,38 @@ files = [
 
 [[package]]
 name = "galsim"
-version = "2.4.7"
+version = "2.4.10"
 description = "The modular galaxy image simulation toolkit"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "GalSim-2.4.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a5e82018ef2c6017f94d723981a31bc41948610b33328f49217085e14b185edf"},
-    {file = "GalSim-2.4.7-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e17282819c7525867072a39539d363a2cf39dd085a89234f89784f75366c8d7b"},
-    {file = "GalSim-2.4.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04b5a75d46ceae834016b252e7e76bebc01b79e40e27cb99fd4b4caf72adcb9f"},
-    {file = "GalSim-2.4.7-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6c63aaebfdebf434d281b1bb6e9d94a1264be0682b5c570d7a5cb75105e851cf"},
-    {file = "GalSim-2.4.7-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0cdca8a6ef661c91890565c3cf2e2af339f917c2b189cf38edc513b9d3281798"},
-    {file = "GalSim-2.4.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0231cfb1255077e20071cb198c7089af23dd588684cbec42fdff6efefbe5104f"},
-    {file = "GalSim-2.4.7-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2cdbf5af8fda389f79449466f6b716a00dd488b3971d3672bead61c65c803204"},
-    {file = "GalSim-2.4.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ddef2855bd3426c329c25f555f8b5ad3a88637c6cc1dd8a230f7e213e58f7d58"},
-    {file = "GalSim-2.4.7-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:0bcbf1803956192e4e2ab15b2ecf090c973533415f34d7ba6e10ed33d7317156"},
-    {file = "GalSim-2.4.7-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:98866574f6a3b0b35c58630687c65ba614eb86c75c5003de8d0cf8448617a84f"},
-    {file = "GalSim-2.4.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d34bfb8b7846f64ee517211551ccadd8ca8dd5ceaefaf5e8d45dd0b1980e95e5"},
-    {file = "GalSim-2.4.7-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bf4e359b691cbc9964de0eb25c709112525a02a592a27be216e7782422d1056c"},
-    {file = "GalSim-2.4.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:699e12c1be15431fbe83f0019b6dc31e99a0c65b77a195b51de0f967f15880ff"},
-    {file = "GalSim-2.4.7-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:1e62c7a95d7406f83a4d4e8b23aeca22df1031d740ddc71d070a8a141930390d"},
-    {file = "GalSim-2.4.7-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:70851b937b064bce88e77d0cbd11f8be766e13af4e2df8e7a63b06fe815dd671"},
-    {file = "GalSim-2.4.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e2960f44d1de9bcea703867d8e8c783572e50ffd38994bca16a2f69861ccfc34"},
-    {file = "GalSim-2.4.7-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d3af55ba0aa025a79eb4e55b0e2430d997ce806b41176eabacf824720ecb08f3"},
-    {file = "GalSim-2.4.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51d14646111f2e21689aec34e12f795140f4ab65c94fd80ceff9bfd77416d7b3"},
-    {file = "GalSim-2.4.7-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:022ece16b0bf444bfe56fb936575110688a1c299333aef207012d92ed2fa2ee0"},
-    {file = "GalSim-2.4.7-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:1c7fb7cff1a79559242e56aef73a52a482efdfcd99fdc12f66ff59061ee5f054"},
-    {file = "GalSim-2.4.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1df2651e880292764fef8250c89325774041e225b0538b4a7efa0d522d6dc7d4"},
-    {file = "GalSim-2.4.7-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f291bf7b7cc5bcb312fff95e8bc2dafbd30d34ae9719ab3d3ef62583b03a6e3"},
-    {file = "GalSim-2.4.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7c38c1923893dd977bd3cc5133892e37603eb79ae5ac2961e1040b6bf215fcd"},
-    {file = "GalSim-2.4.7-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:2c3c9e9b4a1f965bfaca7b8b44581d1276d0219a70bf50b02006a42a5c342306"},
-    {file = "GalSim-2.4.7-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8f990c36dbd87874adfa0aabb652b04274a8e10ff4d82dde912fea307433bd73"},
-    {file = "GalSim-2.4.7.tar.gz", hash = "sha256:267174f23a0a6666a9640b81096bbb065cfe7e3528dbcd2dc2c6c67eab8170bc"},
+    {file = "GalSim-2.4.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:be17ecfd741be6b0fc47bcef722116bb0d10d35f7a517302593fe38b7edf03d1"},
+    {file = "GalSim-2.4.10-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2dae72e2cf04080832213daabac06598855c6a37ec8709fc7a385c126ff7b7bf"},
+    {file = "GalSim-2.4.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8623fcb4d25eefb9590768618aa01b8810dbe524a40f5fbb9cd2d82f1b5bda1d"},
+    {file = "GalSim-2.4.10-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:91dc5aca39b540e16b126d30de537f99013f2801b2f2c22be9b05fb93a550b22"},
+    {file = "GalSim-2.4.10-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7681a6d475e5a055ed012a35db3974e08580e054973667d14386c0ca3aa7fe99"},
+    {file = "GalSim-2.4.10-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3daf692839b336cd663061c51c1771dd60ed45fb5bbd921a6fd69ec25178d535"},
+    {file = "GalSim-2.4.10-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5381148ebe7d4c10e9ba0404284f28e12213d5ca136d86e4e71079f22414c701"},
+    {file = "GalSim-2.4.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ea88de770165ff958a3aa34dbaccadcca724d21b957bedeae5ef94d3be8ba10"},
+    {file = "GalSim-2.4.10-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:05695873596fabbe50d9ce5308f6d38352fd0e72f782a34659f70e5b300a6463"},
+    {file = "GalSim-2.4.10-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:29a18f88346113efd05163a53e15754e4be4410fdacdfb1e276d10c3b1304954"},
+    {file = "GalSim-2.4.10-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f6d48d6fa140dfd762a5de88aa60cd855731d2579475ade5c8e7b13713dd2113"},
+    {file = "GalSim-2.4.10-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aaba719219f1ee28bf289bf083a21ccc2016c6da6dca3a260b7f599ce3249c77"},
+    {file = "GalSim-2.4.10-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebb94dadeea9e95df140f07c9b42fcf6d7d168b909663a9a8b7c05bac5c2fd6d"},
+    {file = "GalSim-2.4.10-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:57d187386267977e799d9d41f056c6cbf2a22b8c2fdefc671390806c4ee41537"},
+    {file = "GalSim-2.4.10-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:678bd8796fa999d691c230ffeb7b27083e5903726b225b668325dfcedee6d06b"},
+    {file = "GalSim-2.4.10-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cb2db1678b7363c0e56d16afa2018061c49a83c8113af74f372ceab3a7a42c86"},
+    {file = "GalSim-2.4.10-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:80691d9cd74eb2db0ca8a9e4fdcd63d4eccdfac54801fd3c681fba215af3eaa7"},
+    {file = "GalSim-2.4.10-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dae6da25db5960a030e18c00ace05a66e001f031c86f55494a229343a39b027"},
+    {file = "GalSim-2.4.10-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:b100fdad5e8898a3bb90d5c1d45f5e79e75389d19f1e5fdb9b22bd33740050e3"},
+    {file = "GalSim-2.4.10-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:ca2ba821261d5a59a4dcd52fc9612bc07334ba633e86a502165fbebfa02bef52"},
+    {file = "GalSim-2.4.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b0d613b73a6c1fb1ace9b4fce6663f308865adb946896c97023e3538ee7592c2"},
+    {file = "GalSim-2.4.10-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1042a3966010ee2ddb9b4c0ff67e9def90b76f91948c999c0683cdd93700ea30"},
+    {file = "GalSim-2.4.10-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8387504cb3b88fdff85969b4aae9840fbd30b56f7516a53130c230faf5d13dc3"},
+    {file = "GalSim-2.4.10-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:1fdace7239e2586696574e566bcb5baee2e9df4477e528b20b5c27012cd7f5a4"},
+    {file = "GalSim-2.4.10-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e1b6de2ec8369f5b2c8b8193b219b577e46dce64161813445a1dc3619c2bdccc"},
+    {file = "GalSim-2.4.10.tar.gz", hash = "sha256:246b9b4aa578a4dfa2c78477a5d2c1805c5eb397e1a79c157269c15306e655b7"},
 ]
 
 [package.dependencies]
@@ -4874,7 +4874,8 @@ files = [
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win32.whl", hash = "sha256:763d65baa3b952479c4e972669f679fe490eee058d5aa85da483ebae2009d231"},
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
-    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:1a6391a7cabb7641c32517539ca42cf84b87b667bad38b78d4d42dd23e957c81"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:9c7617df90c1365638916b98cdd9be833d31d337dbcd722485597b43c4a215bf"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win32.whl", hash = "sha256:f6d3d39611ac2e4f62c3128a9eed45f19a6608670c5a2f4f07f24e8de3441d38"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win_amd64.whl", hash = "sha256:da538167284de58a52109a9b89b8f6a53ff8437dd6dc26d33b57bf6699153122"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ hydra-core = ">=1.0.4"
 yolov5 = "^7.0.9"
 bokeh = "^3.1.1"
 astropy = ">=4.2.1"
-galsim = ">=2.2.4"
+galsim = ">=2.4.10"
 reproject = ">=0.11.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
pip doesn't support galsim 2.4.7 anymore, so we're upgrading to the latest version 2.4.10.