### PR TITLE
re-fix of old silent error (loss shape broadcast mismatch caused by extra dim of size 1)

### DIFF
--- a/bliss/encoder/variational_dist.py
+++ b/bliss/encoder/variational_dist.py
@@ -133,6 +133,8 @@ class VariationalFactor:
             target = torch.where(gating.unsqueeze(-1), target, 0)
         assert not torch.isnan(target).any()
         ungated_nll = -qk.log_prob(target)
+        if ungated_nll.dim() == target.dim():  # (b, w, h, 1) -> (b,w,h) silent error
+            ungated_nll = ungated_nll.squeeze(-1)
         return ungated_nll * gating
 
 


### PR DESCRIPTION
had to re-fix the gating error after recent changes, now convergence (or anything of size (b, h, w, 1)) is correctly squeezed before being gated even in the absence of n_sources