### PR TITLE
Don't load real images when simulating data

### DIFF
--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -101,7 +101,7 @@ def nelec_to_nmgy_for_catalog(est_cat, nelec_per_nmgy_per_band):
 
 
 def predict(cfg):
-    survey = instantiate(cfg.predict.dataset)
+    survey = instantiate(cfg.predict.dataset, load_image_data=True)
 
     # below collections indexed by image_id
     images_for_frame = {}
@@ -279,8 +279,8 @@ def plot_image(cfg, ra, dec, img, w, h, est_plocs, survey_true_plocs, title):
         decals_plocs = TractorFullCatalog.from_file(
             tractor_filename,
             wcs=decals[0]["wcs"][cfg.simulator.prior.reference_band],
-            height=decals[0]["image"].shape[1],
-            width=decals[0]["image"].shape[2],
+            height=decals[0]["background"].shape[1],
+            width=decals[0]["background"].shape[2],
         ).plocs[0]
         decals_plocs = np.array(crop_plocs(cfg, w, h, decals_plocs, do_crop).cpu())
 
@@ -293,8 +293,8 @@ def plot_image(cfg, ra, dec, img, w, h, est_plocs, survey_true_plocs, title):
         sdss_plocs = PhotoFullCatalog.from_file(
             photocat_filename,
             wcs=sdss[0]["wcs"][cfg.simulator.prior.reference_band],
-            height=sdss[0]["image"].shape[1],
-            width=sdss[0]["image"].shape[2],
+            height=sdss[0]["background"].shape[1],
+            width=sdss[0]["background"].shape[2],
         ).plocs[0]
         sdss_plocs = np.array(crop_plocs(cfg, w, h, sdss_plocs, do_crop).cpu())
     return TabPanel(

--- a/bliss/surveys/des.py
+++ b/bliss/surveys/des.py
@@ -80,10 +80,13 @@ class DarkEnergySurvey(Survey):
                 "z": "decam/CP/V4.8.2a/CP20170926/c4d_170927_025655_ooi_z_ls9",
             },
         ),
+        load_image_data: bool = False,
     ):
         super().__init__()
 
         self.des_path = Path(dir_path)
+
+        self.load_image_data = load_image_data
 
         self.image_id_list = self.process_image_ids(image_ids)
         self.bands = tuple(range(len(self.BANDS)))
@@ -98,10 +101,12 @@ class DarkEnergySurvey(Survey):
         self.flux_calibration_dict = self.get_flux_calibrations()
 
         self.catalog_cls = TractorFullCatalog
-        self._predict_batch = {"images": self[0]["image"], "background": self[0]["background"]}
+        if self.load_image_data:
+            self._predict_batch = {"images": self[0]["image"], "background": self[0]["background"]}
 
     def prepare_data(self):
-        self.downloader.download_images()
+        if self.load_image_data:
+            self.downloader.download_images()
         self.downloader.download_backgrounds()
         self.downloader.download_psfexs()
 
@@ -130,18 +135,20 @@ class DarkEnergySurvey(Survey):
         first_present_bl_obj = self.read_image_for_band(des_image_id, first_present_bl)
         image_list[DES.BANDS.index(first_present_bl)] = first_present_bl_obj
 
-        img_shape = first_present_bl_obj["image"].shape
+        img_shape = first_present_bl_obj["background"].shape
         for b, bl in enumerate(self.BANDS):
             if bl != first_present_bl and des_image_id[bl]:
                 image_list[b] = self.read_image_for_band(des_image_id, bl)
             elif bl != first_present_bl:
                 image_list[b] = {
-                    "image": np.zeros(img_shape, dtype=np.float32),
                     "background": np.random.rand(*img_shape).astype(np.float32),
                     "wcs": first_present_bl_obj["wcs"],  # NOTE: junk; just for format
                     "flux_calibration_list": np.ones((1, 1, 1)),
-                    "sig1": 0.0,
                 }
+                if self.load_image_data:
+                    image_list[b].update(
+                        {"image": np.zeros(img_shape).astype(np.float32), "sig1": 0.0}
+                    )
 
         ret = {}
         for k in image_list[0]:
@@ -157,33 +164,36 @@ class DarkEnergySurvey(Survey):
         brickname = des_image_id["decals_brickname"]
         ccdname = des_image_id["ccdname"]
         image_basename = DESDownloader.image_basename_from_filename(des_image_id[band], band)
-        image_fits = fits.open(self.des_path / brickname[:3] / brickname / f"{image_basename}.fits")
-        image_hdu = image_fits[0]
-        image = image_hdu.data  # pylint: disable=no-member
-        hr = image_hdu.header  # pylint: disable=no-member
+        img_fits_filename = self.des_path / brickname[:3] / brickname / f"{image_basename}.fits"
+        hr = fits.getheader(img_fits_filename, 0)  # pylint: disable=no-member
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FITSFixedWarning)
             wcs = WCS(hr)
-
-        # compute sig1 (cf. https://github.com/dstndstn/tractor/blob/cdb82000422e85c9c97b134edadff31d68bced0c/projects/desi/decam.py#L313-L333) # noqa: E501 # pylint: disable=line-too-long
-        diffs = image[:-5:10, :-5:10] - image[5::10, 5::10]
-        mad = np.median(np.abs(diffs).ravel())
-        zpscale = DES.zpt_to_scale(hr["MAGZPT"])
-        sig1 = (1.4826 * mad / np.sqrt(2.0)) / zpscale
+        image_shape = (hr["NAXIS2"], hr["NAXIS1"])
 
         flux_calibration = self.GAIN * hr["EXPTIME"]
-        image_nelec = image.astype(np.float32) * flux_calibration
         background_nelec = (
             self.splinesky_level_for_band(brickname, ccdname, des_image_id[band], image.shape)
             * flux_calibration
         )
-        return {
-            "image": image_nelec,
+        d = {
             "background": background_nelec,
             "wcs": wcs,
             "flux_calibration_list": np.array([[[flux_calibration]]]),
-            "sig1": sig1,
         }
+        if self.load_image_data:
+            # compute sig1 (cf. https://github.com/dstndstn/tractor/blob/cdb82000422e85c9c97b134edadff31d68bced0c/projects/desi/decam.py#L313-L333) # noqa: E501 # pylint: disable=line-too-long
+            image = fits.getdata(img_fits_filename, 0)  # pylint: disable=no-member
+
+            # TODO: don't use image data to compute sig1 - so DECaLS gen won't load DES images
+            diffs = image[:-5:10, :-5:10] - image[5::10, 5::10]
+            mad = np.median(np.abs(diffs).ravel())
+            zpscale = DES.zpt_to_scale(hr["MAGZPT"])
+            sig1 = (1.4826 * mad / np.sqrt(2.0)) / zpscale
+                
+            image_nelec = image.astype(np.float32) * flux_calibration
+            d.update({"image": image_nelec, "sig1": sig1})
+        return d
 
     def splinesky_level_for_band(self, brickname, ccdname, image_filename, image_shape):
         save_filename = DESDownloader.save_filename_from_image_filename(image_filename)

--- a/bliss/surveys/des.py
+++ b/bliss/surveys/des.py
@@ -105,8 +105,7 @@ class DarkEnergySurvey(Survey):
             self._predict_batch = {"images": self[0]["image"], "background": self[0]["background"]}
 
     def prepare_data(self):
-        if self.load_image_data:
-            self.downloader.download_images()
+        self.downloader.download_images()
         self.downloader.download_backgrounds()
         self.downloader.download_psfexs()
 
@@ -173,7 +172,7 @@ class DarkEnergySurvey(Survey):
 
         flux_calibration = self.GAIN * hr["EXPTIME"]
         background_nelec = (
-            self.splinesky_level_for_band(brickname, ccdname, des_image_id[band], image.shape)
+            self.splinesky_level_for_band(brickname, ccdname, des_image_id[band], image_shape)
             * flux_calibration
         )
         d = {
@@ -190,7 +189,7 @@ class DarkEnergySurvey(Survey):
             mad = np.median(np.abs(diffs).ravel())
             zpscale = DES.zpt_to_scale(hr["MAGZPT"])
             sig1 = (1.4826 * mad / np.sqrt(2.0)) / zpscale
-                
+
             image_nelec = image.astype(np.float32) * flux_calibration
             d.update({"image": image_nelec, "sig1": sig1})
         return d

--- a/bliss/surveys/sdss.py
+++ b/bliss/surveys/sdss.py
@@ -108,15 +108,14 @@ class SloanDigitalSkySurvey(Survey):
                 for field, gain in zip(fieldnums, fieldgains):
                     self.rcfgcs.append((run, camcol, field, gain))
 
-        if self.load_image_data:
-            self.downloader.download_images()
-            for rcfgc in self.rcfgcs:
-                run, camcol, field, _ = rcfgc
-                field_path = self.sdss_path / f"{run}/{camcol}/{field}"
-                for bl in SloanDigitalSkySurvey.BANDS:
-                    frame_name = f"frame-{bl}-{run:06d}-{camcol:d}-{field:04d}.fits"
-                    frame_path = field_path / frame_name
-                    assert Path(frame_path).exists(), f"{frame_path} does not exist."
+        self.downloader.download_images()
+        for rcfgc in self.rcfgcs:
+            run, camcol, field, _ = rcfgc
+            field_path = self.sdss_path / f"{run}/{camcol}/{field}"
+            for bl in SloanDigitalSkySurvey.BANDS:
+                frame_name = f"frame-{bl}-{run:06d}-{camcol:d}-{field:04d}.fits"
+                frame_path = field_path / frame_name
+                assert Path(frame_path).exists(), f"{frame_path} does not exist."
 
         self.items = [None for _ in range(len(self.rcfgcs))]
 

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -188,8 +188,8 @@ class TestDecalsCatalog:
         decals_cat = TractorFullCatalog.from_file(
             cat_path=sample_file,
             wcs=decals[0]["wcs"][DECaLS.BANDS.index("r")],
-            height=decals[0]["image"].shape[1],
-            width=decals[0]["image"].shape[2],
+            height=decals[0]["background"].shape[1],
+            width=decals[0]["background"].shape[2],
         )
 
         ras = decals_cat["ra"].numpy()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -14,7 +14,7 @@ from bliss.surveys.sdss import SloanDigitalSkySurvey as SDSS
 class TestMetrics:
     def _get_sdss_data(self, cfg):
         """Loads SDSS frame and Photo Catalog."""
-        sdss = instantiate(cfg.surveys.sdss)
+        sdss = instantiate(cfg.surveys.sdss, load_image_data=True)
 
         run, camcol, field = sdss.image_id(0)
         photo_cat = PhotoFullCatalog.from_file(

--- a/tests/test_sdss.py
+++ b/tests/test_sdss.py
@@ -11,7 +11,7 @@ class TestSDSS:
         the_cfg.surveys.sdss.fields = [{"run": 3900, "camcol": 6, "fields": [269]}]
         sdss_obj = instantiate(the_cfg.surveys.sdss)
         an_obj = sdss_obj[0]
-        for k in ("image", "background", "gain", "flux_calibration_list", "calibration"):
+        for k in ("background", "gain", "flux_calibration_list", "calibration"):
             assert isinstance(an_obj[k], np.ndarray)
 
         assert an_obj["field"] == 269
@@ -23,5 +23,6 @@ class TestSDSS:
         the_cfg.paths.root = str(tmpdir_factory.mktemp("root"))
         if cfg.surveys.sdss.dir_path != the_cfg.surveys.sdss.dir_path:
             copytree(cfg.surveys.sdss.dir_path, the_cfg.surveys.sdss.dir_path, dirs_exist_ok=True)
-        sdss_obj = instantiate(the_cfg.surveys.sdss)[0]
+        # Also tests images loaded
+        sdss_obj = instantiate(the_cfg.surveys.sdss, load_image_data=True)[0]
         assert sdss_obj["image"].shape == (5, 1489, 2048)


### PR DESCRIPTION
Added binary variable `load_image_data` that conditionally loads real survey image data only when it is needed (e.g., in predict).

NOTE: DES image data is currently loaded for DECaLS data simulation because the parameter `sig1` used for DECaLS coadd PSF simulation uses this image data for its computation. This dependence likely can be easily removed.

Fixes #907.