### PR TITLE
Uploading temporary baseline model supporting 5D input, 3D conv

### DIFF
--- a/data/pretrained_models/3d_conv_log.pt
+++ b/data/pretrained_models/3d_conv_log.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d5d75819d54d0a9c27e805cd4ef70400f591c56a82abff3181547b49f902586
+size 123516127


### PR DESCRIPTION
This PR uploads a temporary baseline model supporting 5D input with 3D convolutions. The only transform it takes is a `log_transform` of the background-subtracted image. 