### PR TITLE
GalaxyClusterEncoder simplification and DES calibration

### DIFF
--- a/case_studies/galaxy_clustering/config.yaml
+++ b/case_studies/galaxy_clustering/config.yaml
@@ -63,7 +63,6 @@ encoder:
       _target_: torchmetrics.MetricCollection
       _convert_: "partial"
       metrics: ${my_metrics}
-    sample_image_renders: null
     var_dist:
         _target_: case_studies.galaxy_clustering.encoder.variational_dist.GalaxyClusterVariationalDist
         tile_slen: ${encoder.tile_slen}

--- a/case_studies/galaxy_clustering/config.yaml
+++ b/case_studies/galaxy_clustering/config.yaml
@@ -38,33 +38,6 @@ train:
 
 variational_factors:
   - _target_: bliss.encoder.variational_dist.BernoulliFactor
-    name: n_sources
-    sample_rearrange: null
-    nll_rearrange: null
-    nll_gating: null
-  - _target_: bliss.encoder.variational_dist.TDBNFactor
-    name: locs
-    sample_rearrange: "b ht wt d -> b ht wt 1 d"
-    nll_rearrange: "b ht wt 1 d -> b ht wt d"
-    nll_gating: n_sources
-  - _target_: bliss.encoder.variational_dist.BernoulliFactor
-    name: source_type
-    sample_rearrange: "b ht wt -> b ht wt 1 1"
-    nll_rearrange: "b ht wt 1 1 -> b ht wt"
-    nll_gating: n_sources
-  - _target_: bliss.encoder.variational_dist.LogNormalFactor
-    name: star_fluxes
-    dim: 4
-    sample_rearrange: "b ht wt d -> b ht wt 1 d"
-    nll_rearrange: "b ht wt 1 d -> b ht wt d"
-    nll_gating: is_star
-  - _target_: bliss.encoder.variational_dist.LogNormalFactor
-    name: galaxy_fluxes
-    dim: 4
-    sample_rearrange: "b ht wt d -> b ht wt 1 d"
-    nll_rearrange: "b ht wt 1 d -> b ht wt d"
-    nll_gating: is_galaxy
-  - _target_: bliss.encoder.variational_dist.BernoulliFactor
     name: membership
     sample_rearrange: "b ht wt -> b ht wt 1 1"
     nll_rearrange: "b ht wt 1 1 -> b ht wt"
@@ -90,6 +63,11 @@ encoder:
       _target_: torchmetrics.MetricCollection
       _convert_: "partial"
       metrics: ${my_metrics}
+    sample_image_renders: null
+    var_dist:
+        _target_: case_studies.galaxy_clustering.encoder.variational_dist.GalaxyClusterVariationalDist
+        tile_slen: ${encoder.tile_slen}
+        factors: ${variational_factors}
     use_checkerboard: false
 
 

--- a/case_studies/galaxy_clustering/data_generation/DES_data_extraction.py
+++ b/case_studies/galaxy_clustering/data_generation/DES_data_extraction.py
@@ -9,7 +9,7 @@ from pyvo.dal import sia
 
 from case_studies.galaxy_clustering import cluster_utils as utils
 
-DES_DATAPATH = "/home/kapnadak/bliss/case_studies/galaxy_clustering/data/DES_images"
+DES_DATAPATH = os.environ["BLISS_HOME"] + "/case_studies/galaxy_clustering/data/DES_images"
 if not os.path.exists(DES_DATAPATH):
     os.makedirs(DES_DATAPATH)
 

--- a/case_studies/galaxy_clustering/data_generation/galsim-des.yaml
+++ b/case_studies/galaxy_clustering/data_generation/galsim-des.yaml
@@ -95,7 +95,7 @@ image :
 
   nproc : 24
   type : Scattered
-  pixel_scale : 1.0
+  pixel_scale : 0.2636
   xsize : '@variables.image_size'
   ysize : '@variables.image_size'
   stamp_size : 100

--- a/case_studies/galaxy_clustering/encoder/encoder.py
+++ b/case_studies/galaxy_clustering/encoder/encoder.py
@@ -1,3 +1,4 @@
+from bliss.catalog import BaseTileCatalog
 from bliss.encoder.convnet import CatalogNet, ContextNet
 from bliss.encoder.encoder import Encoder
 from case_studies.galaxy_clustering.encoder.convnet import GalaxyClusterFeaturesNet
@@ -29,3 +30,17 @@ class GalaxyClusterEncoder(Encoder):
         self.checkerboard_net = ContextNet(num_features, n_params_per_source)
         if self.double_detect:
             self.second_net = CatalogNet(num_features, n_params_per_source)
+
+    def update_metrics(self, batch, batch_idx):
+        target_cat = BaseTileCatalog(self.tile_slen, batch["tile_catalog"])
+        target_cat = target_cat.symmetric_crop(self.tiles_to_crop)
+
+        mode_cat = self.sample(batch, use_mode=True)
+        self.mode_metrics.update(target_cat, mode_cat)
+
+        sample_cat = self.sample(batch, use_mode=False)
+        self.sample_metrics.update(target_cat, sample_cat)
+
+    def on_validation_epoch_end(self):
+        self.report_metrics(self.mode_metrics, "val/mode", show_epoch=True)
+        self.report_metrics(self.sample_metrics, "val/sample", show_epoch=True)

--- a/case_studies/galaxy_clustering/encoder/metrics.py
+++ b/case_studies/galaxy_clustering/encoder/metrics.py
@@ -12,13 +12,10 @@ class ClusterMembershipAccuracy(Metric):
         self.add_state("membership_fn", default=torch.zeros(1), dist_reduce_fx="sum")
         self.add_state("n_matches", default=torch.zeros(1), dist_reduce_fx="sum")
 
-    def update(self, true_cat, est_cat, matching):
+    def update(self, true_cat, est_cat):
         for i in range(true_cat.batch_size):
-            tcat_matches, ecat_matches = matching[i]
-            self.n_matches += tcat_matches.size(0)
-
-            true_membership = true_cat["membership"][i][tcat_matches].to(torch.bool)
-            est_membership = est_cat["membership"][i][ecat_matches].to(torch.bool)
+            true_membership = true_cat["membership"][i].to(torch.bool)
+            est_membership = est_cat["membership"][i].to(torch.bool)
 
             self.membership_tp += (true_membership * est_membership).sum()
             self.membership_tn += (~true_membership * ~est_membership).sum()

--- a/case_studies/galaxy_clustering/encoder/variational_dist.py
+++ b/case_studies/galaxy_clustering/encoder/variational_dist.py
@@ -1,0 +1,9 @@
+from bliss.catalog import BaseTileCatalog
+from bliss.encoder.variational_dist import VariationalDist
+
+
+class GalaxyClusterVariationalDist(VariationalDist):
+    def sample(self, x_cat, use_mode=True):
+        fp_pairs = self._factor_param_pairs(x_cat)
+        d = {qk.name: qk.sample(params, use_mode) for qk, params in fp_pairs}
+        return BaseTileCatalog(self.tile_slen, d)

--- a/case_studies/galaxy_clustering/notebooks/PredictionTest.ipynb
+++ b/case_studies/galaxy_clustering/notebooks/PredictionTest.ipynb
@@ -1,0 +1,459 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from os import environ\n",
+    "from pathlib import Path\n",
+    "from typing import List\n",
+    "\n",
+    "import torch\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "from hydra import initialize, compose\n",
+    "from hydra.utils import instantiate\n",
+    "from omegaconf import DictConfig, OmegaConf\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from bliss.simulator.simulated_dataset import CachedSimulatedDataset, FileDatum\n",
+    "from bliss.surveys.des import DarkEnergySurvey, DESDownloader\n",
+    "\n",
+    "\n",
+    "\n",
+    "from pathlib import Path\n",
+    "from hydra import initialize, compose\n",
+    "from bliss.main import predict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "environ[\"CUDA_VISIBLE_DEVICES\"] = \"7\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'paths': {'root': '${oc.env:BLISS_HOME}', 'sdss': '/data/scratch/sdss', 'decals': '/data/scratch/decals', 'des': '/data/scratch/des', 'dc2': '/data/scratch/dc2local', 'output': '${paths.root}/output'}, 'prior': {'_target_': 'case_studies.galaxy_clustering.prior.GalaxyClusterPrior', 'survey_bands': ['u', 'g', 'r', 'i', 'z'], 'reference_band': 2, 'star_color_model_path': '${simulator.survey.dir_path}/color_models/star_gmm_nmgy.pkl', 'gal_color_model_path': '${simulator.survey.dir_path}/color_models/gal_gmm_nmgy.pkl', 'n_tiles_h': 56, 'n_tiles_w': 56, 'tile_slen': 16, 'batch_size': 1, 'max_sources': 6, 'mean_sources': 0.48, 'min_sources': 0, 'prob_galaxy': 0.2, 'star_flux_exponent': 0.9859821185389767, 'star_flux_truncation': 5685.588160703261, 'star_flux_loc': -1.162430157551662, 'star_flux_scale': 1.4137911256506595, 'galaxy_flux_truncation': 1013, 'galaxy_flux_exponent': 0.47, 'galaxy_flux_scale': 0.6301037, 'galaxy_flux_loc': 0.0, 'galaxy_a_concentration': 0.39330758068481686, 'galaxy_a_loc': 0.8371888967872619, 'galaxy_a_scale': 4.432725319432478, 'galaxy_a_bd_ratio': 2.0}, 'simulator': {'_target_': 'bliss.simulator.simulated_dataset.SimulatedDataset', 'survey': '${surveys.sdss}', 'prior': '${prior}', 'n_batches': 128, 'use_coaddition': False, 'coadd_depth': 1, 'num_workers': 32, 'valid_n_batches': 10, 'fix_validation_set': True}, 'cached_simulator': {'_target_': 'bliss.simulator.simulated_dataset.CachedSimulatedDataset', 'batch_size': 16, 'splits': '0:60/60:90/90:100', 'num_workers': 1, 'cached_data_path': '${paths.root}/case_studies/galaxy_clustering/data/file_data/', 'file_prefix': 'file_data_'}, 'variational_factors': [{'_target_': 'bliss.encoder.variational_dist.BernoulliFactor', 'name': 'n_sources', 'sample_rearrange': None, 'nll_rearrange': None, 'nll_gating': None}, {'_target_': 'bliss.encoder.variational_dist.TDBNFactor', 'name': 'locs', 'sample_rearrange': 'b ht wt d -> b ht wt 1 d', 'nll_rearrange': 'b ht wt 1 d -> b ht wt d', 'nll_gating': 'n_sources'}, {'_target_': 'bliss.encoder.variational_dist.BernoulliFactor', 'name': 'source_type', 'sample_rearrange': 'b ht wt -> b ht wt 1 1', 'nll_rearrange': 'b ht wt 1 1 -> b ht wt', 'nll_gating': 'n_sources'}, {'_target_': 'bliss.encoder.variational_dist.LogNormalFactor', 'name': 'star_fluxes', 'dim': 4, 'sample_rearrange': 'b ht wt d -> b ht wt 1 d', 'nll_rearrange': 'b ht wt 1 d -> b ht wt d', 'nll_gating': 'is_star'}, {'_target_': 'bliss.encoder.variational_dist.LogNormalFactor', 'name': 'galaxy_fluxes', 'dim': 4, 'sample_rearrange': 'b ht wt d -> b ht wt 1 d', 'nll_rearrange': 'b ht wt 1 d -> b ht wt d', 'nll_gating': 'is_galaxy'}, {'_target_': 'bliss.encoder.variational_dist.BernoulliFactor', 'name': 'membership', 'sample_rearrange': 'b ht wt -> b ht wt 1 1', 'nll_rearrange': 'b ht wt 1 1 -> b ht wt', 'nll_gating': 'n_sources'}], 'encoder': {'_target_': 'case_studies.galaxy_clustering.encoder.encoder.GalaxyClusterEncoder', 'survey_bands': ['g', 'r', 'i', 'z'], 'tile_slen': '${simulator.prior.tile_slen}', 'tiles_to_crop': 0, 'min_flux_for_loss': 0, 'min_flux_for_metrics': 0, 'optimizer_params': {'lr': 0.001}, 'scheduler_params': {'milestones': [32], 'gamma': 0.1}, 'image_normalizer': {'_target_': 'bliss.encoder.image_normalizer.ImageNormalizer', 'bands': [0, 1, 2, 3], 'include_original': False, 'include_background': True, 'concat_psf_params': False, 'num_psf_params': 6, 'log_transform_stdevs': None, 'use_clahe': False, 'clahe_min_stdev': None}, 'var_dist': {'_target_': 'bliss.encoder.variational_dist.VariationalDist', 'tile_slen': '${encoder.tile_slen}', 'factors': '${variational_factors}'}, 'matcher': {'_target_': 'bliss.encoder.metrics.CatalogMatcher', 'dist_slack': 1.0, 'mag_slack': None, 'mag_band': 2}, 'metrics': {'_target_': 'torchmetrics.MetricCollection', '_convert_': 'partial', 'metrics': {'detection_performance': {'_target_': 'bliss.encoder.metrics.DetectionPerformance', 'mag_bin_cutoffs': [19, 19.4, 19.8, 20.2, 20.6, 21, 21.4, 21.8]}, 'source_type_accuracy': {'_target_': 'bliss.encoder.metrics.SourceTypeAccuracy', 'flux_bin_cutoffs': [200, 400, 600, 800, 1000]}, 'flux_error': {'_target_': 'bliss.encoder.metrics.FluxError', 'survey_bands': '${encoder.survey_bands}'}, 'cluster_membership_error': {'_target_': 'case_studies.galaxy_clustering.encoder.metrics.ClusterMembershipAccuracy'}}}, 'sample_image_renders': {'_target_': 'torchmetrics.MetricCollection', 'metrics': [{'_target_': 'bliss.encoder.sample_image_renders.PlotSampleImages', 'frequency': 1, 'restrict_batch': 0, 'tiles_to_crop': 1, 'tile_slen': '${simulator.prior.tile_slen}'}]}, 'do_data_augmentation': False, 'compile_model': False, 'double_detect': False, 'use_checkerboard': True}, 'surveys': {'sdss': {'_target_': 'bliss.surveys.sdss.SloanDigitalSkySurvey', 'dir_path': '${paths.sdss}', 'fields': [{'run': 94, 'camcol': 1, 'fields': [12]}], 'psf_config': {'pixel_scale': 0.396, 'psf_slen': 25}, 'pixel_shift': 2, 'align_to_band': None, 'load_image_data': False}, 'decals': {'_target_': 'bliss.surveys.decals.DarkEnergyCameraLegacySurvey', 'dir_path': '${paths.decals}', 'sky_coords': [{'ra': 336.6643042496718, 'dec': -0.9316385797930247}], 'bands': [0, 1, 3], 'psf_config': {'pixel_scale': 0.262, 'psf_slen': 63}, 'pixel_shift': 2}, 'des': {'_target_': 'bliss.surveys.des.DarkEnergySurvey', 'dir_path': '${paths.des}', 'image_ids': [{'sky_coord': {'ra': 336.6643042496718, 'dec': -0.9316385797930247}, 'decals_brickname': '3366m010', 'ccdname': 'S28', 'g': 'decam/CP/V4.8.2a/CP20171108/c4d_171109_002003_ooi_g_ls9', 'r': 'decam/CP/V4.8.2a/CP20170926/c4d_170927_025457_ooi_r_ls9', 'i': '', 'z': 'decam/CP/V4.8.2a/CP20170926/c4d_170927_025655_ooi_z_ls9'}], 'psf_config': {'pixel_scale': 0.262, 'psf_slen': 63}, 'pixel_shift': 2}, 'dc2': {'_target_': 'bliss.surveys.dc2.DC2', 'data_dir': '${paths.dc2}/run2.2i-dr6-v4/coadd-t3828-t3829/deepCoadd-results/', 'cat_path': '${paths.dc2}/merged_catalog_with_flux_over_50.pkl', 'split_results_dir': '${paths.output}/dc2_split_results', 'batch_size': 64, 'n_split': 50, 'image_lim': [4000, 4000], 'num_workers': 4, 'split_processes_num': 4, 'min_flux_for_loss': '${encoder.min_flux_for_loss}'}}, 'mode': 'train', 'generate': {'n_image_files': 32, 'n_batches_per_file': 16, 'simulator': '${simulator}', 'cached_data_path': None, 'file_prefix': 'dataset'}, 'train': {'trainer': {'_target_': 'pytorch_lightning.Trainer', 'logger': {'_target_': 'pytorch_lightning.loggers.TensorBoardLogger', 'save_dir': '${paths.output}', 'name': None, 'version': None, 'default_hp_metric': False}, 'callbacks': [{'_target_': 'pytorch_lightning.callbacks.ModelCheckpoint', 'filename': 'best_encoder', 'save_top_k': 1, 'verbose': True, 'monitor': 'val/_loss', 'mode': 'min', 'save_on_train_epoch_end': False, 'auto_insert_metric_name': False}, {'_target_': 'pytorch_lightning.callbacks.early_stopping.EarlyStopping', 'monitor': 'val/_loss', 'mode': 'min', 'patience': 5}], 'reload_dataloaders_every_n_epochs': 0, 'check_val_every_n_epoch': 1, 'log_every_n_steps': 10, 'min_epochs': 1, 'max_epochs': 50, 'accelerator': 'gpu', 'devices': 1, 'precision': '32-true'}, 'data_source': '${cached_simulator}', 'encoder': '${encoder}', 'seed': 42, 'pretrained_weights': None, 'testing': True}, 'predict': {'dataset': '${surveys.des}', 'trainer': {'_target_': 'pytorch_lightning.Trainer', 'accelerator': 'gpu', 'precision': '${train.trainer.precision}'}, 'encoder': '${encoder}', 'weight_save_path': '${paths.root}/output/version_215/checkpoints/best_encoder.ckpt', 'device': 'cuda:0'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "#environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
+    "with initialize(config_path=\"../\", version_base=None):\n",
+    "    cfg = compose(\"config\", {\n",
+    "        \"encoder.tiles_to_crop=0\",\n",
+    "        })\n",
+    "    print(cfg)\n",
+    "#bliss_cats = predict(cfg.predict)\n",
+    "#bliss_cat, = bliss_cats.values()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'dataset': '${surveys.des}', 'trainer': {'_target_': 'pytorch_lightning.Trainer', 'accelerator': 'gpu', 'precision': '${train.trainer.precision}'}, 'encoder': '${encoder}', 'weight_save_path': '${paths.root}/output/version_215/checkpoints/best_encoder.ckpt', 'device': 'cuda:0'}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cfg.predict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "GPU available: True (cuda), used: True\n",
+      "TPU available: False, using: 0 TPU cores\n",
+      "IPU available: False, using: 0 IPUs\n",
+      "HPU available: False, using: 0 HPUs\n"
+     ]
+    }
+   ],
+   "source": [
+    "encoder = instantiate(cfg.predict.encoder)\n",
+    "enc_state_dict = torch.load(cfg.predict.weight_save_path)\n",
+    "enc_state_dict = enc_state_dict[\"state_dict\"]\n",
+    "encoder.load_state_dict(enc_state_dict)\n",
+    "dataset = instantiate(cfg.cached_simulator)\n",
+    "trainer = instantiate(cfg.predict.trainer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'_target_': 'case_studies.galaxy_clustering.encoder.encoder.GalaxyClusterEncoder', 'survey_bands': ['g', 'r', 'i', 'z'], 'tile_slen': '${simulator.prior.tile_slen}', 'tiles_to_crop': 0, 'min_flux_for_loss': 0, 'min_flux_for_metrics': 0, 'optimizer_params': {'lr': 0.001}, 'scheduler_params': {'milestones': [32], 'gamma': 0.1}, 'image_normalizer': {'_target_': 'bliss.encoder.image_normalizer.ImageNormalizer', 'bands': [0, 1, 2, 3], 'include_original': False, 'include_background': True, 'concat_psf_params': False, 'num_psf_params': 6, 'log_transform_stdevs': None, 'use_clahe': False, 'clahe_min_stdev': None}, 'var_dist': {'_target_': 'bliss.encoder.variational_dist.VariationalDist', 'tile_slen': '${encoder.tile_slen}', 'factors': '${variational_factors}'}, 'matcher': {'_target_': 'bliss.encoder.metrics.CatalogMatcher', 'dist_slack': 1.0, 'mag_slack': None, 'mag_band': 2}, 'metrics': {'_target_': 'torchmetrics.MetricCollection', '_convert_': 'partial', 'metrics': {'detection_performance': {'_target_': 'bliss.encoder.metrics.DetectionPerformance', 'mag_bin_cutoffs': [19, 19.4, 19.8, 20.2, 20.6, 21, 21.4, 21.8]}, 'source_type_accuracy': {'_target_': 'bliss.encoder.metrics.SourceTypeAccuracy', 'flux_bin_cutoffs': [200, 400, 600, 800, 1000]}, 'flux_error': {'_target_': 'bliss.encoder.metrics.FluxError', 'survey_bands': '${encoder.survey_bands}'}, 'cluster_membership_error': {'_target_': 'case_studies.galaxy_clustering.encoder.metrics.ClusterMembershipAccuracy'}}}, 'sample_image_renders': {'_target_': 'torchmetrics.MetricCollection', 'metrics': [{'_target_': 'bliss.encoder.sample_image_renders.PlotSampleImages', 'frequency': 1, 'restrict_batch': 0, 'tiles_to_crop': 1, 'tile_slen': '${simulator.prior.tile_slen}'}]}, 'do_data_augmentation': False, 'compile_model': False, 'double_detect': False, 'use_checkerboard': True}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cfg.predict.encoder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [7]\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e415f4ccc60445acbf5a6735eacb5113",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Predicting: 0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "enc_output = trainer.predict(encoder, datamodule=dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataloader_iter = iter(dataset.predict_dataloader())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'mode_cat': TileCatalog(16 x 20 x 20; n_sources, locs, source_type, star_fluxes, galaxy_fluxes, membership),\n",
+       " 'sample_cat': TileCatalog(16 x 20 x 20; n_sources, locs, source_type, star_fluxes, galaxy_fluxes, membership)}"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "enc_output[i]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor(0.7617)\n",
+      "tensor(0.7545)\n",
+      "tensor(0.7831)\n",
+      "tensor(0.6606)\n",
+      "tensor(0.7428)\n",
+      "tensor(0.7314)\n",
+      "tensor(0.7914)\n",
+      "tensor(0.7291)\n",
+      "tensor(0.8064)\n",
+      "tensor(0.7417)\n",
+      "tensor(0.7417)\n",
+      "tensor(0.7102)\n",
+      "tensor(0.7886)\n",
+      "tensor(0.8294)\n",
+      "tensor(0.8667)\n",
+      "tensor(0.6769)\n",
+      "tensor(0.7378)\n",
+      "tensor(0.7269)\n",
+      "tensor(0.8436)\n",
+      "tensor(0.7305)\n",
+      "tensor(0.7563)\n",
+      "tensor(0.8248)\n",
+      "tensor(0.8311)\n",
+      "tensor(0.7555)\n",
+      "tensor(0.7536)\n",
+      "tensor(0.7544)\n",
+      "tensor(0.7420)\n",
+      "tensor(0.8606)\n",
+      "tensor(0.7786)\n",
+      "tensor(0.7494)\n",
+      "tensor(0.7533)\n",
+      "tensor(0.8033)\n",
+      "tensor(0.7789)\n",
+      "tensor(0.8572)\n",
+      "tensor(0.7725)\n",
+      "tensor(0.7766)\n",
+      "tensor(0.7423)\n",
+      "tensor(0.8138)\n",
+      "tensor(0.8105)\n",
+      "tensor(0.7569)\n",
+      "tensor(0.7467)\n",
+      "tensor(0.7247)\n",
+      "tensor(0.7228)\n",
+      "tensor(0.8033)\n",
+      "tensor(0.7650)\n",
+      "tensor(0.8050)\n",
+      "tensor(0.7533)\n",
+      "tensor(0.7909)\n",
+      "tensor(0.7441)\n",
+      "tensor(0.7303)\n",
+      "tensor(0.7292)\n",
+      "tensor(0.7550)\n",
+      "tensor(0.7958)\n",
+      "tensor(0.7989)\n",
+      "tensor(0.7527)\n",
+      "tensor(0.7569)\n",
+      "tensor(0.7398)\n",
+      "tensor(0.7242)\n",
+      "tensor(0.7641)\n",
+      "tensor(0.7031)\n",
+      "tensor(0.7127)\n",
+      "tensor(0.7295)\n",
+      "tensor(0.3489)\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(len(dataloader_iter)):\n",
+    "    truth = next(dataloader_iter)\n",
+    "    outputs = enc_output[i]\n",
+    "    accuracy = (outputs[\"mode_cat\"][\"membership\"] == truth[\"tile_catalog\"][\"membership\"]).sum()\n",
+    "    print(accuracy/())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(2233)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(outputs[\"mode_cat\"][\"membership\"] == truth[\"tile_catalog\"][\"membership\"]).sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([8, 20, 20, 1, 1])"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "truth[\"tile_catalog\"][\"membership\"].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cma = ClusterMembershipAccuracy()\n",
+    "dataloader_iter = iter(dataset.predict_dataloader())\n",
+    "true_cat = next(dataloader_iter)\n",
+    "est_cat = enc_output[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bliss.catalog import TileCatalog\n",
+    "target_cat = TileCatalog(20, true_cat[\"tile_catalog\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "est_cat[\"mode_cat\"].batch_size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cma.update()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([3, 20, 20, 1, 1])"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "first_item[\"tile_catalog\"][\"membership\"].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([3, 20, 20, 1, 1])"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "enc_output[0][\"mode_cat\"][\"membership\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([314,   0, 276, 274,   0, 204,   0, 232,   0, 208, 269, 267])"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(enc_output[0][\"mode_cat\"][\"n_sources\"] > 0).view(12, -1).sum(dim=1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/case_studies/galaxy_clustering/prior.py
+++ b/case_studies/galaxy_clustering/prior.py
@@ -272,7 +272,7 @@ class GalaxyClusterPrior:
         """
         hlr_samples = []
         for i in range(self.size):
-            hlr_samples.append(np.random.uniform(1.0, 4.0, len(flux_samples[i])))
+            hlr_samples.append(np.random.uniform(0.5, 1.0, len(flux_samples[i])))
         return hlr_samples
 
     def sample_flux_r(self, redshift_samples):


### PR DESCRIPTION
- Subclassed `VariationalDist` to sample `BaseTileCatalog` instead of `TileCatalog`
- Removed catalog matching from metrics and retained only cluster membership in variational factors and metrics
- Omit `sample_image_renders` in `on_validation_epoch_end`
- Preliminary prediction notebook
- Calibrate prior pixel scale with DES pixel scale