### PR TITLE
remove BLISS_HOME environment variable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,6 @@ jobs:
       - name: Checkout github repo
         uses: actions/checkout@v3
 
-      - name: Create environment variables
-        run: echo "BLISS_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-
       - name: Install poetry
         run: pipx install poetry
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Create environment variables
         run: |
-          echo "BLISS_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "JUPYTER_PLATFORM_DIRS=1" >> $GITHUB_ENV
           echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
 

--- a/bliss/conf/base_config.yaml
+++ b/bliss/conf/base_config.yaml
@@ -11,14 +11,12 @@ hydra:
         dir: .
 
 paths:
-    root: ${oc.env:BLISS_HOME}
-
     sdss: /data/scratch/sdss
     decals: /data/scratch/decals
     des: /data/scratch/des
     dc2: /data/scratch/dc2local
 
-    output: ${paths.root}/output
+    output: ${oc.env:HOME}/bliss_output
 
 prior:
     _target_: bliss.simulator.prior.CatalogPrior
@@ -66,64 +64,64 @@ cached_simulator:
     cached_data_path: ${generate.cached_data_path}
 
 variational_factors:
-  - _target_: bliss.encoder.variational_dist.BernoulliFactor
-    name: n_sources
-    sample_rearrange: null
-    nll_rearrange: null
-    nll_gating: null
-  - _target_: bliss.encoder.variational_dist.TDBNFactor
-    name: locs
-    sample_rearrange: "b ht wt d -> b ht wt 1 d"
-    nll_rearrange: "b ht wt 1 d -> b ht wt d"
-    nll_gating: n_sources
-  - _target_: bliss.encoder.variational_dist.BernoulliFactor
-    name: source_type
-    sample_rearrange: "b ht wt -> b ht wt 1 1"
-    nll_rearrange: "b ht wt 1 1 -> b ht wt"
-    nll_gating: n_sources
-  - _target_: bliss.encoder.variational_dist.LogNormalFactor
-    name: star_fluxes
-    dim: 5
-    sample_rearrange: "b ht wt d -> b ht wt 1 d"
-    nll_rearrange: "b ht wt 1 d -> b ht wt d"
-    nll_gating: is_star
-  - _target_: bliss.encoder.variational_dist.LogNormalFactor
-    name: galaxy_fluxes
-    dim: 5
-    sample_rearrange: "b ht wt d -> b ht wt 1 d"
-    nll_rearrange: "b ht wt 1 d -> b ht wt d"
-    nll_gating: is_galaxy
-  - _target_: bliss.encoder.variational_dist.LogitNormalFactor
-    name: galaxy_disk_frac
-    sample_rearrange: "b ht wt d -> b ht wt 1 d"
-    nll_rearrange: "b ht wt 1 1 -> b ht wt 1"
-    nll_gating: is_galaxy
-  - _target_: bliss.encoder.variational_dist.LogitNormalFactor
-    name: galaxy_beta_radians
-    high: 3.1415926
-    sample_rearrange: "b ht wt d -> b ht wt 1 d"
-    nll_rearrange: "b ht wt 1 1 -> b ht wt 1"
-    nll_gating: is_galaxy
-  - _target_: bliss.encoder.variational_dist.LogitNormalFactor
-    name: galaxy_disk_q
-    sample_rearrange: "b ht wt d -> b ht wt 1 d"
-    nll_rearrange: "b ht wt 1 1 -> b ht wt 1"
-    nll_gating: is_galaxy
-  - _target_: bliss.encoder.variational_dist.LogNormalFactor
-    name: galaxy_a_d
-    sample_rearrange: "b ht wt d -> b ht wt 1 d"
-    nll_rearrange: "b ht wt 1 1 -> b ht wt 1"
-    nll_gating: is_galaxy
-  - _target_: bliss.encoder.variational_dist.LogitNormalFactor
-    name: galaxy_bulge_q
-    sample_rearrange: "b ht wt d -> b ht wt 1 d"
-    nll_rearrange: "b ht wt 1 1 -> b ht wt 1"
-    nll_gating: is_galaxy
-  - _target_: bliss.encoder.variational_dist.LogNormalFactor
-    name: galaxy_a_b
-    sample_rearrange: "b ht wt d -> b ht wt 1 d"
-    nll_rearrange: "b ht wt 1 1 -> b ht wt 1"
-    nll_gating: is_galaxy
+    - _target_: bliss.encoder.variational_dist.BernoulliFactor
+      name: n_sources
+      sample_rearrange: null
+      nll_rearrange: null
+      nll_gating: null
+    - _target_: bliss.encoder.variational_dist.TDBNFactor
+      name: locs
+      sample_rearrange: "b ht wt d -> b ht wt 1 d"
+      nll_rearrange: "b ht wt 1 d -> b ht wt d"
+      nll_gating: n_sources
+    - _target_: bliss.encoder.variational_dist.BernoulliFactor
+      name: source_type
+      sample_rearrange: "b ht wt -> b ht wt 1 1"
+      nll_rearrange: "b ht wt 1 1 -> b ht wt"
+      nll_gating: n_sources
+    - _target_: bliss.encoder.variational_dist.LogNormalFactor
+      name: star_fluxes
+      dim: 5
+      sample_rearrange: "b ht wt d -> b ht wt 1 d"
+      nll_rearrange: "b ht wt 1 d -> b ht wt d"
+      nll_gating: is_star
+    - _target_: bliss.encoder.variational_dist.LogNormalFactor
+      name: galaxy_fluxes
+      dim: 5
+      sample_rearrange: "b ht wt d -> b ht wt 1 d"
+      nll_rearrange: "b ht wt 1 d -> b ht wt d"
+      nll_gating: is_galaxy
+    - _target_: bliss.encoder.variational_dist.LogitNormalFactor
+      name: galaxy_disk_frac
+      sample_rearrange: "b ht wt d -> b ht wt 1 d"
+      nll_rearrange: "b ht wt 1 1 -> b ht wt 1"
+      nll_gating: is_galaxy
+    - _target_: bliss.encoder.variational_dist.LogitNormalFactor
+      name: galaxy_beta_radians
+      high: 3.1415926
+      sample_rearrange: "b ht wt d -> b ht wt 1 d"
+      nll_rearrange: "b ht wt 1 1 -> b ht wt 1"
+      nll_gating: is_galaxy
+    - _target_: bliss.encoder.variational_dist.LogitNormalFactor
+      name: galaxy_disk_q
+      sample_rearrange: "b ht wt d -> b ht wt 1 d"
+      nll_rearrange: "b ht wt 1 1 -> b ht wt 1"
+      nll_gating: is_galaxy
+    - _target_: bliss.encoder.variational_dist.LogNormalFactor
+      name: galaxy_a_d
+      sample_rearrange: "b ht wt d -> b ht wt 1 d"
+      nll_rearrange: "b ht wt 1 1 -> b ht wt 1"
+      nll_gating: is_galaxy
+    - _target_: bliss.encoder.variational_dist.LogitNormalFactor
+      name: galaxy_bulge_q
+      sample_rearrange: "b ht wt d -> b ht wt 1 d"
+      nll_rearrange: "b ht wt 1 1 -> b ht wt 1"
+      nll_gating: is_galaxy
+    - _target_: bliss.encoder.variational_dist.LogNormalFactor
+      name: galaxy_a_b
+      sample_rearrange: "b ht wt d -> b ht wt 1 d"
+      nll_rearrange: "b ht wt 1 1 -> b ht wt 1"
+      nll_gating: is_galaxy
 
 metrics:
     detection_performance:
@@ -175,11 +173,11 @@ encoder:
     sample_image_renders:
         _target_: torchmetrics.MetricCollection
         metrics:
-          - _target_: bliss.encoder.sample_image_renders.PlotSampleImages
-            frequency: 1
-            restrict_batch: 0
-            tiles_to_crop: 1
-            tile_slen: ${simulator.prior.tile_slen}
+            - _target_: bliss.encoder.sample_image_renders.PlotSampleImages
+              frequency: 1
+              restrict_batch: 0
+              tiles_to_crop: 1
+              tile_slen: ${simulator.prior.tile_slen}
 
     do_data_augmentation: false
     compile_model: false  # if true, compile model for potential performance
@@ -203,22 +201,22 @@ surveys:
     decals:
         _target_: bliss.surveys.decals.DarkEnergyCameraLegacySurvey
         dir_path: ${paths.decals}
-        sky_coords: # in degrees
+        sky_coords:  # in degrees
             # brick '3366m010' corresponds to SDSS RCF 94-1-12
             - ra: 336.6643042496718
               dec: -0.9316385797930247
-        bands: [0, 1, 3] # grz
+        bands: [0, 1, 3]  # grz
         psf_config:
-            pixel_scale: 0.262 # see https://github.com/legacysurvey/legacypipe/blob/6811e465cf1d6f0beb9824a2f1964de8a1a8cc12/py/legacyanalysis/deep-coadd.py#L20
-            psf_slen: 63 # see https://github.com/legacysurvey/legacypipe/blob/ba1ffd4969c1f920566e780118c542d103cbd9a5/py/legacypipe/config/common.psfex#L8
+            pixel_scale: 0.262
+            psf_slen: 63
         pixel_shift: 2
     des:
         _target_: bliss.surveys.des.DarkEnergySurvey
         dir_path: ${paths.des}
         image_ids:
             - sky_coord:
-                ra: 336.6643042496718
-                dec: -0.9316385797930247
+              ra: 336.6643042496718
+              dec: -0.9316385797930247
               decals_brickname: "3366m010"
               ccdname: "S28"
               g: "decam/CP/V4.8.2a/CP20171108/c4d_171109_002003_ooi_g_ls9"
@@ -262,16 +260,16 @@ train:
             save_dir: ${paths.output}
             name: null
             version: null
-            default_hp_metric: False
+            default_hp_metric: false
         callbacks:
             - _target_: pytorch_lightning.callbacks.ModelCheckpoint
               filename: best_encoder
               save_top_k: 1
-              verbose: True
+              verbose: true
               monitor: val/_loss
               mode: min
-              save_on_train_epoch_end: False
-              auto_insert_metric_name: False
+              save_on_train_epoch_end: false
+              auto_insert_metric_name: false
             - _target_: pytorch_lightning.callbacks.early_stopping.EarlyStopping
               monitor: val/_loss
               mode: min

--- a/bliss/conf/base_config.yaml
+++ b/bliss/conf/base_config.yaml
@@ -215,8 +215,8 @@ surveys:
         dir_path: ${paths.des}
         image_ids:
             - sky_coord:
-              ra: 336.6643042496718
-              dec: -0.9316385797930247
+                  ra: 336.6643042496718
+                  dec: -0.9316385797930247
               decals_brickname: "3366m010"
               ccdname: "S28"
               g: "decam/CP/V4.8.2a/CP20171108/c4d_171109_002003_ooi_g_ls9"

--- a/bliss/main.py
+++ b/bliss/main.py
@@ -1,6 +1,4 @@
-import logging
 import random
-from os import environ, getenv
 from pathlib import Path
 from typing import List
 
@@ -113,17 +111,6 @@ def predict(predict_cfg):
 @hydra.main(config_path="conf", config_name="base_config", version_base=None)
 def main(cfg):
     """Main entry point(s) for BLISS."""
-    if not getenv("BLISS_HOME"):
-        project_path = Path(__file__).resolve()
-        bliss_home = project_path.parents[1]
-        environ["BLISS_HOME"] = bliss_home.as_posix()
-
-        logger = logging.getLogger(__name__)
-        logger.warning(
-            "WARNING: BLISS_HOME not set, setting to project root %s\n",  # noqa: WPS323
-            environ["BLISS_HOME"],
-        )
-
     if cfg.mode == "generate":
         generate(cfg.generate)
     elif cfg.mode == "train":

--- a/case_studies/catalog_comparison/catalog_comparison.ipynb
+++ b/case_studies/catalog_comparison/catalog_comparison.ipynb
@@ -51,7 +51,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
     "with initialize(config_path=\".\", version_base=None):\n",
     "    cfg = compose(\"config\")"
    ]

--- a/case_studies/dc2_cataloging/DC2_bootstrap_generate_data.ipynb
+++ b/case_studies/dc2_cataloging/DC2_bootstrap_generate_data.ipynb
@@ -111,7 +111,6 @@
    "source": [
     "print(\"+\" * 100, flush=True)\n",
     "print(\"initialization begins\", flush=True)\n",
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
     "\n",
     "output_dir = Path(\"./DC2_bootstrap_output/\")\n",
     "output_dir.mkdir(parents=True, exist_ok=True)\n",

--- a/case_studies/dc2_cataloging/DC2_bootstrap_testing.ipynb
+++ b/case_studies/dc2_cataloging/DC2_bootstrap_testing.ipynb
@@ -38,8 +38,6 @@
     "import tqdm\n",
     "from pytorch_lightning.utilities import move_data_to_device\n",
     "\n",
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
-    "\n",
     "output_dir = Path(\"./DC2_bootstrap_output/\")\n",
     "output_dir.mkdir(parents=True, exist_ok=True)"
    ]

--- a/case_studies/dc2_cataloging/DC2_bootstrap_testing_full_image.ipynb
+++ b/case_studies/dc2_cataloging/DC2_bootstrap_testing_full_image.ipynb
@@ -33,8 +33,6 @@
     "from case_studies.dc2_cataloging.utils.load_lsst import get_lsst_full_cat\n",
     "from case_studies.dc2_cataloging.utils.safe_metric_collection import SafeMetricCollection as MetricCollection\n",
     "\n",
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
-    "\n",
     "output_dir = Path(\"./DC2_bootstrap_test_full_image_output/\")\n",
     "output_dir.mkdir(parents=True, exist_ok=True)\n",
     "\n",

--- a/case_studies/dc2_cataloging/DC2_boundary_performance.ipynb
+++ b/case_studies/dc2_cataloging/DC2_boundary_performance.ipynb
@@ -34,8 +34,6 @@
     "from bliss.encoder.metrics import DetectionPerformance, SourceTypeFilter\n",
     "from case_studies.dc2_cataloging.utils.metrics import InBoundaryFilter, OutBoundaryFilter\n",
     "\n",
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
-    "\n",
     "output_dir = Path(\"./DC2_boundary_performance_output/\")\n",
     "output_dir.mkdir(parents=True, exist_ok=True)\n",
     "\n",

--- a/case_studies/dc2_cataloging/DC2_classification_accuracy.ipynb
+++ b/case_studies/dc2_cataloging/DC2_classification_accuracy.ipynb
@@ -32,8 +32,6 @@
     "from case_studies.dc2_cataloging.utils.load_lsst import get_lsst_full_cat\n",
     "from case_studies.dc2_cataloging.utils.safe_metric_collection import SafeMetricCollection as MetricCollection\n",
     "\n",
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
-    "\n",
     "output_dir = Path(\"./DC2_classification_accuracy_output/\")\n",
     "output_dir.mkdir(parents=True, exist_ok=True)\n",
     "\n",

--- a/case_studies/dc2_cataloging/DC2_exp.ipynb
+++ b/case_studies/dc2_cataloging/DC2_exp.ipynb
@@ -50,8 +50,6 @@
     "from bliss.surveys.dc2 import DC2\n",
     "from pathlib import Path\n",
     "\n",
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
-    "\n",
     "output_dir = Path(\"./DC2_exp_output/\")\n",
     "output_dir.mkdir(parents=True, exist_ok=True)\n",
     "\n",

--- a/case_studies/galaxy_clustering/config.yaml
+++ b/case_studies/galaxy_clustering/config.yaml
@@ -29,7 +29,7 @@ cached_simulator:
     batch_size: 5
     splits: 0:60/60:90/90:100  # train/val/test splits as percent ranges
     num_workers: 2
-    cached_data_path: ${paths.root}/case_studies/galaxy_clustering/data/file_data/
+    cached_data_path: ${paths.output}/case_studies/galaxy_clustering/data/file_data/
 
 train:
     trainer:
@@ -75,5 +75,5 @@ predict:
         accelerator: "gpu"
         precision: ${train.trainer.precision}
     encoder: ${encoder}
-    weight_save_path: ${paths.root}/output/version_186/checkpoints/best_encoder.ckpt
+    weight_save_path: ${paths.output}/version_186/checkpoints/best_encoder.ckpt
     device: "cuda:0"

--- a/case_studies/galaxy_clustering/config.yaml
+++ b/case_studies/galaxy_clustering/config.yaml
@@ -36,11 +36,11 @@ train:
         precision: 32-true
 
 variational_factors:
-  - _target_: bliss.encoder.variational_dist.BernoulliFactor
-    name: membership
-    sample_rearrange: "b ht wt -> b ht wt 1 1"
-    nll_rearrange: "b ht wt 1 1 -> b ht wt"
-    nll_gating: null
+    - _target_: bliss.encoder.variational_dist.BernoulliFactor
+      name: membership
+      sample_rearrange: "b ht wt -> b ht wt 1 1"
+      nll_rearrange: "b ht wt 1 1 -> b ht wt"
+      nll_gating: null
 
 my_metrics:
   cluster_membership_acc:

--- a/case_studies/galaxy_clustering/data_generation/DES_data_extraction.py
+++ b/case_studies/galaxy_clustering/data_generation/DES_data_extraction.py
@@ -9,7 +9,7 @@ from pyvo.dal import sia
 
 from case_studies.galaxy_clustering import cluster_utils as utils
 
-DES_DATAPATH = os.environ["BLISS_HOME"] + "/case_studies/galaxy_clustering/data/DES_images"
+DES_DATAPATH = os.environ["HOME"] + "/bliss/case_studies/galaxy_clustering/data/DES_images"
 if not os.path.exists(DES_DATAPATH):
     os.makedirs(DES_DATAPATH)
 

--- a/case_studies/galaxy_clustering/notebooks/PredictionTest.ipynb
+++ b/case_studies/galaxy_clustering/notebooks/PredictionTest.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,19 +49,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'paths': {'root': '${oc.env:BLISS_HOME}', 'sdss': '/data/scratch/sdss', 'decals': '/data/scratch/decals', 'des': '/data/scratch/des', 'dc2': '/data/scratch/dc2local', 'output': '${paths.root}/output'}, 'prior': {'_target_': 'case_studies.galaxy_clustering.prior.GalaxyClusterPrior', 'survey_bands': ['u', 'g', 'r', 'i', 'z'], 'reference_band': 2, 'star_color_model_path': '${simulator.survey.dir_path}/color_models/star_gmm_nmgy.pkl', 'gal_color_model_path': '${simulator.survey.dir_path}/color_models/gal_gmm_nmgy.pkl', 'n_tiles_h': 56, 'n_tiles_w': 56, 'tile_slen': 16, 'batch_size': 1, 'max_sources': 6, 'mean_sources': 0.48, 'min_sources': 0, 'prob_galaxy': 0.2, 'star_flux_exponent': 0.9859821185389767, 'star_flux_truncation': 5685.588160703261, 'star_flux_loc': -1.162430157551662, 'star_flux_scale': 1.4137911256506595, 'galaxy_flux_truncation': 1013, 'galaxy_flux_exponent': 0.47, 'galaxy_flux_scale': 0.6301037, 'galaxy_flux_loc': 0.0, 'galaxy_a_concentration': 0.39330758068481686, 'galaxy_a_loc': 0.8371888967872619, 'galaxy_a_scale': 4.432725319432478, 'galaxy_a_bd_ratio': 2.0}, 'simulator': {'_target_': 'bliss.simulator.simulated_dataset.SimulatedDataset', 'survey': '${surveys.sdss}', 'prior': '${prior}', 'n_batches': 128, 'use_coaddition': False, 'coadd_depth': 1, 'num_workers': 32, 'valid_n_batches': 10, 'fix_validation_set': True}, 'cached_simulator': {'_target_': 'bliss.simulator.simulated_dataset.CachedSimulatedDataset', 'batch_size': 16, 'splits': '0:60/60:90/90:100', 'num_workers': 1, 'cached_data_path': '${paths.root}/case_studies/galaxy_clustering/data/file_data/', 'file_prefix': 'file_data_'}, 'variational_factors': [{'_target_': 'bliss.encoder.variational_dist.BernoulliFactor', 'name': 'n_sources', 'sample_rearrange': None, 'nll_rearrange': None, 'nll_gating': None}, {'_target_': 'bliss.encoder.variational_dist.TDBNFactor', 'name': 'locs', 'sample_rearrange': 'b ht wt d -> b ht wt 1 d', 'nll_rearrange': 'b ht wt 1 d -> b ht wt d', 'nll_gating': 'n_sources'}, {'_target_': 'bliss.encoder.variational_dist.BernoulliFactor', 'name': 'source_type', 'sample_rearrange': 'b ht wt -> b ht wt 1 1', 'nll_rearrange': 'b ht wt 1 1 -> b ht wt', 'nll_gating': 'n_sources'}, {'_target_': 'bliss.encoder.variational_dist.LogNormalFactor', 'name': 'star_fluxes', 'dim': 4, 'sample_rearrange': 'b ht wt d -> b ht wt 1 d', 'nll_rearrange': 'b ht wt 1 d -> b ht wt d', 'nll_gating': 'is_star'}, {'_target_': 'bliss.encoder.variational_dist.LogNormalFactor', 'name': 'galaxy_fluxes', 'dim': 4, 'sample_rearrange': 'b ht wt d -> b ht wt 1 d', 'nll_rearrange': 'b ht wt 1 d -> b ht wt d', 'nll_gating': 'is_galaxy'}, {'_target_': 'bliss.encoder.variational_dist.BernoulliFactor', 'name': 'membership', 'sample_rearrange': 'b ht wt -> b ht wt 1 1', 'nll_rearrange': 'b ht wt 1 1 -> b ht wt', 'nll_gating': 'n_sources'}], 'encoder': {'_target_': 'case_studies.galaxy_clustering.encoder.encoder.GalaxyClusterEncoder', 'survey_bands': ['g', 'r', 'i', 'z'], 'tile_slen': '${simulator.prior.tile_slen}', 'tiles_to_crop': 0, 'min_flux_for_loss': 0, 'min_flux_for_metrics': 0, 'optimizer_params': {'lr': 0.001}, 'scheduler_params': {'milestones': [32], 'gamma': 0.1}, 'image_normalizer': {'_target_': 'bliss.encoder.image_normalizer.ImageNormalizer', 'bands': [0, 1, 2, 3], 'include_original': False, 'include_background': True, 'concat_psf_params': False, 'num_psf_params': 6, 'log_transform_stdevs': None, 'use_clahe': False, 'clahe_min_stdev': None}, 'var_dist': {'_target_': 'bliss.encoder.variational_dist.VariationalDist', 'tile_slen': '${encoder.tile_slen}', 'factors': '${variational_factors}'}, 'matcher': {'_target_': 'bliss.encoder.metrics.CatalogMatcher', 'dist_slack': 1.0, 'mag_slack': None, 'mag_band': 2}, 'metrics': {'_target_': 'torchmetrics.MetricCollection', '_convert_': 'partial', 'metrics': {'detection_performance': {'_target_': 'bliss.encoder.metrics.DetectionPerformance', 'mag_bin_cutoffs': [19, 19.4, 19.8, 20.2, 20.6, 21, 21.4, 21.8]}, 'source_type_accuracy': {'_target_': 'bliss.encoder.metrics.SourceTypeAccuracy', 'flux_bin_cutoffs': [200, 400, 600, 800, 1000]}, 'flux_error': {'_target_': 'bliss.encoder.metrics.FluxError', 'survey_bands': '${encoder.survey_bands}'}, 'cluster_membership_error': {'_target_': 'case_studies.galaxy_clustering.encoder.metrics.ClusterMembershipAccuracy'}}}, 'sample_image_renders': {'_target_': 'torchmetrics.MetricCollection', 'metrics': [{'_target_': 'bliss.encoder.sample_image_renders.PlotSampleImages', 'frequency': 1, 'restrict_batch': 0, 'tiles_to_crop': 1, 'tile_slen': '${simulator.prior.tile_slen}'}]}, 'do_data_augmentation': False, 'compile_model': False, 'double_detect': False, 'use_checkerboard': True}, 'surveys': {'sdss': {'_target_': 'bliss.surveys.sdss.SloanDigitalSkySurvey', 'dir_path': '${paths.sdss}', 'fields': [{'run': 94, 'camcol': 1, 'fields': [12]}], 'psf_config': {'pixel_scale': 0.396, 'psf_slen': 25}, 'pixel_shift': 2, 'align_to_band': None, 'load_image_data': False}, 'decals': {'_target_': 'bliss.surveys.decals.DarkEnergyCameraLegacySurvey', 'dir_path': '${paths.decals}', 'sky_coords': [{'ra': 336.6643042496718, 'dec': -0.9316385797930247}], 'bands': [0, 1, 3], 'psf_config': {'pixel_scale': 0.262, 'psf_slen': 63}, 'pixel_shift': 2}, 'des': {'_target_': 'bliss.surveys.des.DarkEnergySurvey', 'dir_path': '${paths.des}', 'image_ids': [{'sky_coord': {'ra': 336.6643042496718, 'dec': -0.9316385797930247}, 'decals_brickname': '3366m010', 'ccdname': 'S28', 'g': 'decam/CP/V4.8.2a/CP20171108/c4d_171109_002003_ooi_g_ls9', 'r': 'decam/CP/V4.8.2a/CP20170926/c4d_170927_025457_ooi_r_ls9', 'i': '', 'z': 'decam/CP/V4.8.2a/CP20170926/c4d_170927_025655_ooi_z_ls9'}], 'psf_config': {'pixel_scale': 0.262, 'psf_slen': 63}, 'pixel_shift': 2}, 'dc2': {'_target_': 'bliss.surveys.dc2.DC2', 'data_dir': '${paths.dc2}/run2.2i-dr6-v4/coadd-t3828-t3829/deepCoadd-results/', 'cat_path': '${paths.dc2}/merged_catalog_with_flux_over_50.pkl', 'split_results_dir': '${paths.output}/dc2_split_results', 'batch_size': 64, 'n_split': 50, 'image_lim': [4000, 4000], 'num_workers': 4, 'split_processes_num': 4, 'min_flux_for_loss': '${encoder.min_flux_for_loss}'}}, 'mode': 'train', 'generate': {'n_image_files': 32, 'n_batches_per_file': 16, 'simulator': '${simulator}', 'cached_data_path': None, 'file_prefix': 'dataset'}, 'train': {'trainer': {'_target_': 'pytorch_lightning.Trainer', 'logger': {'_target_': 'pytorch_lightning.loggers.TensorBoardLogger', 'save_dir': '${paths.output}', 'name': None, 'version': None, 'default_hp_metric': False}, 'callbacks': [{'_target_': 'pytorch_lightning.callbacks.ModelCheckpoint', 'filename': 'best_encoder', 'save_top_k': 1, 'verbose': True, 'monitor': 'val/_loss', 'mode': 'min', 'save_on_train_epoch_end': False, 'auto_insert_metric_name': False}, {'_target_': 'pytorch_lightning.callbacks.early_stopping.EarlyStopping', 'monitor': 'val/_loss', 'mode': 'min', 'patience': 5}], 'reload_dataloaders_every_n_epochs': 0, 'check_val_every_n_epoch': 1, 'log_every_n_steps': 10, 'min_epochs': 1, 'max_epochs': 50, 'accelerator': 'gpu', 'devices': 1, 'precision': '32-true'}, 'data_source': '${cached_simulator}', 'encoder': '${encoder}', 'seed': 42, 'pretrained_weights': None, 'testing': True}, 'predict': {'dataset': '${surveys.des}', 'trainer': {'_target_': 'pytorch_lightning.Trainer', 'accelerator': 'gpu', 'precision': '${train.trainer.precision}'}, 'encoder': '${encoder}', 'weight_save_path': '${paths.root}/output/version_215/checkpoints/best_encoder.ckpt', 'device': 'cuda:0'}}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "#environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
     "with initialize(config_path=\"../\", version_base=None):\n",
     "    cfg = compose(\"config\", {\n",
     "        \"encoder.tiles_to_crop=0\",\n",
@@ -73,40 +64,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'dataset': '${surveys.des}', 'trainer': {'_target_': 'pytorch_lightning.Trainer', 'accelerator': 'gpu', 'precision': '${train.trainer.precision}'}, 'encoder': '${encoder}', 'weight_save_path': '${paths.root}/output/version_215/checkpoints/best_encoder.ckpt', 'device': 'cuda:0'}"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cfg.predict"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "GPU available: True (cuda), used: True\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "IPU available: False, using: 0 IPUs\n",
-      "HPU available: False, using: 0 HPUs\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "encoder = instantiate(cfg.predict.encoder)\n",
     "enc_state_dict = torch.load(cfg.predict.weight_save_path)\n",
@@ -118,58 +87,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'_target_': 'case_studies.galaxy_clustering.encoder.encoder.GalaxyClusterEncoder', 'survey_bands': ['g', 'r', 'i', 'z'], 'tile_slen': '${simulator.prior.tile_slen}', 'tiles_to_crop': 0, 'min_flux_for_loss': 0, 'min_flux_for_metrics': 0, 'optimizer_params': {'lr': 0.001}, 'scheduler_params': {'milestones': [32], 'gamma': 0.1}, 'image_normalizer': {'_target_': 'bliss.encoder.image_normalizer.ImageNormalizer', 'bands': [0, 1, 2, 3], 'include_original': False, 'include_background': True, 'concat_psf_params': False, 'num_psf_params': 6, 'log_transform_stdevs': None, 'use_clahe': False, 'clahe_min_stdev': None}, 'var_dist': {'_target_': 'bliss.encoder.variational_dist.VariationalDist', 'tile_slen': '${encoder.tile_slen}', 'factors': '${variational_factors}'}, 'matcher': {'_target_': 'bliss.encoder.metrics.CatalogMatcher', 'dist_slack': 1.0, 'mag_slack': None, 'mag_band': 2}, 'metrics': {'_target_': 'torchmetrics.MetricCollection', '_convert_': 'partial', 'metrics': {'detection_performance': {'_target_': 'bliss.encoder.metrics.DetectionPerformance', 'mag_bin_cutoffs': [19, 19.4, 19.8, 20.2, 20.6, 21, 21.4, 21.8]}, 'source_type_accuracy': {'_target_': 'bliss.encoder.metrics.SourceTypeAccuracy', 'flux_bin_cutoffs': [200, 400, 600, 800, 1000]}, 'flux_error': {'_target_': 'bliss.encoder.metrics.FluxError', 'survey_bands': '${encoder.survey_bands}'}, 'cluster_membership_error': {'_target_': 'case_studies.galaxy_clustering.encoder.metrics.ClusterMembershipAccuracy'}}}, 'sample_image_renders': {'_target_': 'torchmetrics.MetricCollection', 'metrics': [{'_target_': 'bliss.encoder.sample_image_renders.PlotSampleImages', 'frequency': 1, 'restrict_batch': 0, 'tiles_to_crop': 1, 'tile_slen': '${simulator.prior.tile_slen}'}]}, 'do_data_augmentation': False, 'compile_model': False, 'double_detect': False, 'use_checkerboard': True}"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cfg.predict.encoder"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [7]\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e415f4ccc60445acbf5a6735eacb5113",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Predicting: 0it [00:00, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "enc_output = trainer.predict(encoder, datamodule=dataset)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,100 +114,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'mode_cat': TileCatalog(16 x 20 x 20; n_sources, locs, source_type, star_fluxes, galaxy_fluxes, membership),\n",
-       " 'sample_cat': TileCatalog(16 x 20 x 20; n_sources, locs, source_type, star_fluxes, galaxy_fluxes, membership)}"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "enc_output[i]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "tensor(0.7617)\n",
-      "tensor(0.7545)\n",
-      "tensor(0.7831)\n",
-      "tensor(0.6606)\n",
-      "tensor(0.7428)\n",
-      "tensor(0.7314)\n",
-      "tensor(0.7914)\n",
-      "tensor(0.7291)\n",
-      "tensor(0.8064)\n",
-      "tensor(0.7417)\n",
-      "tensor(0.7417)\n",
-      "tensor(0.7102)\n",
-      "tensor(0.7886)\n",
-      "tensor(0.8294)\n",
-      "tensor(0.8667)\n",
-      "tensor(0.6769)\n",
-      "tensor(0.7378)\n",
-      "tensor(0.7269)\n",
-      "tensor(0.8436)\n",
-      "tensor(0.7305)\n",
-      "tensor(0.7563)\n",
-      "tensor(0.8248)\n",
-      "tensor(0.8311)\n",
-      "tensor(0.7555)\n",
-      "tensor(0.7536)\n",
-      "tensor(0.7544)\n",
-      "tensor(0.7420)\n",
-      "tensor(0.8606)\n",
-      "tensor(0.7786)\n",
-      "tensor(0.7494)\n",
-      "tensor(0.7533)\n",
-      "tensor(0.8033)\n",
-      "tensor(0.7789)\n",
-      "tensor(0.8572)\n",
-      "tensor(0.7725)\n",
-      "tensor(0.7766)\n",
-      "tensor(0.7423)\n",
-      "tensor(0.8138)\n",
-      "tensor(0.8105)\n",
-      "tensor(0.7569)\n",
-      "tensor(0.7467)\n",
-      "tensor(0.7247)\n",
-      "tensor(0.7228)\n",
-      "tensor(0.8033)\n",
-      "tensor(0.7650)\n",
-      "tensor(0.8050)\n",
-      "tensor(0.7533)\n",
-      "tensor(0.7909)\n",
-      "tensor(0.7441)\n",
-      "tensor(0.7303)\n",
-      "tensor(0.7292)\n",
-      "tensor(0.7550)\n",
-      "tensor(0.7958)\n",
-      "tensor(0.7989)\n",
-      "tensor(0.7527)\n",
-      "tensor(0.7569)\n",
-      "tensor(0.7398)\n",
-      "tensor(0.7242)\n",
-      "tensor(0.7641)\n",
-      "tensor(0.7031)\n",
-      "tensor(0.7127)\n",
-      "tensor(0.7295)\n",
-      "tensor(0.3489)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for i in range(len(dataloader_iter)):\n",
     "    truth = next(dataloader_iter)\n",
@@ -282,47 +136,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "tensor(2233)"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "(outputs[\"mode_cat\"][\"membership\"] == truth[\"tile_catalog\"][\"membership\"]).sum()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "torch.Size([8, 20, 20, 1, 1])"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "truth[\"tile_catalog\"][\"membership\"].shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,20 +176,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 82,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "est_cat[\"mode_cat\"].batch_size"
    ]
@@ -373,60 +194,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "torch.Size([3, 20, 20, 1, 1])"
-      ]
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "first_item[\"tile_catalog\"][\"membership\"].shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "torch.Size([3, 20, 20, 1, 1])"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "enc_output[0][\"mode_cat\"][\"membership\"]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "tensor([314,   0, 276, 274,   0, 204,   0, 232,   0, 208, 269, 267])"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "(enc_output[0][\"mode_cat\"][\"n_sources\"] > 0).view(12, -1).sum(dim=1)"
    ]

--- a/case_studies/multiband/alignment.ipynb
+++ b/case_studies/multiband/alignment.ipynb
@@ -53,7 +53,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
     "with initialize(config_path=\".\", version_base=None):\n",
     "    cfg = compose(\"config\", overrides={\"surveys.sdss.load_image_data=true\"})"
    ]

--- a/case_studies/multiband/color_model.ipynb
+++ b/case_studies/multiband/color_model.ipynb
@@ -49,7 +49,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
     "with initialize(config_path=\".\", version_base=None):\n",
     "    cfg = compose(\"config\")"
    ]

--- a/case_studies/multiband/multiband_exp.ipynb
+++ b/case_studies/multiband/multiband_exp.ipynb
@@ -48,7 +48,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
     "with initialize(config_path=\".\", version_base=None):\n",
     "    cfg = compose(\"config\")"
    ]

--- a/case_studies/psf_variation/evaluate_models.ipynb
+++ b/case_studies/psf_variation/evaluate_models.ipynb
@@ -36,7 +36,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "environ[\"BLISS_HOME\"] = \"~/bliss\"\n",
     "with initialize(config_path=\".\", version_base=None):\n",
     "    cfg = compose(\"config\")"
    ]

--- a/case_studies/psf_variation/psf_variation_demo.ipynb
+++ b/case_studies/psf_variation/psf_variation_demo.ipynb
@@ -56,8 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# set bliss home directory and load config\n",
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
+    "# load config\n",
     "with hydra.initialize(config_path=\".\", version_base=None):\n",
     "    cfg = hydra.compose(\"config\")"
    ]

--- a/case_studies/redshift/redshift_from_predicted_mag/DC2_mag_predict.ipynb
+++ b/case_studies/redshift/redshift_from_predicted_mag/DC2_mag_predict.ipynb
@@ -50,8 +50,7 @@
     "from bliss.surveys.dc2 import DC2\n",
     "from pathlib import Path\n",
     "\n",
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[2])\n",
-    "home = environ[\"BLISS_HOME\"]"
+    "home = str(Path().resolve().parents[2])"
    ]
   },
   {

--- a/case_studies/spatial_tiling/boundary_miscalibration.ipynb
+++ b/case_studies/spatial_tiling/boundary_miscalibration.ipynb
@@ -33,7 +33,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
     "with initialize(config_path=\"../../bliss/conf\", version_base=None):\n",
     "    cfg = compose(\"base_config\")\n",
     "\n",

--- a/case_studies/spatial_tiling/m2.ipynb
+++ b/case_studies/spatial_tiling/m2.ipynb
@@ -294,7 +294,6 @@
     "from hydra import initialize, compose\n",
     "from bliss.main import predict\n",
     "\n",
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
     "with initialize(config_path=\"../../case_studies/spatial_tiling/\", version_base=None):\n",
     "    cfg = compose(\"m2_config\", {\n",
     "        \"encoder.tiles_to_crop=3\",\n",

--- a/case_studies/weak_lensing/lensing_config.yaml
+++ b/case_studies/weak_lensing/lensing_config.yaml
@@ -4,9 +4,6 @@ defaults:
     - _self_
     - override hydra/job_logging: stdout
 
-paths:
-    root: ${oc.env:BLISS_HOME}
-
 variational_factors:
   - _target_: bliss.encoder.variational_dist.BivariateNormalFactor
     name: shear

--- a/case_studies/weak_lensing/notebooks/dc2_shear_conv.ipynb
+++ b/case_studies/weak_lensing/notebooks/dc2_shear_conv.ipynb
@@ -52,7 +52,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "environ[\"BLISS_HOME\"] = str(Path().resolve().parents[1])\n",
     "with initialize(config_path=\".\", version_base=None):\n",
     "    cfg = compose(\"config\")\n",
     "train_dc2_cfg = cfg.copy()"

--- a/case_studies/weak_lensing/notebooks/encoder_evaluation.ipynb
+++ b/case_studies/weak_lensing/notebooks/encoder_evaluation.ipynb
@@ -26,7 +26,6 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "environ[\"BLISS_HOME\"] = \"/home/twhit/bliss\"\n",
     "with initialize(config_path=\"../\", version_base=None):\n",
     "    cfg = compose(\"lensing_config\", {\n",
     "        \"train.trainer.logger=null\",\n",

--- a/case_studies/weak_lensing/notebooks/example.ipynb
+++ b/case_studies/weak_lensing/notebooks/example.ipynb
@@ -112,7 +112,6 @@
    "outputs": [],
    "source": [
     "# Change twhit to your username\n",
-    "environ[\"BLISS_HOME\"] = \"/home/twhit/bliss\"\n",
     "with initialize(config_path=\"../../../case_studies/dependent_tiling\", version_base=None):\n",
     "    cfg = compose(\"m2_config\", overrides={\"surveys.sdss.load_image_data=true\"})"
    ]

--- a/case_studies/weak_lensing/notebooks/generate_images.ipynb
+++ b/case_studies/weak_lensing/notebooks/generate_images.ipynb
@@ -38,7 +38,6 @@
    "source": [
     "# Change twhit to your username\n",
     "os.chdir('/home/twhit/bliss/case_studies/weak_lensing/')\n",
-    "environ[\"BLISS_HOME\"] = \"/home/twhit/bliss\"\n",
     "\n",
     "# Compose lensing_config.yaml\n",
     "with initialize(config_path=\"../\", version_base=None):\n",

--- a/case_studies/weak_lensing/notebooks/predictions.ipynb
+++ b/case_studies/weak_lensing/notebooks/predictions.ipynb
@@ -26,7 +26,6 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "environ[\"BLISS_HOME\"] = \"/home/twhit/bliss\"\n",
     "with initialize(config_path=\"../\", version_base=None):\n",
     "    cfg = compose(\"lensing_config\", {\n",
     "        \"predict.trainer.accelerator=cpu\",\n",

--- a/case_studies/weak_lensing/notebooks/training_loop.ipynb
+++ b/case_studies/weak_lensing/notebooks/training_loop.ipynb
@@ -27,7 +27,6 @@
     "\n",
     "home_dir = os.environ['HOME']\n",
     "bliss_dir = f\"{home_dir}/bliss\"\n",
-    "environ[\"BLISS_HOME\"] = bliss_dir\n",
     "\n",
     "os.chdir(f\"{bliss_dir}/case_studies/weak_lensing/\")\n",
     "from bliss.catalog import TileCatalog"

--- a/case_studies/weak_lensing/notebooks/updated_prior.ipynb
+++ b/case_studies/weak_lensing/notebooks/updated_prior.ipynb
@@ -31,7 +31,6 @@
    "source": [
     "# Change stevefan to your username\n",
     "os.chdir('/home/stevefan/bliss/case_studies/weak_lensing/')\n",
-    "environ[\"BLISS_HOME\"] = \"/home/stevefan/bliss\"\n",
     "\n",
     "# Compose lensing_config.yaml\n",
     "with initialize(config_path=\"../\", version_base=None):\n",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,13 +30,14 @@ def output_path(tmpdir_factory):
 @pytest.fixture(scope="session")
 def cfg(pytestconfig, cached_data_path, output_path):
     use_gpu = pytestconfig.getoption("gpu")
+    test_data_dir = Path(__file__).parent / "data"
 
     # pytest-specific overrides
     overrides = {
         "train.trainer.accelerator": "gpu" if use_gpu else "cpu",
         "predict.trainer.accelerator": "gpu" if use_gpu else "cpu",
         "predict.device": "cuda:0" if use_gpu else "cpu",
-        "paths.root": Path(__file__).parents[1].as_posix(),
+        "paths.test_data": test_data_dir,
         "paths.output": str(output_path),
         "cached_simulator.cached_data_path": str(cached_data_path),
         "generate.cached_data_path": str(cached_data_path),

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -11,7 +11,7 @@ def setup_teardown(cfg, monkeypatch):
     # override `align` for now (kernprof analyzes ~40% runtime); TODO: test alignment
     monkeypatch.setattr("bliss.align.align", lambda x, **_args: x)
 
-    checkpoint_dir = cfg.paths.root + "/checkpoints"
+    checkpoint_dir = cfg.paths.output + "/checkpoints"
     if Path(checkpoint_dir).exists():
         shutil.rmtree(checkpoint_dir)
 

--- a/tests/test_sdss.py
+++ b/tests/test_sdss.py
@@ -21,7 +21,6 @@ class TestSDSS:
 
     def test_sdss_custom_dir(self, cfg, tmpdir_factory):
         the_cfg = cfg.copy()
-        the_cfg.paths.root = str(tmpdir_factory.mktemp("root"))
         if cfg.surveys.sdss.dir_path != the_cfg.surveys.sdss.dir_path:
             copytree(cfg.surveys.sdss.dir_path, the_cfg.surveys.sdss.dir_path, dirs_exist_ok=True)
         # Also tests images loaded

--- a/tests/testing_config.yaml
+++ b/tests/testing_config.yaml
@@ -4,13 +4,12 @@ defaults:
     - _self_
 
 paths:
-    test_data: ${oc.env:BLISS_HOME}/tests/data
-
+    output: null  # overridden in conftest.py
+    test_data: null  # overridden in conftest.py
     sdss: ${paths.test_data}/sdss
     decals: ${paths.test_data}/decals
     des: ${paths.test_data}/des
     dc2: ${paths.test_data}/dc2
-
     pretrained_models: ${paths.test_data}/pretrained_models
 
 prior:
@@ -31,7 +30,7 @@ cached_simulator:
 
 surveys:
     sdss:
-        fields:  # list of dictionaries, each with run, camcol, and list of fields
+        fields:
             - run: 94
               camcol: 1
               fields: [12]
@@ -77,7 +76,7 @@ encoder:
 generate:
     n_image_files: 3
     n_batches_per_file: 1
-    cached_data_path: null # use pytest tmpdir
+    cached_data_path: null  # use pytest tmpdir
 
 train:
     seed: 42


### PR DESCRIPTION
In hindsight, we never should have had an environment variable called `BLISS_HOME`. Our pytest files can get the path to the test data with `Path(__file__).parent / 'data'` and our main `bliss` executable shouldn't need to know about the source code location. It's enough for it to know where to write output and where to read survey data.