### PR TITLE
Randomly shuffle cached data files when loading them in

### DIFF
--- a/bliss/cached_dataset.py
+++ b/bliss/cached_dataset.py
@@ -269,6 +269,7 @@ class CachedSimulatedDataModule(pl.LightningDataModule):
         file_names = [
             f for f in sorted(os.listdir(str(self.cached_data_path))) if f.endswith(".pt")
         ]
+        random.shuffle(file_names)
         if self.subset_fraction:
             file_names = file_names[: math.ceil(len(file_names) * self.subset_fraction)]
         self.file_paths = [os.path.join(str(self.cached_data_path), f) for f in file_names]


### PR DESCRIPTION
Minor update to #1075.

The sorted list of file names returned by `sorted(os.listdir(str(self.cached_data_path)))` might have a meaningful order. For example, DC2 split files have a non-random ra/dec order when listed alphanumerically. As a result, if we split the cached data files into train/val/test based on the order in which they appear in `sorted(os.listdir())`, the assignment is not random with respect to ra/dec (or any other variable that determines their order).

To fix this, we randomly shuffle the list of files after loading them in. `random.shuffle()` is seeded by `pl.seed_everything()`, so it will be reproducible across any training runs that set the same seed.

This fix probably won't matter for most case studies, but it's helpful for weak lensing because we use our test set predictions to compute two-point correlation functions, and it's necessary to have a representative range of ra/decs for those calculations.