### PR TITLE
Update BLISS version to 0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ name = "bliss-toolkit"
 packages = [{include = "bliss"}]
 readme = "README.md"
 repository = "https://github.com/prob-ml/bliss"
-version = "0.2.2"
+version = "0.3"
 
 [tool.poetry.scripts]
 bliss = "bliss.api:main"


### PR DESCRIPTION
Only change after v0.3 PyPI version is fixes to GMM model load warning, so have just tagged latest status as v0.3.