### PR TITLE
Consistent ordering of cached data files between deeplearning and Great Lakes

### DIFF
--- a/bliss/cached_dataset.py
+++ b/bliss/cached_dataset.py
@@ -266,7 +266,9 @@ class CachedSimulatedDataModule(pl.LightningDataModule):
         raise RuntimeError(f"setup skips stage {stage}")
 
     def _load_file_paths_and_slices(self):
-        file_names = [f for f in os.listdir(str(self.cached_data_path)) if f.endswith(".pt")]
+        file_names = [
+            f for f in sorted(os.listdir(str(self.cached_data_path))) if f.endswith(".pt")
+        ]
         if self.subset_fraction:
             file_names = file_names[: math.ceil(len(file_names) * self.subset_fraction)]
         self.file_paths = [os.path.join(str(self.cached_data_path), f) for f in file_names]


### PR DESCRIPTION
`os.listdir()` does not necessarily list files in the same order on Great Lakes as it does on the deeplearning server, even if the contents of the directory are the same in both places and the same random seed is set in both places.

This behavior is documented, e.g., [here](https://stackoverflow.com/questions/4813061/non-alphanumeric-list-order-from-os-listdir) and [here](https://stackoverflow.com/questions/31534583/is-os-listdir-deterministic).

This issue is relevant for any BLISS case study that trains a network on Great Lakes and then evaluates the trained network on the deeplearning server. In `CachedSimulatedDataModule`, files are assigned to train/val/test based on the order in which they are read in by `os.listdir()`. So because of the behavior mentioned above, one could obtain different train/val/test splits on deeplearning and Great Lakes even if the directory contents and random seed are the same in both places.

The proposed fix just wraps `sorted()` around the list of file names.