### PR TITLE
Compute metrics during training with RegionEncoder

### DIFF
--- a/bliss/metrics.py
+++ b/bliss/metrics.py
@@ -154,6 +154,8 @@ class BlissMetrics(Metric):
             if ntrue == 0 or nest == 0:
                 if nest > 0:
                     self.detection_fp += nest
+                match_true.append([])
+                match_est.append([])
                 continue
 
             mtrue, mest, dkeep, avg_distance, avg_keep_distance = match_by_locs(
@@ -204,6 +206,8 @@ class BlissMetrics(Metric):
 
         # get parameters depending on the kind of catalog
         if self.mode is MetricsMode.FULL:
+            if not (match_true and match_est):
+                return  # need matches to compute classification metrics on full catalog
             true_params, est_params = self._get_classification_params_full(
                 true, est, match_true, match_est
             )

--- a/case_studies/adaptive_tiling/region_encoder.py
+++ b/case_studies/adaptive_tiling/region_encoder.py
@@ -606,7 +606,13 @@ class RegionEncoder(Encoder):
             self.log("{}/{}".format(logging_name, k), v, batch_size=batch_size)
 
         if log_metrics or plot_images:
-            est_tile_cat = self.variational_mode(pred, return_full=False)
+            est_full_cat = self.variational_mode(pred, return_full=True)
+
+        # log all metrics
+        if log_metrics:
+            metrics = self.metrics(true_cat.to_full_params(), est_full_cat)
+            for k, v in metrics.items():
+                self.log("{}/{}".format(logging_name, k), v, batch_size=batch_size)
 
         # log a grid of figures to the tensorboard
         if plot_images:
@@ -615,7 +621,6 @@ class RegionEncoder(Encoder):
             nrows = int(n_samples**0.5)  # for figure
 
             target_full_cat = true_cat.to_full_params()
-            est_full_cat = est_tile_cat.to_full_params()
             idx = est_full_cat.n_sources.nonzero().view(-1)[:n_samples]
 
             margin_px = self.tiles_to_crop * self.tile_slen


### PR DESCRIPTION
Fixes #915.

I remembered the main issue with metrics wasn't the predicted catalog, it was that the true catalog is a `RegionCatalog` and we don't have a good way of converting it to a `TileCatalog` for the conditional tile-based metrics. Since we care more about detection metrics with the region encoder, I just used the `FullCatalog`-based metrics instead.