### PR TITLE
more modular config file

### DIFF
--- a/bliss/catalog.py
+++ b/bliss/catalog.py
@@ -324,17 +324,8 @@ class TileCatalog(UserDict):
 
         return TileCatalog(self.tile_slen, d)
 
-    # endregion
-
     def __repr__(self):
-        """A computationally efficient representation of a TileCatalog.
-        By defining this method, we no longer get warnings from the debugger that says
-        'pydevd warning: Computing repr of self (TileCatalog) was slow'.
-
-        Returns:
-            string: a representation of a tile catalog
-        """
-        return f"TileCatalog({self.batch_size}, {self.n_tiles_h}, {self.n_tiles_w})"
+        return f"TileCatalog({self.batch_size} x {self.n_tiles_h} x {self.n_tiles_w})"
 
 
 class FullCatalog(UserDict):
@@ -342,7 +333,10 @@ class FullCatalog(UserDict):
 
     @staticmethod
     def plocs_from_ra_dec(ras, decs, wcs: WCS):
-        """Converts RA/DEC coordinates into pixel coordinates.
+        """Converts RA/DEC coordinates into BLISS's pixel coordinates.
+            BLISS pixel coordinates have (0, 0) as the lower-left corner, whereas standard pixel
+            coordinates begin at (-0.5, -0.5). BLISS pixel coordinates are in row-column order,
+            whereas standard pixel coordinates are in column-row order.
 
         Args:
             ras (Tensor): (b, n) tensor of RA coordinates in degrees.
@@ -505,6 +499,8 @@ class FullCatalog(UserDict):
             ValueError: If the number of sources in one tile exceeds `max_sources_per_tile` and
                 `ignore_extra_sources` is False.
         """
+        # TODO: a FullCatalog only needs to "know" its height and width to convert itself to a
+        # TileCatalog. So those parameters should be passed on conversion, not initialization.
         tile_coords = torch.div(self.plocs, tile_slen, rounding_mode="trunc").to(torch.int)
         n_tiles_h = math.ceil(self.height / tile_slen)
         n_tiles_w = math.ceil(self.width / tile_slen)

--- a/bliss/cli.py
+++ b/bliss/cli.py
@@ -29,11 +29,11 @@ def main(cfg):
         )
 
     if cfg.mode == "generate":
-        generate(cfg)
+        generate(cfg.generate)
     elif cfg.mode == "train":
-        train(cfg)
+        train(cfg.train)
     elif cfg.mode == "predict":
-        predict(cfg)
+        predict(cfg.predict)
     else:
         raise KeyError
 

--- a/bliss/conf/base_config.yaml
+++ b/bliss/conf/base_config.yaml
@@ -10,8 +10,6 @@ hydra:
     run:
         dir: .
 
-mode: train
-
 paths:
     root: ${oc.env:BLISS_HOME}
     data: ${paths.root}/data
@@ -93,47 +91,6 @@ encoder:
     compile_model: false  # if true, compile model for potential performance
     two_layers: false
 
-generate:
-    n_workers_per_process: 0
-    n_batches: ${simulator.n_batches}
-    batch_size: ${simulator.prior.batch_size}
-    max_images_per_file: 4096
-    cached_data_path: ${paths.data}/cached_dataset
-    file_prefix: dataset
-
-training:
-    name: null
-    version: null
-    n_epochs: 50
-    save_top_k: 1
-    enable_early_stopping: true
-    patience: 10
-    pretrained_weights: null
-    trainer:
-        _target_: pytorch_lightning.Trainer
-        logger: true
-        enable_checkpointing: true
-        profiler: null
-        reload_dataloaders_every_n_epochs: 0
-        check_val_every_n_epoch: 1
-        log_every_n_steps: 10  # corresponds to n_batches
-        max_epochs: ${training.n_epochs}
-        min_epochs: 1
-        accelerator: "gpu"
-        devices: 1
-    testing: true
-    seed: 42
-    weight_save_path: null
-    data_source: ${cached_simulator}
-    encoder_target: ${encoder}  # whether to use normal encoder or RegionEncoder
-
-predict:
-    dataset: ${surveys.sdss}
-    trainer: ${training.trainer}
-    encoder: ${encoder}
-    weight_save_path: ${paths.pretrained_models}/clahed_logged_20percent.pt
-    device: "cuda:0"
-
 surveys:
     sdss:
         _target_: bliss.surveys.sdss.SloanDigitalSkySurvey
@@ -186,3 +143,52 @@ surveys:
         image_lim: [4000, 4000]
         use_deconv_channel: ${encoder.image_normalizer.use_deconv_channel}
         deconv_path: ${paths.dc2}/coadd_deconv_image
+
+
+#######################################################################
+# things above matter only if they are referenced below
+
+mode: train
+
+generate:
+    n_workers_per_process: 0
+    n_batches: ${simulator.n_batches}
+    batch_size: ${simulator.prior.batch_size}
+    max_images_per_file: 4096
+    cached_data_path: ${paths.data}/cached_dataset
+    file_prefix: dataset
+    simulator: ${simulator}
+
+train:
+    name: null
+    version: null
+    n_epochs: 50
+    save_top_k: 1
+    enable_early_stopping: true
+    patience: 10
+    pretrained_weights: null
+    trainer:
+        _target_: pytorch_lightning.Trainer
+        logger: true
+        enable_checkpointing: true
+        profiler: null
+        reload_dataloaders_every_n_epochs: 0
+        check_val_every_n_epoch: 1
+        log_every_n_steps: 10  # corresponds to n_batches
+        max_epochs: ${train.n_epochs}
+        min_epochs: 1
+        accelerator: "gpu"
+        devices: 1
+    testing: true
+    seed: 42
+    weight_save_path: null
+    data_source: ${cached_simulator}
+    encoder: ${encoder}
+    output_dir: ${paths.output}
+
+predict:
+    dataset: ${surveys.sdss}
+    trainer: ${train.trainer}
+    encoder: ${encoder}
+    weight_save_path: ${paths.pretrained_models}/clahed_logged_20percent.pt
+    device: "cuda:0"

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -4,20 +4,10 @@ from hydra.utils import instantiate
 
 def predict(cfg):
     encoder = instantiate(cfg.encoder)
-    encoder.eval()
     encoder.load_state_dict(torch.load(cfg.predict.weight_save_path))
-
     dataset = instantiate(cfg.predict.dataset)
-
     trainer = instantiate(cfg.training.trainer)
     enc_output = trainer.predict(encoder, datamodule=dataset)
 
-    est_cat_tables = []
-    for batch_output in enc_output:
-        est_cat = batch_output["est_cat"]
-        full_cat = est_cat.to_full_catalog()
-        astropy_cat = full_cat.to_astropy_table(cfg.encoder.survey_bands)
-        est_cat_tables.append(astropy_cat)
-
-    # eventually we should return variational distribution samples too
-    return est_cat_tables
+    est_cats = [b["est_cat"].to_full_catalog() for b in enc_output]
+    return dict(zip(dataset.image_ids(), est_cats))

--- a/bliss/predict.py
+++ b/bliss/predict.py
@@ -2,11 +2,11 @@ import torch
 from hydra.utils import instantiate
 
 
-def predict(cfg):
-    encoder = instantiate(cfg.encoder)
-    encoder.load_state_dict(torch.load(cfg.predict.weight_save_path))
-    dataset = instantiate(cfg.predict.dataset)
-    trainer = instantiate(cfg.training.trainer)
+def predict(predict_cfg):
+    encoder = instantiate(predict_cfg.encoder)
+    encoder.load_state_dict(torch.load(predict_cfg.weight_save_path))
+    dataset = instantiate(predict_cfg.dataset)
+    trainer = instantiate(predict_cfg.trainer)
     enc_output = trainer.predict(encoder, datamodule=dataset)
 
     est_cats = [b["est_cat"].to_full_catalog() for b in enc_output]

--- a/bliss/train.py
+++ b/bliss/train.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 import pytorch_lightning as pl
 import torch
 from hydra.utils import instantiate
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.loggers import TensorBoardLogger
@@ -15,29 +15,36 @@ from pytorch_lightning.profilers import AdvancedProfiler
 from pytorch_lightning.utilities import rank_zero_only
 
 
-def train(cfg: DictConfig):  # pylint: disable=too-many-branches, too-many-statements
-    # setup paths and seed
-    paths = OmegaConf.to_container(cfg.paths, resolve=True)
-    setup_paths(paths)
-    pl.seed_everything(cfg.training.seed)
+def train(train_cfg: DictConfig):  # pylint: disable=too-many-branches, too-many-statements
+    # setup seed
+    pl.seed_everything(train_cfg.seed)
 
     # setup dataset
-    data_source_cfg = cfg.training.data_source
+    data_source_cfg = train_cfg.data_source
     dataset = instantiate(data_source_cfg)
 
     # setup model
-    encoder = instantiate(cfg.training.encoder_target)
+    encoder = instantiate(train_cfg.encoder)
 
     # load pretrained weights
-    if cfg.training.pretrained_weights is not None:
-        enc_state_dict = torch.load(cfg.training.pretrained_weights)
+    if train_cfg.pretrained_weights is not None:
+        enc_state_dict = torch.load(train_cfg.pretrained_weights)
         encoder.load_state_dict(enc_state_dict)
 
+    # setup logger
+    logger = False
+    if train_cfg.trainer.logger:
+        logger = TensorBoardLogger(
+            save_dir=train_cfg.output_dir,
+            name=train_cfg.name,
+            version=train_cfg.version,
+            default_hp_metric=False,
+        )
+
     # setup trainer
-    logger = setup_logger(cfg, paths)
-    checkpoint_callback = setup_checkpoint_callback(cfg)
-    early_stopping = setup_early_stopping(cfg)
-    profiler = setup_profiler(cfg)
+    checkpoint_callback = setup_checkpoint_callback(train_cfg)
+    early_stopping = setup_early_stopping(train_cfg)
+    profiler = setup_profiler(train_cfg)
 
     callbacks = []
     if checkpoint_callback:
@@ -45,12 +52,10 @@ def train(cfg: DictConfig):  # pylint: disable=too-many-branches, too-many-state
     if early_stopping:
         callbacks.append(early_stopping)
 
-    trainer = instantiate(
-        cfg.training.trainer, logger=logger, profiler=profiler, callbacks=callbacks
-    )
+    trainer = instantiate(train_cfg.trainer, logger=logger, profiler=profiler, callbacks=callbacks)
 
     if logger:
-        log_hyperparameters(config=cfg, trainer=trainer)
+        log_hyperparameters(train_cfg=train_cfg, trainer=trainer)
 
     # train!
     tic = time_ns()
@@ -58,46 +63,20 @@ def train(cfg: DictConfig):  # pylint: disable=too-many-branches, too-many-state
     toc = time_ns()
     train_time_sec = (toc - tic) * 1e-9
     # test!
-    if cfg.training.testing:
+    if train_cfg.testing:
         trainer.test(encoder, datamodule=dataset)
 
     # Save the best model to the final path
-    if cfg.training.weight_save_path and checkpoint_callback.best_model_path:
-        save_best_model(cfg, checkpoint_callback.best_model_path, train_time_sec)
+    if train_cfg.weight_save_path and checkpoint_callback.best_model_path:
+        save_best_model(train_cfg, checkpoint_callback.best_model_path, train_time_sec)
 
 
-def setup_paths(paths):
-    """Ensures that necessary paths exist before training."""
-    assert isinstance(paths, dict)
-    for key in paths.keys():
-        path = Path(paths[key])
-        if path.exists():
-            continue
-        if key in {"data", "sdss", "decals", "des", "dc2", "output", "pretrained_models"}:
-            path.mkdir(parents=True)
-        else:
-            err = "path for {} ({}) does not exist".format(str(key), path.as_posix())
-            raise FileNotFoundError(err)
-
-
-def setup_logger(cfg, paths):
-    logger = False
-    if cfg.training.trainer.logger:
-        logger = TensorBoardLogger(
-            save_dir=paths["output"],
-            name=cfg.training.name,
-            version=cfg.training.version,
-            default_hp_metric=False,
-        )
-    return logger
-
-
-def setup_checkpoint_callback(cfg):
+def setup_checkpoint_callback(train_cfg):
     checkpoint_callback = None
-    if cfg.training.trainer.enable_checkpointing:
+    if train_cfg.trainer.enable_checkpointing:
         checkpoint_callback = ModelCheckpoint(
             filename="epoch{epoch}",
-            save_top_k=cfg.training.save_top_k,
+            save_top_k=train_cfg.save_top_k,
             verbose=True,
             monitor="val-layer1/_loss",
             mode="min",
@@ -107,28 +86,28 @@ def setup_checkpoint_callback(cfg):
     return checkpoint_callback
 
 
-def setup_early_stopping(cfg):
+def setup_early_stopping(train_cfg):
     early_stopping = None
-    if cfg.training.enable_early_stopping:
+    if train_cfg.enable_early_stopping:
         early_stopping = EarlyStopping(
-            monitor="val-layer1/_loss", mode="min", patience=cfg.training.patience
+            monitor="val-layer1/_loss", mode="min", patience=train_cfg.patience
         )
     return early_stopping
 
 
-def setup_profiler(cfg):
+def setup_profiler(train_cfg):
     profiler = None
-    if cfg.training.trainer.profiler:
+    if train_cfg.trainer.profiler:
         profiler = AdvancedProfiler(filename="profile")
     return profiler
 
 
 # https://github.com/ashleve/lightning-hydra-template/blob/main/src/utils/utils.py
 @rank_zero_only
-def log_hyperparameters(config, trainer) -> None:
+def log_hyperparameters(train_cfg, trainer) -> None:
     """Log config to all Lightning loggers."""
     # send hparams to all loggers
-    trainer.logger.log_hyperparams(config)
+    trainer.logger.log_hyperparams(train_cfg)
     # trick to disable logging any more hyperparameters for all loggers
     trainer.logger.log_hyperparams = empty
 
@@ -146,18 +125,18 @@ def is_json_serializable(x):
     return ret
 
 
-def save_best_model(cfg, best_model_path, train_time_sec):
+def save_best_model(train_cfg, best_model_path, train_time_sec):
     """Saves the best checkpoint to the final model path."""
     # load best weights from checkpoint
     model_checkpoint = torch.load(best_model_path, map_location="cpu")
     model_state_dict = model_checkpoint["state_dict"]
 
     # save model
-    Path(cfg.training.weight_save_path).parent.mkdir(parents=True, exist_ok=True)
-    torch.save(model_state_dict, cfg.training.weight_save_path)
+    Path(train_cfg.weight_save_path).parent.mkdir(parents=True, exist_ok=True)
+    torch.save(model_state_dict, train_cfg.weight_save_path)
 
     # save log
-    result_path = cfg.training.weight_save_path + ".log.json"
+    result_path = train_cfg.weight_save_path + ".log.json"
     with open(result_path, "w", encoding="utf-8") as fp:
         cp_data = model_checkpoint["callbacks"]
         key = list(cp_data.keys())[0]

--- a/case_studies/api/api.py
+++ b/case_studies/api/api.py
@@ -51,7 +51,7 @@ class BlissClient:
         for k, v in kwargs.items():
             OmegaConf.update(cfg, k, v)
 
-        _generate(cfg)
+        _generate(cfg.generate)
 
     def load_pretrained_weights_for_survey(
         self, survey: SurveyType, filename: str, request_headers: Optional[Dict[str, str]] = None
@@ -84,11 +84,11 @@ class BlissClient:
         """
         cfg = OmegaConf.create(self.base_cfg)
         # apply overrides
-        cfg.training.weight_save_path = cfg.paths.output + f"/{weight_save_path}"
+        cfg.train.weight_save_path = cfg.paths.output + f"/{weight_save_path}"
         for k, v in kwargs.items():
             OmegaConf.update(cfg, k, v)
 
-        _train(cfg)
+        _train(cfg.train)
 
     def train_on_cached_data(
         self,
@@ -110,18 +110,18 @@ class BlissClient:
         """
         cfg = OmegaConf.create(self.base_cfg)
         # apply overrides
-        cfg.training.weight_save_path = cfg.paths.output + f"/{weight_save_path}"
+        cfg.train.weight_save_path = cfg.paths.output + f"/{weight_save_path}"
         cfg.cached_simulator.splits = splits
         cfg.cached_simulator.batch_size = batch_size
         if pretrained_weights_filename is not None:
-            cfg.training.pretrained_weights = (
+            cfg.train.pretrained_weights = (
                 cfg.paths.pretrained_models + f"/{pretrained_weights_filename}"
             )
         for k, v in kwargs.items():
             OmegaConf.update(cfg, k, v)
-        cfg.training.data_source = cfg.cached_simulator
+        cfg.train.data_source = cfg.cached_simulator
 
-        _train(cfg)
+        _train(cfg.train)
 
     def load_survey(self, survey: SurveyType, run, camcol, field, download_dir: str):
         SDSSDownloader([(run, camcol, field)], self.cwd + f"/{download_dir}").download_all()
@@ -157,7 +157,7 @@ class BlissClient:
         for k, v in kwargs.items():
             OmegaConf.update(cfg, k, v)
 
-        return _predict(cfg)
+        return _predict(cfg.predict)
 
     def plot_predictions_in_notebook(self):
         """Plot predictions in notebook."""
@@ -240,7 +240,7 @@ def main(cfg):
             **cfg,
         )
     elif cfg.mode == "train":
-        bliss_client.train(weight_save_path=cfg.training.weight_save_path, **cfg)
+        bliss_client.train(weight_save_path=cfg.train.weight_save_path, **cfg)
     elif cfg.mode == "predict":
         # survey="sdss" is hack since OmegaConf.update overwrites predict.dataset
         bliss_client.predict(survey="sdss", weight_save_path=cfg.predict.weight_save_path, **cfg)

--- a/case_studies/api/test_api.py
+++ b/case_studies/api/test_api.py
@@ -23,7 +23,7 @@ def bliss_client(cfg, tmpdir_factory):
     mock_tests.MockSDSSDownloader(image_ids, client.cwd + "/data/sdss")
     # Hack to apply select conftest.py overrides, since client.base_cfg should be private
     overrides = {
-        "training.trainer.accelerator": cfg.training.trainer.accelerator,
+        "train.trainer.accelerator": cfg.train.trainer.accelerator,
         "predict.device": cfg.predict.device,
     }
     for k, v in overrides.items():
@@ -85,7 +85,7 @@ class TestApi:
 
     def test_train_on_cached_data(self, bliss_client):
         cached_simulator_cfg = {"cached_data_path": "data/tests/multiband_data"}
-        training_cfg = {
+        train_cfg = {
             "n_epochs": 1,
             "trainer": {"check_val_every_n_epoch": 1, "log_every_n_steps": 1},
         }
@@ -95,7 +95,7 @@ class TestApi:
             splits="0:50/50:100/50:100",
             batch_size=8,
             cached_simulator=cached_simulator_cfg,
-            training=training_cfg,
+            training=train_cfg,
         )
 
         assert Path(f"{bliss_client.base_cfg.paths.output}/{weight_save_path}").exists()

--- a/case_studies/decals_e2e_871/config_train.yaml
+++ b/case_studies/decals_e2e_871/config_train.yaml
@@ -25,7 +25,7 @@ encoder:
     image_normalizer:
         z_score: false
 
-training:
+train:
     name: "pytest_encoder"
     version: "version0"
     n_epochs: 1

--- a/case_studies/dependent_tiling/config.yaml
+++ b/case_studies/dependent_tiling/config.yaml
@@ -10,6 +10,7 @@ encoder:
     tile_slen: 2
     min_flux_threshold: 1.59  # 22 magnitude (0.63 is 23 mag; 0.25 is 24 mag)
     two_layers: true
+    tiles_to_crop: 3
 
 prior:
     _target_: bliss.simulator.prior.CatalogPrior
@@ -50,11 +51,8 @@ predict:
             psf_slen: 25
         pixel_shift: 2
         align_to_band: null
-        crop_config:
-            do_rectangle_crop: true
-            left_upper_corner: [630, 310]
-            width: 112
-            height: 112
+        load_image_data: true
+        crop_config: [624, 736, 304, 416]
     trainer: ${training.trainer}
     encoder: ${encoder}
     weight_save_path: ${paths.root}/case_studies/dependent_tiling/m2.pt

--- a/case_studies/dependent_tiling/config.yaml
+++ b/case_studies/dependent_tiling/config.yaml
@@ -53,7 +53,7 @@ predict:
         align_to_band: null
         load_image_data: true
         crop_config: [624, 736, 304, 416]
-    trainer: ${training.trainer}
+    trainer: ${train.trainer}
     encoder: ${encoder}
     weight_save_path: ${paths.root}/case_studies/dependent_tiling/m2.pt
     device: "cuda:0"

--- a/case_studies/dependent_tiling/m2.ipynb
+++ b/case_studies/dependent_tiling/m2.ipynb
@@ -228,7 +228,7 @@
     "with initialize(config_path=\"../../case_studies/dependent_tiling/\", version_base=None):\n",
     "    cfg = compose(\"config\", {})\n",
     "\n",
-    "bliss_cats = predict(cfg)\n",
+    "bliss_cats = predict(cfg.predict)\n",
     "bliss_cat, = bliss_cats.values()"
    ]
   },

--- a/case_studies/dependent_tiling/m2.ipynb
+++ b/case_studies/dependent_tiling/m2.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load SDSS image data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -22,6 +29,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "plt.imshow(f[0].data, origin='lower', cmap='gray_r')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading/viewing HST predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import pandas as pd\n",
     "\n",
     "# catalog from https://catalogs.mast.stsci.edu/hsc/\n",
@@ -29,7 +54,7 @@
     "# radius of 32 arcsec; v3; detailed; MagAuto <= 24\n",
     "fn = '/home/regier/bliss/case_studies/dependent_tiling/HSC-10_20_2023.csv'\n",
     "hst_catalog = pd.read_csv(fn)\n",
-    "hst_catalog"
+    "hst_catalog.head()"
    ]
   },
   {
@@ -38,21 +63,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.coordinates import SkyCoord\n",
+    "from bliss.catalog import FullCatalog\n",
+    "import torch\n",
     "\n",
-    "hst_coords = SkyCoord(ra=hst_catalog['MatchRA'], dec=hst_catalog['MatchDec'], unit='deg')\n",
-    "hst_pix = w.world_to_pixel(hst_coords)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from matplotlib import pyplot as plt\n",
-    "\n",
-    "plt.imshow(f[0].data, origin='lower', cmap='gray_r')"
+    "ra = torch.from_numpy(hst_catalog['MatchRA'].to_numpy())\n",
+    "dec = torch.from_numpy(hst_catalog['MatchDec'].to_numpy())\n",
+    "plocs = FullCatalog.plocs_from_ra_dec(ra, dec, w)"
    ]
   },
   {
@@ -64,29 +80,7 @@
     "from matplotlib.patches import Rectangle\n",
     "\n",
     "plt.imshow(f[0].data, origin='lower', cmap='gray_r')\n",
-    "plt.scatter(hst_pix[0], hst_pix[1], s=10, c='r')\n",
-    "rect = Rectangle((310, 630), 100, 100, linewidth=1, edgecolor='b', facecolor='none')\n",
-    "plt.gca().add_patch(rect)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "in_bounds = (hst_pix[0] > 310) & (hst_pix[0] < 410) & (hst_pix[1] > 630) & (hst_pix[1] < 730)\n",
-    "hst_inbounds = hst_catalog[in_bounds]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.imshow(f[0].data, origin='lower', cmap='gray_r')\n",
-    "plt.scatter(hst_pix[0][in_bounds], hst_pix[1][in_bounds], s=10, c='r')\n",
+    "plt.scatter(plocs[:, 1], plocs[:, 0], s=10, c='r')\n",
     "rect = Rectangle((310, 630), 100, 100, linewidth=1, edgecolor='b', facecolor='none')\n",
     "plt.gca().add_patch(rect)"
    ]
@@ -97,7 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hst_inbounds[\"MatchID\"].unique().shape"
+    "in_bounds = (plocs[:, 1] > 310) & (plocs[:, 1] < 410) & (plocs[:, 0] > 630) & (plocs[:, 0] < 730)"
    ]
   },
   {
@@ -106,7 +100,114 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "plt.imshow(f[0].data, origin='lower', cmap='gray_r')\n",
+    "plt.scatter(plocs[:, 1][in_bounds], plocs[:, 0][in_bounds], s=10, c='r')\n",
+    "rect = Rectangle((310, 630), 100, 100, linewidth=1, edgecolor='b', facecolor='none')\n",
+    "plt.gca().add_patch(rect)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hst_inbounds = hst_catalog[in_bounds.numpy()]\n",
     "hst_inbounds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hcat_f814w = hst_inbounds[hst_inbounds.Filter == \"F814W\"]\n",
+    "hcat_f814w.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The HST's F606W band is like the SDSS r band, but a bit broader\n",
+    "hcat_f606w = hst_inbounds[hst_inbounds.Filter == \"F606W\"]\n",
+    "hcat_f606w.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "hcat = hcat_f814w\n",
+    "# TODO: figure out Bryan's cutoff (1114 stars) and training the corresponding min_flux_threshold\n",
+    "hcat_bright = hcat[hcat.MagAper2 < 22.2]\n",
+    "\n",
+    "ra = torch.from_numpy(hcat_bright.MatchRA.values)\n",
+    "dec = torch.from_numpy(hcat_bright.MatchDec.values)\n",
+    "mag = torch.from_numpy(hcat_bright.MagAper2.values)\n",
+    "\n",
+    "plocs = FullCatalog.plocs_from_ra_dec(ra, dec, w)\n",
+    "plocs_square = plocs - torch.tensor([630, 310])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hcat.shape, hcat_bright.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d = {\n",
+    "    \"plocs\": plocs_square.unsqueeze(0),\n",
+    "    \"star_fluxes\": mag.unsqueeze(0).unsqueeze(2).expand([-1, -1, 5]),\n",
+    "    \"galaxy_fluxes\": mag.unsqueeze(0).unsqueeze(2).expand([-1, -1, 5]) * 0.0,\n",
+    "    \"n_sources\": torch.tensor(plocs.shape[0]).unsqueeze(0),\n",
+    "    \"source_type\": torch.zeros(plocs.shape[0]).unsqueeze(0).unsqueeze(2).long(),\n",
+    "}\n",
+    "true_cat = FullCatalog(100, 100, d)\n",
+    "true_cat.n_sources.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "true_tile_cat = true_cat.to_tile_catalog(2, 5)\n",
+    "true_tile_cat.n_sources.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "true_tile_cat1 = true_tile_cat.get_brightest_sources_per_tile(band=2, exclude_num=0)\n",
+    "true_tile_cat1.n_sources.sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Making predictions with BLISS"
    ]
   },
   {
@@ -119,56 +220,16 @@
     "environ[\"CUDA_VISIBLE_DEVICES\"] = \"1\"\n",
     "\n",
     "from pathlib import Path\n",
-    "import torch\n",
     "from hydra import initialize, compose\n",
-    "from hydra.utils import instantiate\n",
-    "from bliss.encoder import Encoder\n",
+    "from bliss.predict import predict\n",
     "\n",
     "\n",
     "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
     "with initialize(config_path=\"../../case_studies/dependent_tiling/\", version_base=None):\n",
-    "    cfg = compose(\"config\", {\"encoder.two_layers=true\"})\n",
+    "    cfg = compose(\"config\", {})\n",
     "\n",
-    "encoder: Encoder = instantiate(cfg.encoder)\n",
-    "# should use a model trained with aligned data, or with only one band\n",
-    "encoder.load_state_dict(torch.load(\"../../case_studies/dependent_tiling/m2.pt\"))\n",
-    "encoder.eval()\n",
-    "encoder.cuda()\n",
-    "torch.set_grad_enabled(False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dataset = instantiate(cfg.predict.dataset, load_image_data=True)\n",
-    "frame = dataset[0]\n",
-    "batch = {\n",
-    "    \"images\": torch.from_numpy(frame[\"image\"]).unsqueeze(0).cuda(),\n",
-    "    \"background\": torch.from_numpy(frame[\"background\"]).unsqueeze(0).cuda()\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "batch[\"images\"].shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "est_cat, pred = encoder.predict_step(batch, None).values()\n",
-    "est_full = est_cat.to_full_catalog()\n",
-    "est_full.n_sources.sum()"
+    "bliss_cats = predict(cfg)\n",
+    "bliss_cat, = bliss_cats.values()"
    ]
   },
   {
@@ -180,8 +241,8 @@
     "from bliss.metrics import BlissMetrics, MetricsMode\n",
     "\n",
     "metrics = BlissMetrics(\n",
-    "    mode=MetricsMode.FULL, slack=1.0, survey_bands=[0, 1, 2, 3, 4]\n",
-    ").cuda()"
+    "    mode=MetricsMode.FULL, slack=0.5, survey_bands=[0, 1, 2, 3, 4]\n",
+    ")"
    ]
   },
   {
@@ -190,7 +251,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "metrics(est_full, est_full)"
+    "# TODO: require flux within 0.5 mag (as in Bryan's code) for matches and use L2 distance?\n",
+    "metric = metrics(true_cat, bliss_cat)\n",
+    "metric[\"detection_recall\"], metric[\"detection_precision\"], metric[\"f1\"]"
    ]
   },
   {
@@ -199,40 +262,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hcat = hst_inbounds[hst_inbounds.Filter == \"F606W\"]\n",
-    "hcat"
+    "metric = metrics(true_tile_cat1.to_full_catalog(), bliss_cat)\n",
+    "metric[\"detection_recall\"], metric[\"detection_precision\"], metric[\"f1\"]"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "ra = torch.from_numpy(hcat.MatchRA.values)\n",
-    "dec = torch.from_numpy(hcat.MatchRA.values)\n",
-    "mag = torch.from_numpy(hcat.MagAuto.values)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mag"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from bliss.catalog import FullCatalog\n",
+    "### marginal\n",
     "\n",
-    "plocs = FullCatalog.plocs_from_ra_dec(ra, dec, frame[\"wcs\"][2])\n",
-    "plocs.shape"
+    "marginal: (0.5738866329193115, 0.47767481207847595, 0.521379292011261)\n",
+    "\n",
+    "marginal (brightest): (0.5853960514068604, 0.3984835743904114, 0.4741854667663574)\n",
+    "\n",
+    "### dependent\n",
+    "\n",
+    "dependent: (0.5829959511756897, 0.5092838406562805, 0.5436526536941528)\n",
+    "\n",
+    "dependent (brightest): (0.5952970385551453, 0.4252873659133911, 0.4961320757865906)\n",
+    "\n"
    ]
   },
   {
@@ -241,13 +290,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d = {\n",
-    "    \"plocs\": plocs.unsqueeze(0),\n",
-    "    \"star_fluxes\": mag.unsqueeze(0).unsqueeze(2),\n",
-    "    \"n_sources\": torch.tensor(plocs.shape[0]).unsqueeze(0),\n",
-    "    \"source_type\": torch.zeros(plocs.shape[0]).unsqueeze(0).unsqueeze(2).long(),\n",
+    "from hydra.utils import instantiate\n",
+    "\n",
+    "encoder = instantiate(cfg.encoder)\n",
+    "encoder.load_state_dict(torch.load(cfg.predict.weight_save_path))\n",
+    "dataset = instantiate(cfg.predict.dataset)\n",
+    "dataset.prepare_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch = {\n",
+    "    \"images\": torch.from_numpy(dataset[0][\"image\"]).unsqueeze(0),\n",
+    "    \"background\": torch.from_numpy(dataset[0][\"background\"]).unsqueeze(0),\n",
     "}\n",
-    "true_cat = FullCatalog(112, 112, d).to(\"cuda\")"
+    "x_features = encoder.get_features(batch)\n",
+    "x_cat_second = encoder.second_net(x_features)\n",
+    "pred_second = encoder.make_layer(x_cat_second)\n",
+    "est_cat2_uncropped = pred_second.sample(use_mode=True)\n",
+    "est_cat2 = est_cat2_uncropped.symmetric_crop(cfg.encoder.tiles_to_crop)\n"
    ]
   },
   {
@@ -256,7 +321,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "metric = metrics(est_full, true_cat)"
+    "metric = metrics(true_cat, est_cat2.to_full_catalog())\n",
+    "metric[\"detection_recall\"], metric[\"detection_precision\"], metric[\"f1\"]"
    ]
   },
   {
@@ -264,9 +330,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "metric[\"detection_recall\"]"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/case_studies/diskrw_gsimages_721/config.yaml
+++ b/case_studies/diskrw_gsimages_721/config.yaml
@@ -41,7 +41,7 @@ generate:
     max_images_per_file: 64
     cached_data_path: /data/scratch/zhteoh/cached_dataset_${simulator.prior.mean_sources}_${simulator.prior.n_tiles_h}tiles_50GB
 
-training:
+train:
     name: "encoder"
     version: "sdss"
     pretrained_weights: ${paths.pretrained_models}/sdss.pt

--- a/case_studies/psf_variation/psf_variation_demo.ipynb
+++ b/case_studies/psf_variation/psf_variation_demo.ipynb
@@ -294,7 +294,7 @@
    ],
    "source": [
     "# instantiate the Trainer\n",
-    "trainer = hydra.utils.instantiate(cfg.training.trainer, accelerator=\"cpu\", logger=None)\n",
+    "trainer = hydra.utils.instantiate(cfg.train.trainer, accelerator=\"cpu\", logger=None)\n",
     "\n",
     "# make predictions\n",
     "base_results = trainer.predict(base_model, dataloader)\n",

--- a/case_studies/summer_template/config.yaml
+++ b/case_studies/summer_template/config.yaml
@@ -17,9 +17,9 @@ simulator:
     background:
         _target_: bliss.simulator.background.SimulatedSDSSBackground
 
-training:
+train:
     # name: "encoder"
     # version: "sdss_one_band"
     # pretrained_weights: ${paths.pretrained_models}/crowded_field.pt
-    weight_save_path: ${paths.output}/${training.name}/${training.version}.pt
+    weight_save_path: ${paths.output}/${train.name}/${train.version}.pt
     seed: 42

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/prob-ml/bliss"
 version = "0.3"
 
 [tool.poetry.scripts]
-bliss = "bliss.api:main"
+bliss = "bliss.cli:main"
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def cfg(pytestconfig, cached_data_path, output_path):
 
     # pytest-specific overrides
     overrides = {
-        "training.trainer.accelerator": "gpu" if use_gpu else "cpu",
+        "train.trainer.accelerator": "gpu" if use_gpu else "cpu",
         "predict.device": "cuda:0" if use_gpu else "cpu",
         "paths.root": Path(__file__).parents[1].as_posix(),
         "paths.output": str(output_path),

--- a/tests/test_dc2.py
+++ b/tests/test_dc2.py
@@ -50,14 +50,14 @@ class TestDC2:
         # why are these bands out of order? (should be "ugrizy") why does the test break if they
         # are ordered correctly?
         train_dc2_cfg.encoder.survey_bands = ["g", "i", "r", "u", "y", "z"]
-        train_dc2_cfg.training.data_source = train_dc2_cfg.surveys.dc2
+        train_dc2_cfg.train.data_source = train_dc2_cfg.surveys.dc2
         train_dc2_cfg.encoder.image_normalizer.use_deconv_channel = True
         train_dc2_cfg.encoder.do_data_augmentation = True
-        train_dc2_cfg.training.pretrained_weights = None
+        train_dc2_cfg.train.pretrained_weights = None
         # log transform doesn't work in this test because the DC2 background is sometimes negative.
         # why would the background be negative? are we using the wrong background estimate?
         train_dc2_cfg.encoder.image_normalizer.log_transform_stdevs = []
-        train(train_dc2_cfg)
+        train(train_dc2_cfg.train)
 
     def test_dc2_augmentation(self, cfg):
         train_dc2_cfg = cfg.copy()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -7,7 +7,7 @@ from bliss.generate import generate
 
 class TestGenerate:
     def test_generate_sdss(self, cfg):
-        generate(cfg)
+        generate(cfg.generate)
         # check that cached dataset exists
         cached_dataset_should_exist = cfg.generate.n_batches > 0 and (
             cfg.generate.batch_size < cfg.generate.max_images_per_file

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -32,6 +32,6 @@ class TestPredict:
             {"run": 94, "camcol": 1, "fields": [12]},
             {"run": 3635, "camcol": 1, "fields": [169]},
         ]
-        astropy_cats = predict(the_cfg)
+        astropy_cats = predict(the_cfg.predict)
 
         assert len(astropy_cats) == len(the_cfg.surveys.sdss.fields)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -32,6 +32,9 @@ class TestPredict:
             {"run": 94, "camcol": 1, "fields": [12]},
             {"run": 3635, "camcol": 1, "fields": [169]},
         ]
-        astropy_cats = predict(the_cfg.predict)
+        bliss_cats = predict(the_cfg.predict)
+        assert len(bliss_cats) == len(the_cfg.surveys.sdss.fields)
 
+        bands = cfg.encoder.survey_bands
+        astropy_cats = [c.to_astropy_table(bands) for c in bliss_cats.values()]
         assert len(astropy_cats) == len(the_cfg.surveys.sdss.fields)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -25,7 +25,7 @@ def clear_checkpoints(cfg):
 class TestTrain:
     def test_train_sdss(self, cfg):
         train_sdss_cfg = cfg.copy()
-        train(train_sdss_cfg)
+        train(train_sdss_cfg.train)
 
     def test_train_des(self, cfg):
         train_des_cfg = cfg.copy()
@@ -39,9 +39,9 @@ class TestTrain:
             DES.BANDS.index("z"),
         ]
         train_des_cfg.encoder.survey_bands = DES.BANDS
-        train_des_cfg.training.pretrained_weights = None
-        train_des_cfg.training.testing = True
-        train(train_des_cfg)
+        train_des_cfg.train.pretrained_weights = None
+        train_des_cfg.train.testing = True
+        train(train_des_cfg.train)
 
     def test_train_decals(self, cfg):
         train_decals_cfg = cfg.copy()
@@ -56,21 +56,21 @@ class TestTrain:
             DECaLS.BANDS.index("z"),
         ]
         train_decals_cfg.encoder.survey_bands = DECaLS.BANDS
-        train_decals_cfg.training.pretrained_weights = None
-        train_decals_cfg.training.testing = True
+        train_decals_cfg.train.pretrained_weights = None
+        train_decals_cfg.train.testing = True
 
         train_decals_cfg.simulator.use_coaddition = True
         train_decals_cfg.simulator.coadd_depth = 2
-        train(train_decals_cfg)
+        train(train_decals_cfg.train)
 
     def test_train_with_cached_data(self, cfg, tmp_path):
         the_cfg = cfg.copy()
         the_cfg.paths.output = tmp_path
         the_cfg.generate.cached_data_path = tmp_path
-        generate(the_cfg)
+        generate(the_cfg.generate)
 
-        the_cfg.training.data_source = "${cached_simulator}"
+        the_cfg.train.data_source = "${cached_simulator}"
         the_cfg.cached_simulator.cached_data_path = tmp_path
         os.chdir(tmp_path)
-        the_cfg.training.weight_save_path = str(tmp_path / "encoder.pt")
-        train(the_cfg)
+        the_cfg.train.weight_save_path = str(tmp_path / "encoder.pt")
+        train(the_cfg.train)

--- a/tests/testing_config.yaml
+++ b/tests/testing_config.yaml
@@ -19,13 +19,29 @@ cached_simulator:
     splits: 0:34/34:67/67:100  # train/val/test splits as percent ranges
     batch_size: 1
 
+surveys:
+    sdss:
+        fields:  # list of dictionaries, each with run, camcol, and list of fields
+            - run: 94
+              camcol: 1
+              fields: [12]
+        load_image_data: true
+    dc2:
+        data_dir: ${paths.data}/tests/dc2/dc2_multiband/
+        cat_path: ${paths.dc2}/merged_catalog/merged_catalog_psf_100000.pkl
+        n_split: 5
+        image_lim: [800, 800]
+        deconv_path: ${paths.data}/tests/dc2/coadd_deconv_image
+
+#########################################
+
 generate:
     n_batches: 3
     batch_size: 1
     max_images_per_file: 1
     cached_data_path: null # use pytest tmpdir
 
-training:
+train:
     name: "pytest_encoder"
     version: "version0"
     n_epochs: 1
@@ -46,17 +62,3 @@ training:
 predict:
     decals_frame: ${paths.decals}/336/3366m010/tractor-3366m010.fits
     device: "cpu"
-
-surveys:
-    sdss:
-        fields:  # list of dictionaries, each with run, camcol, and list of fields
-            - run: 94
-              camcol: 1
-              fields: [12]
-        load_image_data: true
-    dc2:
-        data_dir: ${paths.data}/tests/dc2/dc2_multiband/
-        cat_path: ${paths.dc2}/merged_catalog/merged_catalog_psf_100000.pkl
-        n_split: 5
-        image_lim: [800, 800]
-        deconv_path: ${paths.data}/tests/dc2/coadd_deconv_image


### PR DESCRIPTION
With this PR each of our three top-level methods (`generate`, `train`, and `predict`) only receives the subset of the config parameters that are relevant to it.