### PR TITLE
Filter region catalog by flux per tile when converting from tile catalog

### DIFF
--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -238,7 +239,45 @@ class TestRegionCatalog:
         )
         assert full_cat.plocs.equal(true_locs)
 
-    def test_tile_cat_to_region(self, basic_tilecat):
-        region_cat = tile_cat_to_region_cat(basic_tilecat, 0.5)
+    def test_tile_cat_to_region_basic(self, basic_tilecat):
+        region_cat = tile_cat_to_region_cat(basic_tilecat, 0.5, discard_extra_sources=False)
         full_cat = basic_tilecat.to_full_params()
         assert region_cat.to_full_params().plocs.equal(full_cat.plocs)
+
+    def test_tile_cat_to_region_filtering(self):
+        d = {
+            "n_sources": torch.zeros(3, 2, 2),
+            "locs": torch.zeros(3, 2, 2, 1, 2),
+            "source_type": torch.ones((3, 2, 2, 1, 1)).bool(),
+            "galaxy_params": torch.zeros((3, 2, 2, 1, 6)),
+            "star_fluxes": torch.ones((3, 2, 2, 1, 5)) * 1000,
+            "galaxy_fluxes": torch.ones(3, 2, 2, 1, 5) * 1000,
+        }
+        # BATCH 0: top right interior, center right boundary
+        d["n_sources"][0, 0, 1] = 1
+        d["n_sources"][0, 1, 1] = 1
+        d["locs"][0, 0, 1, 0] = torch.tensor([0.5, 0.5])
+        d["locs"][0, 1, 1, 0] = torch.tensor([0.02, 0.5])
+        d["galaxy_fluxes"][0, 0, 1, 0, 2] = 5000  # keep top right
+
+        # BATCH 1: top left interior, top center boundary
+        d["n_sources"][1, 0, 0] = 1
+        d["n_sources"][1, 0, 1] = 1
+        d["locs"][1, 0, 0, 0] = torch.tensor([0.5, 0.5])
+        d["locs"][1, 0, 1, 0] = torch.tensor([0.5, 0.02])
+        d["galaxy_fluxes"][1, 0, 1, 0, 2] = 5000  # keep top center
+
+        # BATCH 2: only one source in top left
+        d["n_sources"][2, 0, 0] = 1
+        d["locs"][2, 0, 0, 0] = torch.tensor([0.5, 0.5])
+
+        tilecat = TileCatalog(4, d)
+
+        # make sure no warning when converting (since extra sources have been discarded)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            region_cat = tile_cat_to_region_cat(tilecat, 0.5, discard_extra_sources=True)
+
+        n_sources = region_cat.n_sources
+        assert n_sources[0, 0, 2] == n_sources[1, 0, 1] == n_sources[2, 0, 0] == 1
+        assert n_sources[0].sum() == n_sources[1].sum() == n_sources[2].sum()


### PR DESCRIPTION
Previously, when converting a `TileCatalog` to a `RegionCatalog` we would just discard it if the conversion would produce a region catalog with multiple sources in one tile. Now, we instead keep the highest flux source and turn off all others in that tile.

The high-level algorithm is as follows:
```
1. Create a unique integer index for each region
2. Unfold with a 3x3 kernel with padding=1 and stride=2 to get number of sources and integer indices in each 3x3 tile
3. Determine which tiles have more than one source and the integer index of those regions
4. For each problematic tile:
    - Get the flux of all "on" sources
    - Find the integer index of the region with the highest flux
    - Turn off all regions in the tile (for simplicity)
    - Turn the max flux region back on
```