### PR TITLE
Speeding up drawImage by reducing folding_threshold for galaxies with dim fluxes

### DIFF
--- a/bliss/simulator/decoder.py
+++ b/bliss/simulator/decoder.py
@@ -181,6 +181,13 @@ class Decoder(nn.Module):
 
                 # essentially all the runtime of the simulator is incurred by this call
                 # to drawImage
+
+                dim_threshold = 700
+                galaxy_fluxes = source_params["galaxy_fluxes"]
+                avg_flux = galaxy_fluxes.sum().item() / len(galaxy_fluxes)
+                if avg_flux <= dim_threshold:
+                    galsim_obj.folding_threshold = 0.95
+
                 galsim_obj.drawImage(
                     offset=offset,
                     method=getattr(self.survey.psf, "psf_draw_method", "auto"),


### PR DESCRIPTION
Every time drawImage() called, the folding_threshold (originally defaulted set to 0.995) is lowered to 0.95 if the average flux across bands is lower than a dim threshold. Use to speed up the drawing process.