### PR TITLE
fable refactor

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --all-extras
+          uv sync
 
       - name: Create local changes
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync
 
       - name: Run ruff format check
         run: uv run ruff format --check .

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ git clone git@github.com:prob-ml/bliss.git
 
 ```bash
 cd bliss
-uv sync --all-extras
+uv sync
 ```
 
 6. Activate the virtual environment:

--- a/bliss/surveys/dc2.py
+++ b/bliss/surveys/dc2.py
@@ -334,26 +334,26 @@ class DC2FullCatalog(FullCatalog):
         flux_r_band = catalog["flux_r"].values
         catalog = catalog.loc[flux_r_band > kwargs["catalog_min_r_flux"]]
 
-        objid = torch.from_numpy(catalog["id"].values)
-        match_id = torch.from_numpy(catalog["match_objectId"].values)
-        ra = torch.from_numpy(catalog["ra"].values)
-        dec = torch.from_numpy(catalog["dec"].values)
+        objid = torch.tensor(catalog["id"].values)
+        match_id = torch.tensor(catalog["match_objectId"].values)
+        ra = torch.tensor(catalog["ra"].values)
+        dec = torch.tensor(catalog["dec"].values)
         plocs = cls.plocs_from_ra_dec(ra, dec, wcs).squeeze(0)
-        galaxy_bools = torch.from_numpy((catalog["truth_type"] == 1).values)
-        star_bools = torch.from_numpy((catalog["truth_type"] == 2).values)
-        source_type = torch.from_numpy(catalog["truth_type"].values)
+        galaxy_bools = torch.tensor((catalog["truth_type"] == 1).values)
+        star_bools = torch.tensor((catalog["truth_type"] == 2).values)
+        source_type = torch.tensor(catalog["truth_type"].values)
         # we ignore the supernova
         source_type = torch.where(source_type == 2, SourceType.STAR, SourceType.GALAXY)
         fluxes, psf_params = cls.get_bands_flux_and_psf(kwargs["bands"], catalog)
-        blendedness = torch.from_numpy(catalog["blendedness"].values)
-        shear1 = torch.from_numpy(catalog["shear_1"].values)
-        shear2 = torch.from_numpy(catalog["shear_2"].values)
+        blendedness = torch.tensor(catalog["blendedness"].values)
+        shear1 = torch.tensor(catalog["shear_1"].values)
+        shear2 = torch.tensor(catalog["shear_2"].values)
         shear = torch.stack((shear1, shear2), dim=-1)
-        ellipticity1 = torch.from_numpy(catalog["ellipticity_1_true"].values)
-        ellipticity2 = torch.from_numpy(catalog["ellipticity_2_true"].values)
+        ellipticity1 = torch.tensor(catalog["ellipticity_1_true"].values)
+        ellipticity2 = torch.tensor(catalog["ellipticity_2_true"].values)
         ellipticity = torch.stack((ellipticity1, ellipticity2), dim=-1)
-        cosmodc2_mask = torch.from_numpy(catalog["cosmodc2_mask"].values)
-        redshifts = torch.from_numpy(catalog["redshifts"].values)
+        cosmodc2_mask = torch.tensor(catalog["cosmodc2_mask"].values)
+        redshifts = torch.tensor(catalog["redshifts"].values)
 
         ori_len = len(catalog)
         d = {
@@ -403,7 +403,7 @@ class DC2FullCatalog(FullCatalog):
         flux_list = []
         psf_params_list = []
         for b in bands:
-            flux_list.append(torch.from_numpy((catalog[f"flux_{b}"]).values))
+            flux_list.append(torch.tensor((catalog[f"flux_{b}"]).values))
             psf_params_name = ["IxxPSF_pixel_", "IyyPSF_pixel_", "IxyPSF_pixel_", "psf_fwhm_"]
             psf_params_cur_band = []
             for i in psf_params_name:

--- a/bliss/surveys/dc2.py
+++ b/bliss/surveys/dc2.py
@@ -319,8 +319,6 @@ class DC2DataModule(CachedSimulatedDataModule):
 class DC2FullCatalog(FullCatalog):
     @classmethod
     def from_file(cls, cat_path, wcs, height, width, **kwargs):
-        # load catalog from either a string path or a Path
-
         cat_path = Path(cat_path)
         suffix = cat_path.suffix.lower()
 
@@ -331,53 +329,51 @@ class DC2FullCatalog(FullCatalog):
         else:
             raise ValueError(f"Unsupported catalog file format: {suffix}")
 
-        flux_r_band = catalog["flux_r"].values
-        catalog = catalog.loc[flux_r_band > kwargs["catalog_min_r_flux"]]
+        catalog = catalog.loc[catalog["flux_r"].values > kwargs["catalog_min_r_flux"]]
 
-        objid = torch.tensor(catalog["id"].values)
-        match_id = torch.tensor(catalog["match_objectId"].values)
-        ra = torch.tensor(catalog["ra"].values)
-        dec = torch.tensor(catalog["dec"].values)
-        plocs = cls.plocs_from_ra_dec(ra, dec, wcs).squeeze(0)
-        truth_type = torch.tensor(catalog["truth_type"].values)
+        col_names = (
+            "id",
+            "match_objectId",
+            "ra",
+            "dec",
+            "truth_type",
+            "blendedness",
+            "shear_1",
+            "shear_2",
+            "ellipticity_1_true",
+            "ellipticity_2_true",
+            "cosmodc2_mask",
+            "redshifts",
+        )
+        cols = {name: torch.tensor(catalog[name].values) for name in col_names}
+
+        plocs = cls.plocs_from_ra_dec(cols["ra"], cols["dec"], wcs).squeeze(0)
+        truth_type = cols["truth_type"]
         star_galaxy_filter = (truth_type == 1) | (truth_type == 2)
         # we ignore the supernova
         source_type = torch.where(truth_type == 2, SourceType.STAR, SourceType.GALAXY)
         fluxes, psf_params = cls.get_bands_flux_and_psf(kwargs["bands"], catalog)
-        blendedness = torch.tensor(catalog["blendedness"].values)
-        shear1 = torch.tensor(catalog["shear_1"].values)
-        shear2 = torch.tensor(catalog["shear_2"].values)
-        shear = torch.stack((shear1, shear2), dim=-1)
-        ellipticity1 = torch.tensor(catalog["ellipticity_1_true"].values)
-        ellipticity2 = torch.tensor(catalog["ellipticity_2_true"].values)
-        ellipticity = torch.stack((ellipticity1, ellipticity2), dim=-1)
-        cosmodc2_mask = torch.tensor(catalog["cosmodc2_mask"].values)
-        redshifts = torch.tensor(catalog["redshifts"].values)
+        shear = torch.stack((cols["shear_1"], cols["shear_2"]), dim=-1)
+        ellipticity = torch.stack((cols["ellipticity_1_true"], cols["ellipticity_2_true"]), dim=-1)
 
-        ori_len = len(catalog)
+        plocs_start_point = torch.tensor([0.0, 0.0])
+        plocs_end_point = torch.tensor([height, width])
+        in_bounds = ((plocs > plocs_start_point) & (plocs < plocs_end_point)).all(dim=-1)
+        keep = star_galaxy_filter & in_bounds
+
+        nobj = int(keep.sum())
         d = {
-            "objid": objid.view(1, ori_len, 1),
-            "source_type": source_type.view(1, ori_len, 1),
-            "plocs": plocs.view(1, ori_len, 2),
-            "redshifts": redshifts.view(1, ori_len, 1),
-            "fluxes": fluxes.view(1, ori_len, kwargs["n_bands"]),
-            "blendedness": blendedness.view(1, ori_len, 1),
-            "shear": shear.view(1, ori_len, 2),
-            "ellipticity": ellipticity.view(1, ori_len, 2),
-            "cosmodc2_mask": cosmodc2_mask.view(1, ori_len, 1),
+            "objid": cols["id"][keep].view(1, nobj, 1),
+            "source_type": source_type[keep].view(1, nobj, 1),
+            "plocs": plocs[keep].view(1, nobj, 2),
+            "redshifts": cols["redshifts"][keep].view(1, nobj, 1),
+            "fluxes": fluxes[keep].view(1, nobj, kwargs["n_bands"]),
+            "blendedness": cols["blendedness"][keep].view(1, nobj, 1),
+            "shear": shear[keep].view(1, nobj, 2),
+            "ellipticity": ellipticity[keep].view(1, nobj, 2),
+            "cosmodc2_mask": cols["cosmodc2_mask"][keep].view(1, nobj, 1),
         }
-
-        for k, v in d.items():
-            d[k] = v[:, star_galaxy_filter, :]
-        match_id = match_id[star_galaxy_filter]
-
-        plocs_start_point = torch.tensor([0.0, 0.0]).view(1, 1, -1)
-        plocs_end_point = torch.tensor([height, width]).view(1, 1, -1)
-        plocs_mask = ((d["plocs"] > plocs_start_point) & (d["plocs"] < plocs_end_point)).all(dim=-1)
-        plocs_mask = plocs_mask.squeeze(0)
-        for k, v in d.items():
-            d[k] = v[:, plocs_mask, :]
-        match_id = match_id[plocs_mask]
+        match_id = cols["match_objectId"][keep]
 
         cosmodc2_mask = rearrange(d["cosmodc2_mask"], "1 nobj 1 -> nobj")
         shear = d["shear"]
@@ -391,27 +387,16 @@ class DC2FullCatalog(FullCatalog):
             and torch.isnan(ellipticity[:, ~cosmodc2_mask, :]).all()
         )
 
-        nobj = d["source_type"].shape[1]
         d["n_sources"] = torch.tensor((nobj,))
 
         return cls(height, width, d), psf_params, match_id
 
     @classmethod
-    def get_bands_flux_and_psf(cls, bands, catalog, median=True):
-        flux_list = []
-        psf_params_list = []
-        for b in bands:
-            flux_list.append(torch.tensor((catalog[f"flux_{b}"]).values))
-            psf_params_name = ["IxxPSF_pixel_", "IyyPSF_pixel_", "IxyPSF_pixel_", "psf_fwhm_"]
-            psf_params_cur_band = []
-            for i in psf_params_name:
-                if median:
-                    median_psf = np.nanmedian((catalog[f"{i}{b}"]).values).astype(np.float32)
-                    psf_params_cur_band.append(median_psf)
-                else:
-                    psf_params_cur_band.append(catalog[f"{i}{b}"].values.astype(np.float32))
-            psf_params_list.append(
-                torch.tensor(np.array(psf_params_cur_band))
-            )  # bands x 4 (params per band) x n_obj
-
-        return torch.stack(flux_list).t(), torch.stack(psf_params_list).unsqueeze(0)
+    def get_bands_flux_and_psf(cls, bands, catalog):
+        psf_prefixes = ("IxxPSF_pixel_", "IyyPSF_pixel_", "IxyPSF_pixel_", "psf_fwhm_")
+        fluxes = torch.tensor(catalog[[f"flux_{b}" for b in bands]].values)
+        psf_cols = [f"{p}{b}" for b in bands for p in psf_prefixes]
+        psf_vals = catalog[psf_cols].values.T.reshape(len(bands), len(psf_prefixes), -1)
+        median_psf = np.nanmedian(psf_vals, axis=-1).astype(np.float32)
+        psf_params = torch.tensor(median_psf).unsqueeze(0)
+        return fluxes, psf_params

--- a/bliss/surveys/dc2.py
+++ b/bliss/surveys/dc2.py
@@ -339,11 +339,10 @@ class DC2FullCatalog(FullCatalog):
         ra = torch.tensor(catalog["ra"].values)
         dec = torch.tensor(catalog["dec"].values)
         plocs = cls.plocs_from_ra_dec(ra, dec, wcs).squeeze(0)
-        galaxy_bools = torch.tensor((catalog["truth_type"] == 1).values)
-        star_bools = torch.tensor((catalog["truth_type"] == 2).values)
-        source_type = torch.tensor(catalog["truth_type"].values)
+        truth_type = torch.tensor(catalog["truth_type"].values)
+        star_galaxy_filter = (truth_type == 1) | (truth_type == 2)
         # we ignore the supernova
-        source_type = torch.where(source_type == 2, SourceType.STAR, SourceType.GALAXY)
+        source_type = torch.where(truth_type == 2, SourceType.STAR, SourceType.GALAXY)
         fluxes, psf_params = cls.get_bands_flux_and_psf(kwargs["bands"], catalog)
         blendedness = torch.tensor(catalog["blendedness"].values)
         shear1 = torch.tensor(catalog["shear_1"].values)
@@ -368,7 +367,6 @@ class DC2FullCatalog(FullCatalog):
             "cosmodc2_mask": cosmodc2_mask.view(1, ori_len, 1),
         }
 
-        star_galaxy_filter = galaxy_bools | star_bools
         for k, v in d.items():
             d[k] = v[:, star_galaxy_filter, :]
         match_id = match_id[star_galaxy_filter]

--- a/case_studies/weak_lensing/dc2/dc2.py
+++ b/case_studies/weak_lensing/dc2/dc2.py
@@ -404,18 +404,18 @@ class LensingDC2Catalog:
         """Read and process catalog from pickle file."""
         catalog = pd.read_pickle(cat_path)
 
-        galid = torch.from_numpy(catalog["galaxy_id"].values)
-        ra = torch.from_numpy(catalog["ra"].values)
-        dec = torch.from_numpy(catalog["dec"].values)
+        galid = torch.tensor(catalog["galaxy_id"].values)
+        ra = torch.tensor(catalog["ra"].values)
+        dec = torch.tensor(catalog["dec"].values)
 
-        shear1 = torch.from_numpy(catalog["shear_1"].values)
-        shear2 = torch.from_numpy(catalog["shear_2"].values)
+        shear1 = torch.tensor(catalog["shear_1"].values)
+        shear2 = torch.tensor(catalog["shear_2"].values)
         complex_shear = shear1 + shear2 * 1j
-        convergence = torch.from_numpy(catalog["convergence"].values)
+        convergence = torch.tensor(catalog["convergence"].values)
         reduced_shear = complex_shear / (1.0 - convergence)
 
-        ellip1_intrinsic = torch.from_numpy(catalog["ellipticity_1_true_dc2"].values)
-        ellip2_intrinsic = torch.from_numpy(catalog["ellipticity_2_true_dc2"].values)
+        ellip1_intrinsic = torch.tensor(catalog["ellipticity_1_true_dc2"].values)
+        ellip2_intrinsic = torch.tensor(catalog["ellipticity_2_true_dc2"].values)
         complex_ellip_intrinsic = ellip1_intrinsic + ellip2_intrinsic * 1j
         complex_ellip_lensed = (complex_ellip_intrinsic + reduced_shear) / (
             1.0 + reduced_shear.conj() * complex_ellip_intrinsic
@@ -423,14 +423,14 @@ class LensingDC2Catalog:
         ellip1_lensed = torch.view_as_real(complex_ellip_lensed)[..., 0]
         ellip2_lensed = torch.view_as_real(complex_ellip_lensed)[..., 1]
 
-        ixx = torch.from_numpy(catalog["Iyy_pixel"].values)  # align coordinate system
-        iyy = torch.from_numpy(catalog["Ixx_pixel"].values)  # align coordinate system
-        ixy = torch.from_numpy(catalog["Ixy_pixel"].values)
+        ixx = torch.tensor(catalog["Iyy_pixel"].values)  # align coordinate system
+        iyy = torch.tensor(catalog["Ixx_pixel"].values)  # align coordinate system
+        ixy = torch.tensor(catalog["Ixy_pixel"].values)
         ellip_lsst = (ixx - iyy + 2j * ixy) / (ixx + iyy + 2 * np.sqrt(ixx * iyy - (ixy**2)))
         ellip1_lsst = torch.view_as_real(ellip_lsst)[..., 0]
         ellip2_lsst = torch.view_as_real(ellip_lsst)[..., 1]
 
-        redshift = torch.from_numpy(catalog["redshift"].values)
+        redshift = torch.tensor(catalog["redshift"].values)
 
         _, psf_params = get_bands_flux_and_psf(kwargs["bands"], catalog, median=False)
 

--- a/case_studies/weak_lensing/dc2/utils.py
+++ b/case_studies/weak_lensing/dc2/utils.py
@@ -74,7 +74,7 @@ def get_bands_flux_and_psf(bands, catalog, median=True):
     flux_list = []
     psf_params_list = []
     for b in bands:
-        flux_list.append(torch.from_numpy((catalog[f"flux_{b}"]).values))
+        flux_list.append(torch.tensor((catalog[f"flux_{b}"]).values))
         psf_params_name = ["IxxPSF_pixel_", "IyyPSF_pixel_", "IxyPSF_pixel_", "psf_fwhm_"]
         psf_params_cur_band = []
         for i in psf_params_name:

--- a/docs/docsrc/Installation.rst
+++ b/docs/docsrc/Installation.rst
@@ -30,7 +30,7 @@ Developer Installation
 
     git clone git@github.com:prob-ml/bliss.git
     cd bliss
-    uv sync --all-extras
+    uv sync
 
 5. Activate the virtual environment::
 
@@ -67,7 +67,7 @@ BLISS requires the following core packages:
 - **Astropy** (>=6.1.1): Astronomical utilities
 - **NumPy**, **SciPy**, **Matplotlib**: Scientific computing
 
-All dependencies are automatically installed via ``uv sync --all-extras``.
+All dependencies are automatically installed via ``uv sync``.
 
 Troubleshooting
 ###############

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ explicit = true
 torch = [{index = "pytorch-cu128"}]
 torchvision = [{index = "pytorch-cu128"}]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "Sphinx>=4.0.2",
     "git-lfs>=1.6",
@@ -99,6 +99,7 @@ filterwarnings = [
   "ignore:.*Detected call of `lr_scheduler.step()` before `optimizer.step()`.*:UserWarning",
   "ignore:.*AMP with fp16 is not supported on CPU.*:UserWarning",
   "ignore:.*This process.*is multi-threaded, use of fork.*may lead to deadlocks.*:DeprecationWarning",
+  "ignore:.*isinstance.*LeafSpec.*is deprecated.*:FutureWarning",
 ]
 minversion = "6.0"
 testpaths = [

--- a/uv.lock
+++ b/uv.lock
@@ -412,7 +412,7 @@ dependencies = [
     { name = "treecorr" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "git-lfs" },
     { name = "h5py" },
@@ -446,44 +446,47 @@ requires-dist = [
     { name = "colossus", specifier = ">=1.3.5" },
     { name = "einops", specifier = ">=0.8.0" },
     { name = "galsim", specifier = ">=2.4.10" },
-    { name = "git-lfs", marker = "extra == 'dev'", specifier = ">=1.6" },
-    { name = "h5py", marker = "extra == 'dev'", specifier = ">=3.11.0" },
-    { name = "healpy", marker = "extra == 'dev'", specifier = ">=1.16.6" },
     { name = "hydra-core", specifier = ">=1.0.4" },
-    { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29.5" },
-    { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "lightning", extras = ["extra"], specifier = ">=2.3.3" },
     { name = "lsstdesc-gcr-catalogs", specifier = ">=1.10.1" },
     { name = "matplotlib", specifier = ">=3.3.3" },
-    { name = "nbsphinx", marker = "extra == 'dev'", specifier = ">=0.9.2" },
-    { name = "nbstripout", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "numpy", specifier = ">=1.18.5" },
-    { name = "plotly", marker = "extra == 'dev'", specifier = ">=4.14.3" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=2.9.2" },
-    { name = "pre-commit-hooks", marker = "extra == 'dev'", specifier = ">=4.4.0" },
-    { name = "pyarrow", marker = "extra == 'dev'", specifier = ">=15.0.0" },
     { name = "pyccl", specifier = ">=3.2.1" },
-    { name = "pypandoc", marker = "extra == 'dev'", specifier = ">=1.11" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2.2" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=2.10" },
-    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "pyvo", specifier = ">=1.4.1" },
     { name = "reproject", specifier = ">=0.11.0" },
     { name = "requests", specifier = ">=2.31.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
-    { name = "scikit-learn", marker = "extra == 'dev'", specifier = ">=0.24.2" },
     { name = "scipy", specifier = ">=1.4.1" },
-    { name = "seaborn", marker = "extra == 'dev'", specifier = ">=0.13.0" },
-    { name = "sphinx", marker = "extra == 'dev'", specifier = ">=4.0.2" },
-    { name = "sphinx-rtd-theme", marker = "extra == 'dev'", specifier = ">=0.5.2" },
-    { name = "tensorboard", marker = "extra == 'dev'", specifier = ">=2.20.0" },
     { name = "torch", specifier = ">=2.7.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torchmetrics", specifier = ">=1.4.0.post0" },
     { name = "torchvision", specifier = ">=0.22.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "tqdm", marker = "extra == 'dev'", specifier = ">=4.62.3" },
     { name = "treecorr", specifier = ">=5.1.2" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "git-lfs", specifier = ">=1.6" },
+    { name = "h5py", specifier = ">=3.11.0" },
+    { name = "healpy", specifier = ">=1.16.6" },
+    { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "jupyter", specifier = ">=1.0.0" },
+    { name = "nbsphinx", specifier = ">=0.9.2" },
+    { name = "nbstripout", specifier = ">=0.5.0" },
+    { name = "plotly", specifier = ">=4.14.3" },
+    { name = "pre-commit", specifier = ">=2.9.2" },
+    { name = "pre-commit-hooks", specifier = ">=4.4.0" },
+    { name = "pyarrow", specifier = ">=15.0.0" },
+    { name = "pypandoc", specifier = ">=1.11" },
+    { name = "pytest", specifier = ">=8.2.2" },
+    { name = "pytest-cov", specifier = ">=2.10" },
+    { name = "pytest-xdist", specifier = ">=3.5.0" },
+    { name = "ruff", specifier = ">=0.8.0" },
+    { name = "scikit-learn", specifier = ">=0.24.2" },
+    { name = "seaborn", specifier = ">=0.13.0" },
+    { name = "sphinx", specifier = ">=4.0.2" },
+    { name = "sphinx-rtd-theme", specifier = ">=0.5.2" },
+    { name = "tensorboard", specifier = ">=2.20.0" },
+    { name = "tqdm", specifier = ">=4.62.3" },
+]
 
 [[package]]
 name = "camb"
@@ -858,7 +861,7 @@ name = "cuda-bindings"
 version = "12.9.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/04/8a4d45dc154a8a32982658cc55be291e9778d1197834b15d33427e2f65c1/cuda_bindings-12.9.6-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea331bc47d9988cc61f0ecc5fa8df9dd188b4493ae1c6688bb1ee8ce8ba1af4", size = 7050347, upload-time = "2026-03-11T14:47:35.221Z" },
@@ -891,37 +894,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
     { name = "nvidia-cufile-cu12", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand-cu12", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -2788,7 +2791,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/b8/277c51962ee46fa3e5b203ac5f76107c650f781d6891e681e28e6f3e9fe6/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:08caaf27fe556aca82a3ee3b5aa49a77e7de0cfcb7ff4e5c29da426387a8267e", size = 656910700, upload-time = "2026-02-03T20:40:25.508Z" },
@@ -2800,7 +2803,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -2830,9 +2833,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -2844,7 +2847,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
@@ -3006,7 +3009,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -4401,21 +4404,21 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9c8f38efee365cb9d334de8a83ce52fc7e5fc9e5a7b0853285efa1b69e00b0f2", upload-time = "2026-04-27T17:41:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d252cf975fb18c94a85336323ad425f473df56dab35a44b00399bd70c7a3b997", upload-time = "2026-04-27T17:42:06Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:7c78215c3af4f62e63f2b2e360f1722fc719b0853c7ac22666483d9810613a4c", upload-time = "2026-04-27T17:43:49Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7db3580106bba044da5b8950f3fb8fe5f31999eaab3f6a3aa2ac5d202c3684d2", upload-time = "2026-04-27T17:45:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:db964b33c55035a72ab3e2162287af8f1cc276039c65d015740cc88c26dcedf7", upload-time = "2026-04-27T17:46:18Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:6f367e62fd81b75cdf23ca4b75ced834d2db2cf98d1588ac935bde345de9de23", upload-time = "2026-04-27T17:48:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd1cf1005c5fe419194ee294b7b584ba5ad0f2fb1778b3fe5a7b9c3f4617ddbc", upload-time = "2026-04-27T17:50:01Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:74b628dbc71603977b09f4e140792c6e997081a35ef3421555f3f6e201b81210", upload-time = "2026-04-27T17:50:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:c2a5984deba8e001d166bf9cb83b8351f63a28b009e1a2fa0e4bbf08c90b259b", upload-time = "2026-04-27T17:52:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:baa52f7b8a53cab16587b10f1c27d1000ca033f97236878b685b75d5a1b92408", upload-time = "2026-04-27T17:54:24Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d389a850677f0d24dafae1573644034428d8d3b9c80b51d55ba62fed7e6c8777", upload-time = "2026-04-27T17:55:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-win_amd64.whl", hash = "sha256:d6c21797ff75271b4fbdd905e2d703be4ecea5ea5bbdde4d1c201e9c71bc411d", upload-time = "2026-04-27T17:56:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:06849e9311dbb0617c97557d9c26c99a9e1c4f2ac9cb8e9b6d9b420d522acb91", upload-time = "2026-04-27T17:58:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:169a9987e1f84f0c5eee07544b3a34827a163ac9180e23abf0c3548f1335762c", upload-time = "2026-04-27T17:59:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-win_amd64.whl", hash = "sha256:d86c125d720c2c368c53bd1a4ef062916d91fa965c10448c74c78b5d039faf2d", upload-time = "2026-04-27T18:01:14Z" },
 ]
 
 [[package]]
@@ -4443,21 +4446,21 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ccf26b4b659cfce6f2208cb8326071d51c70219a34856dfdf468d1e19af52c0d" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-win_amd64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cb1f6184a7ba30fba40580e1a01a6604a86c55e79fdda187f40116ee680441ec" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-win_amd64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6168abc019803ac9e97efce27eafd2fdb33db04dcc54a86039537729e5047b29" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-win_amd64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aac647c9130f1f25f5c8f5bca3d95cfd96bdfac93ab54529690b088e64e4fa64" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-win_amd64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b5772c55bfda4377df8f1930d43c4e0231ef231b0228eade4b227c8d3ba6e34e" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:63e35234aed13b6edda37056f417b5c281249669db631e706811917af36b21d7", upload-time = "2026-04-09T23:21:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ccf26b4b659cfce6f2208cb8326071d51c70219a34856dfdf468d1e19af52c0d", upload-time = "2026-03-23T15:36:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:8c0d1c4fbb2c9a4d5d41d0aaa87da20e525bcb2a154ce405725b0be59456804b", upload-time = "2026-04-09T23:21:36Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c4a9cacd521f2a4df0bcd9d8e96704771b928f478f1f3067e4085bb53a1da298", upload-time = "2026-04-09T23:21:37Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cb1f6184a7ba30fba40580e1a01a6604a86c55e79fdda187f40116ee680441ec", upload-time = "2026-03-23T15:36:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:0232cb219927a52d6c98ff202f32d1cdf4802c2195a85fc1f1a0c1b0b4983a4d", upload-time = "2026-04-09T23:21:38Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e594732552a8c2fee2ace9c6475c6c6904fc44ccca622ee6765a89a045416a44", upload-time = "2026-04-09T23:21:38Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6168abc019803ac9e97efce27eafd2fdb33db04dcc54a86039537729e5047b29", upload-time = "2026-03-23T15:36:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:367d42ea703844ecdb516e9d5eb09929012a58705d2622cf4e9e3c37f278cb85", upload-time = "2026-04-09T23:21:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b3865fa227661dd75b7b28c96d3d14e739bd08bf0614132758922fe0e7206f91", upload-time = "2026-04-09T23:21:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aac647c9130f1f25f5c8f5bca3d95cfd96bdfac93ab54529690b088e64e4fa64", upload-time = "2026-03-23T15:36:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-win_amd64.whl", hash = "sha256:6319e1ba49c6f62ac9902f73d0eab207b8a4dc6b4d3392fe9edd9903fff1be0a", upload-time = "2026-04-09T23:21:40Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e2ee9e16ee4518292694537fcbd20d2d27044e381d92b864f637e82795796a84", upload-time = "2026-04-09T23:21:40Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b5772c55bfda4377df8f1930d43c4e0231ef231b0228eade4b227c8d3ba6e34e", upload-time = "2026-03-23T15:36:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-win_amd64.whl", hash = "sha256:f160dc552a086244f7102c898f7be8ef46a41b36bce5ea80a4f2493cb30ca1fc", upload-time = "2026-04-09T23:21:41Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Simplify `DC2FullCatalog`: single keep mask, vectorized flux/PSF extraction, drop dead median kwarg
- Apply review findings: tensor copies in weak lensing case study, derive star/galaxy filter from `truth_type`, update install docs
- Fix test warnings: copy read-only parquet arrays, filter lightning LeafSpec deprecation
- Update CI workflows, README, and lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
