### PR TITLE
Don't modify batch in get_input_tensor

### DIFF
--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -335,8 +335,8 @@ def plot_predict(
         background = backgrounds_for_frame[image_id]
 
         ptc = cfg.encoder.tiles_to_crop * cfg.encoder.tile_slen
-        image = image[0, 0, 0, ptc:-ptc, ptc:-ptc]
-        background = background[0, 0, 0, ptc:-ptc, ptc:-ptc]
+        image = image[0, 0, ptc:-ptc, ptc:-ptc]
+        background = background[0, 0, ptc:-ptc, ptc:-ptc]
 
         w, h = image.shape
 


### PR DESCRIPTION
Previously, `get_input_tensor` modified `batch` in-place to add an extra dim. This is annoying as `batch` can't be used again without squeezing out the extra dim. Instead, we now use a view of the original tensor instead (this is more efficient than making a copy, and since the current code doesn't modify any of the data itself, should be safe to do).

![image](https://github.com/prob-ml/bliss/assets/26699876/608f6d34-958f-44db-9000-d9a0451ecc49)
