### PR TITLE
Quick Bug Fix

### DIFF
--- a/bliss/encoder/image_normalizer.py
+++ b/bliss/encoder/image_normalizer.py
@@ -77,11 +77,11 @@ class AsinhQuantileNormalizer(torch.nn.Module):
     def get_input_tensor(self, batch):
         ss_images = batch["images"]  # assumes images are already sky subtracted
         # select every {pixel_shift}th pixel
-        ss_images = ss_images[:, :, :: self.pixel_shift, :: self.pixel_shift]
+        sliced_images = ss_images[:, :, :: self.pixel_shift, :: self.pixel_shift]
 
         if self.training and self.num_updates < 100:
             self.num_updates += 1
-            cur_quantiles = torch.quantile(ss_images, q=self.q)
+            cur_quantiles = torch.quantile(sliced_images, q=self.q)
             lr = 1.0 / self.num_updates
             self.quantiles *= 1 - lr
             self.quantiles += lr * cur_quantiles

--- a/case_studies/galaxy_clustering/encoder/convnet.py
+++ b/case_studies/galaxy_clustering/encoder/convnet.py
@@ -53,11 +53,17 @@ class GalaxyClusterFeaturesNet(nn.Module):
         )
 
         log_tile_size = torch.log2(torch.tensor(tile_slen))
-        num_downsample = int(torch.round(log_tile_size)) - 3
+        num_total_downsample = int(torch.round(log_tile_size)) - 1
+        num_downsample4, num_downsample2 = divmod(num_total_downsample, 2)
         self.backbone = nn.ModuleList()
 
         if downsample_at_front:
-            for _ in range(num_downsample):
+            for _ in range(num_downsample4):
+                self.backbone.append(
+                    ConvBlock(nch_hidden, 2 * nch_hidden, kernel_size=5, stride=4, padding=2)
+                )
+                nch_hidden *= 2
+            if num_downsample2:
                 self.backbone.append(
                     ConvBlock(nch_hidden, 2 * nch_hidden, kernel_size=5, stride=2, padding=2)
                 )
@@ -77,7 +83,12 @@ class GalaxyClusterFeaturesNet(nn.Module):
             self.backbone.append(ConvBlock(64, 128, stride=2))
             self.backbone.append(nn.Sequential(*[ConvBlock(128, 128) for _ in range(5)]))
             num_channels = 128
-            for _ in range(num_downsample):
+            for _ in range(num_downsample4):
+                self.backbone.append(
+                    ConvBlock(num_channels, 2 * num_channels, kernel_size=5, stride=4, padding=2)
+                )
+                num_channels *= 2
+            if num_downsample2:
                 self.backbone.append(
                     ConvBlock(num_channels, 2 * num_channels, kernel_size=5, stride=2, padding=2)
                 )


### PR DESCRIPTION
Realized that the normalizer used the sliced image as output instead of the original image. Fixed this issue. Since we were getting OOM errors, had to resort to using a mix of stride 4 and stride 2 in our downsampling layers.